### PR TITLE
Toggle en bouton Creation de match

### DIFF
--- a/app/javascript/controllers/match_form_controller.js
+++ b/app/javascript/controllers/match_form_controller.js
@@ -32,7 +32,6 @@ export default class extends Controller {
     "minusBtn",          // Bouton "−" du compteur standard (pour changer sa couleur)
     "plusBtn",           // Bouton "+" du compteur standard (pour changer sa couleur)
     "levelInput",        // Input caché : niveau sélectionné (mis à jour par les boutons)
-    "validationToggle",  // Checkbox du toggle Manuel/Automatique
     "priceInput",        // Champ numérique : prix par joueur
     "bannerImageInput",  // Input caché : URL de l'image de la banner (soumise avec le formulaire)
 
@@ -527,23 +526,38 @@ export default class extends Controller {
   }
 
   // ── Validation : Manuel / Automatique ───────────────────
-  // Le toggle est dans la Section 4 du formulaire
-  // Ordre des labels : "Manuel" à gauche (index 0), "Automatique" à droite (index 1)
-  // checked = Automatique, unchecked = Manuel
+  // Source de vérité : le champ caché #match_validation_mode
+  // Synchronise uniquement la ligne "Validation" du récapitulatif
   updateValidation() {
-    // checked = Automatique → isManual est l'inverse
-    const isManual = !this.validationToggleTarget.checked
+    const hidden = document.getElementById("match_validation_mode")
+    const mode = (hidden && hidden.value) || "automatic"
+    this.recapValidationTarget.textContent = mode === "manual" ? "Manuel" : "Automatique"
+  }
 
-    // Met à jour les labels "Manuel" / "Automatique" autour du toggle
-    const labels = this.element.querySelectorAll(".toggle-label")
-    if (labels.length === 2) {
-      // Premier label = "Manuel" → actif si mode manuel
-      labels[0].classList.toggle("active-label", isManual)
-      // Deuxième label = "Automatique" → actif si mode automatique
-      labels[1].classList.toggle("active-label", !isManual)
-    }
+  // ── Clic sur un bouton Validation (Automatique / Manuel) ──
+  // Met à jour le champ caché, l'état actif des boutons, et le récap
+  selectValidation(event) {
+    const choice = event.currentTarget.dataset.validationChoice
+    const hidden = document.getElementById("match_validation_mode")
+    if (hidden) hidden.value = choice
 
-    // Met à jour la ligne "Validation" dans le récapitulatif
-    this.recapValidationTarget.textContent = isManual ? "Manuel" : "Automatique"
+    // Active/désactive la classe .active sur les deux boutons
+    this.element.querySelectorAll("[data-validation-choice]").forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.validationChoice === choice)
+    })
+
+    this.updateValidation()
+  }
+
+  // ── Clic sur un bouton Visibilité (Public / Privé) ──
+  // Met à jour le champ caché et l'état actif des boutons
+  selectVisibility(event) {
+    const choice = event.currentTarget.dataset.visibilityChoice
+    const hidden = document.getElementById("match_visibility")
+    if (hidden) hidden.value = choice
+
+    this.element.querySelectorAll("[data-visibility-choice]").forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.visibilityChoice === choice)
+    })
   }
 }

--- a/app/views/matches/_form.html.erb
+++ b/app/views/matches/_form.html.erb
@@ -529,7 +529,7 @@
 
           </div><%# fin niveau %>
 
-          <%# ── Toggle : Validation Manuel / Automatique ── %>
+          <%# ── Validation des joueurs : Manuel / Automatique (boutons classiques) ── %>
           <div class="mb-0">
             <label class="form-label d-block">
               Validation des joueurs
@@ -540,58 +540,30 @@
               </span>
             </label>
 
-            <%# Champ caché : contient la vraie valeur envoyée avec le formulaire.
-                Mis à jour via onchange du toggle ci-dessous. %>
-            <%= f.hidden_field :validation_mode, value: (@match.validation_mode || "automatic"),
+            <%# Champ caché : source de vérité envoyée au serveur. Par défaut "automatic". %>
+            <%= f.hidden_field :validation_mode,
+                value: (@match.validation_mode || "automatic"),
                 id: "match_validation_mode" %>
 
-            <%# Conteneur compact : fond + bordure, inline pour ne pas prendre toute la largeur %>
-            <div style="display:inline-flex; align-items:center; gap:0.75rem; margin-top:0.6rem;
-                        background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.12);
-                        border-radius:10px; padding:0.55rem 0.9rem;">
-
-              <%# Label gauche : Manuel — cliquable, vert si sélectionné %>
-              <span id="label_manuel"
-                    onclick="document.getElementById('validation_toggle').checked = false; document.getElementById('validation_toggle').dispatchEvent(new Event('change'));"
-                    style="font-size:0.82rem; font-weight:700; white-space:nowrap; cursor:pointer;
-                           color:<%= @match.manual_validation? ? '#1EDD88' : 'rgba(255,255,255,0.4)' %>;
-                           transition:color 0.15s;">
-                ✋ Manuel
-              </span>
-
-              <%# Toggle pill %>
-              <label class="pill-toggle" for="validation_toggle" style="flex-shrink:0;">
-                <%= check_box_tag :validation_mode_toggle,
-                    "automatic",
-                    !@match.manual_validation?,
-                    class: "pill-toggle-input",
-                    id: "validation_toggle",
-                    data: {
-                      "match-form-target": "validationToggle",
-                      "action": "change->match-form#updateValidation"
-                    },
-                    onchange: "
-                      document.getElementById('match_validation_mode').value = this.checked ? 'automatic' : 'manual';
-                      document.getElementById('label_manuel').style.color      = this.checked ? 'rgba(255,255,255,0.4)' : '#1EDD88';
-                      document.getElementById('label_automatique').style.color = this.checked ? '#1EDD88' : 'rgba(255,255,255,0.4)';
-                    " %>
-                <span class="pill-toggle-track"></span>
-              </label>
-
-              <%# Label droit : Automatique — cliquable, vert si sélectionné %>
-              <span id="label_automatique"
-                    onclick="document.getElementById('validation_toggle').checked = true; document.getElementById('validation_toggle').dispatchEvent(new Event('change'));"
-                    style="font-size:0.82rem; font-weight:700; white-space:nowrap; cursor:pointer;
-                           color:<%= @match.manual_validation? ? 'rgba(255,255,255,0.4)' : '#1EDD88' %>;
-                           transition:color 0.15s;">
+            <%# Groupe de boutons classiques (même style que les boutons de niveau) %>
+            <div class="match-level-buttons" style="margin-top:0.6rem;">
+              <button type="button"
+                      class="match-level-btn <%= 'active' unless @match.manual_validation? %>"
+                      data-validation-choice="automatic"
+                      data-action="click->match-form#selectValidation">
                 ⚡ Automatique
-              </span>
-
+              </button>
+              <button type="button"
+                      class="match-level-btn <%= 'active' if @match.manual_validation? %>"
+                      data-validation-choice="manual"
+                      data-action="click->match-form#selectValidation">
+                ✋ Manuel
+              </button>
             </div>
-          </div><%# fin toggle validation %>
+          </div><%# fin validation %>
 
-          <%# ── Toggle : Visibilité Public / Privé ── %>
-          <%# Champ caché mis à jour par JS selon la position du toggle %>
+          <%# ── Visibilité du match : Public / Privé (boutons classiques) ── %>
+          <%# Champ caché : source de vérité. Par défaut "public". %>
           <%= hidden_field_tag "match[visibility]", @match.visibility.presence || "public", id: "match_visibility" %>
 
           <div class="mb-0 mt-3">
@@ -603,45 +575,22 @@
               </span>
             </label>
 
-            <div style="display:inline-flex; align-items:center; gap:0.75rem; margin-top:0.6rem;
-                        background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.12);
-                        border-radius:10px; padding:0.55rem 0.9rem;">
-
-              <%# Label gauche : Privé — cliquable, vert si sélectionné %>
-              <span id="label_prive"
-                    onclick="document.getElementById('visibility_toggle').checked = false; document.getElementById('visibility_toggle').dispatchEvent(new Event('change'));"
-                    style="font-size:0.82rem; font-weight:700; white-space:nowrap; cursor:pointer;
-                           color:<%= @match.private? ? '#1EDD88' : 'rgba(255,255,255,0.4)' %>;
-                           transition:color 0.15s;">
-                🔒 Privé
-              </span>
-
-              <%# Toggle pill — coché = public (par défaut), décoché = privé %>
-              <label class="pill-toggle" for="visibility_toggle" style="flex-shrink:0;">
-                <%= check_box_tag :visibility_toggle,
-                    "public",
-                    !@match.private?,
-                    class: "pill-toggle-input",
-                    id: "visibility_toggle",
-                    onchange: "
-                      document.getElementById('match_visibility').value   = this.checked ? 'public' : 'private';
-                      document.getElementById('label_prive').style.color  = this.checked ? 'rgba(255,255,255,0.4)' : '#1EDD88';
-                      document.getElementById('label_public').style.color = this.checked ? '#1EDD88' : 'rgba(255,255,255,0.4)';
-                    " %>
-                <span class="pill-toggle-track"></span>
-              </label>
-
-              <%# Label droit : Public — cliquable, vert si sélectionné %>
-              <span id="label_public"
-                    onclick="document.getElementById('visibility_toggle').checked = true; document.getElementById('visibility_toggle').dispatchEvent(new Event('change'));"
-                    style="font-size:0.82rem; font-weight:700; white-space:nowrap; cursor:pointer;
-                           color:<%= @match.private? ? 'rgba(255,255,255,0.4)' : '#1EDD88' %>;
-                           transition:color 0.15s;">
+            <%# Groupe de boutons classiques (même style que les boutons de niveau) %>
+            <div class="match-level-buttons" style="margin-top:0.6rem;">
+              <button type="button"
+                      class="match-level-btn <%= 'active' unless @match.private? %>"
+                      data-visibility-choice="public"
+                      data-action="click->match-form#selectVisibility">
                 🌍 Public
-              </span>
-
+              </button>
+              <button type="button"
+                      class="match-level-btn <%= 'active' if @match.private? %>"
+                      data-visibility-choice="private"
+                      data-action="click->match-form#selectVisibility">
+                🔒 Privé
+              </button>
             </div>
-          </div><%# fin toggle visibilité %>
+          </div><%# fin visibilité %>
 
           <%# ── Sélecteur d'équipe (optionnel, visible si l'user est capitaine d'une équipe) ── %>
           <% if @my_captained_teams&.any? %>
@@ -667,6 +616,10 @@
                          style="accent-color:#1EDD88;"
                          onchange="
                            document.getElementById('match_team_id').value = '';
+                           document.getElementById('match_visibility').value = 'public';
+                           document.querySelectorAll('[data-visibility-choice]').forEach(function(btn) {
+                             btn.classList.toggle('active', btn.dataset.visibilityChoice === 'public');
+                           });
                          ">
                   <span style="font-size:0.82rem; color:rgba(255,255,255,0.6);">Aucune équipe</span>
                 </label>
@@ -680,9 +633,9 @@
                            onchange="
                              document.getElementById('match_team_id').value = '<%= team.id %>';
                              document.getElementById('match_visibility').value = 'private';
-                             document.getElementById('visibility_toggle').checked = false;
-                             document.getElementById('label_prive').style.color = '#1EDD88';
-                             document.getElementById('label_public').style.color = 'rgba(255,255,255,0.4)';
+                             document.querySelectorAll('[data-visibility-choice]').forEach(function(btn) {
+                               btn.classList.toggle('active', btn.dataset.visibilityChoice === 'private');
+                             });
                            ">
                     <%# Mini blason %>
                     <div style="flex-shrink:0; width:26px; height:26px; border-radius:5px; overflow:hidden; background:rgba(255,255,255,0.06); display:flex; align-items:center; justify-content:center;">


### PR DESCRIPTION
**Contexte :** sur la page de création d'un match, les choix « Manuel/Automatique » et « Privé/Public » étaient présentés sous forme de pill-toggles (interrupteurs). Remplacement par des boutons classiques sélectionnables.

**Changements**
[app/views/matches/_form.html.erb]
• Suppression des deux pill-toggles (validation et visibilité) et de leurs labels cliquables associés.
• Remplacement par deux groupes de boutons classiques utilisant le style existant .match-level-btn (même rendu que les boutons de niveau déjà présents plus haut dans le formulaire). La classe .active marque l'option sélectionnée.
• Valeurs par défaut : Automatique et Public, via @match.validation_mode || "automatic" et @match.visibility.presence || "public".
• Les boutons sont câblés à des actions Stimulus : click->match-form#selectValidation et click->match-form#selectVisibility.
• Sélecteur d'équipe : le onchange sur le choix d'une équipe force désormais la visibilité en private et active le bouton Privé via querySelectorAll('[data-visibility-choice]'). Symétriquement, sélectionner « Aucune équipe » remet la visibilité en public et réactive le bouton Public.

[app/javascript/controllers/match_form_controller.js]
• Suppression du target validationToggle (la checkbox n'existe plus).
• updateValidation() réécrite : elle lit la source de vérité directement depuis le champ caché #match_validation_mode et synchronise uniquement la ligne « Validation » du récapitulatif.
• Ajout de selectValidation(event) : met à jour #match_validation_mode, bascule la classe .active entre les deux boutons Validation, puis appelle updateValidation().
• Ajout de selectVisibility(event) : met à jour #match_visibility et bascule la classe .active entre les deux boutons Visibilité.

**Comportement final**
• Par défaut à l'ouverture du formulaire : Automatique + Public actifs.
• Clic sur un bouton : l'autre se désactive, le champ caché est mis à jour, et le récapitulatif suit pour la validation.
• Associer une équipe force Privé automatiquement ; repasser sur « Aucune équipe » remet automatiquement Public.