### PR TITLE
perf amélio

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,8 @@
-// Import Google fonts
-@import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+// Google Fonts — chargés via <link> dans application.html.erb (plus performant
+// que @import CSS qui bloque le rendu). Seules les variables sont définies ici.
 
 // Bebas Neue — géométrique, condensé, style Futura anguleux
-// Utilisé pour les titres de la page "Qui sommes-nous ?"
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
+// Utilisé pour les titres hero et de la page "Qui sommes-nous ?"
 $display-font: "Bebas Neue", "Impact", sans-serif;
 
 // Define fonts for body and headers

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
   <head>
     <%# Encodage déclaré explicitement — bonne pratique HTML5 et prérequis SEO %>
     <meta charset="utf-8">
@@ -51,17 +51,21 @@
       }
     <% end %>
 
+    <%# ── Google Fonts — chargement optimisé ──────────────────────────────────
+        Placé AVANT le stylesheet principal pour que le navigateur lance la connexion
+        vers Google Fonts en parallèle du téléchargement de application.css.
+        preconnect : ouvre la connexion TCP/TLS dès que possible (gain ~100ms).
+        Une seule requête pour Nunito + Work Sans + Bebas Neue via l'API CSS2.
+        display=swap : le navigateur affiche une police de secours immédiatement
+        → pas de texte invisible pendant le chargement (évite le FOIT). %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Nunito:wght@400;700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= favicon_link_tag "favicon.png" %>
-
-    <%# Lucide Icons — bibliothèque d'icônes SVG légères %>
-    <%# Doc : https://lucide.dev/icons/ — utilisation : <i data-lucide="nom-icone"></i> %>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
-
-    <%# Bebas Neue — police utilisée pour les chiffres de la player card %>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
   </head>
 
   <%# data-controller="scroll-to-error" : sur chaque chargement de page, fait défiler
@@ -123,8 +127,15 @@
     <%# Modale grille des niveaux — disponible sur toutes les pages via le bouton "?" %>
     <%= render "shared/level_grid_modal" %>
 
+    <%# Lucide Icons — bibliothèque d'icônes SVG légères %>
+    <%# Chargé ici (bas du body) et non dans le <head> pour éviter de bloquer
+        le rendu de la page (render-blocking). À cet endroit, tout le DOM visible
+        est déjà parsé et affiché — le script s'exécute immédiatement après. %>
+    <%# Doc : https://lucide.dev/icons/ — utilisation : <i data-lucide="nom-icone"></i> %>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+
     <%# Initialise toutes les icônes Lucide présentes dans la page %>
-    <%# Appelé en bas de body pour que le DOM soit chargé %>
+    <%# Appelé juste après le script Lucide pour garantir que lucide est défini %>
     <script>
       // Initialisation au premier chargement de la page
       lucide.createIcons();

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -5,7 +5,7 @@
 // Nom du cache : incrémenté à "v2" pour forcer l'effacement du cache v1
 // (le cache v1 contenait des pages HTML avec du contenu utilisateur, ce qui causait
 //  l'affichage de photos incorrectes après connexion)
-const CACHE_NAME = "teams-up-v2";
+const CACHE_NAME = "teams-up-v3";
 
 // Seule la page offline est pré-cachée (les pages HTML contiennent du contenu
 // spécifique à l'utilisateur connecté → jamais en cache)
@@ -60,7 +60,13 @@ self.addEventListener("fetch", (event) => {
   // En cas d'échec réseau → on renvoie la page offline.
   if (event.request.mode === "navigate") {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match("/offline"))
+      fetch(event.request).catch(async () => {
+        // caches.match() retourne undefined si la page offline n'est pas en cache
+        // (ex: première visite, cache vidé). On utilise Response.error() comme
+        // filet de sécurité — c'est un objet Response valide que le navigateur accepte.
+        const cached = await caches.match("/offline");
+        return cached || Response.error();
+      })
     );
     return;
   }
@@ -87,9 +93,12 @@ self.addEventListener("fetch", (event) => {
         }
         return networkResponse;
       })
-      .catch(() => {
+      .catch(async () => {
         // Réseau indisponible → on cherche dans le cache
-        return caches.match(event.request);
+        // Si l'asset n'est pas en cache non plus, on retourne Response.error()
+        // (objet Response valide) plutôt que undefined → évite le TypeError console
+        const cached = await caches.match(event.request);
+        return cached || Response.error();
       })
   );
 });

--- a/app/views/shared/_match_card.html.erb
+++ b/app/views/shared/_match_card.html.erb
@@ -38,7 +38,9 @@
 
   <%# ── Image du terrain + overlays ──────────────────────────────────────── %>
   <div class="match-card-img-wrapper">
-    <%= image_tag cover_image, alt: "Terrain #{match.title}", class: "match-card-img" %>
+    <%# loading: lazy → le navigateur ne télécharge cette image que quand la carte
+        approche du viewport. Évite de charger les images hors-écran au chargement initial. %>
+    <%= image_tag cover_image, alt: "Terrain #{match.title}", class: "match-card-img", loading: "lazy" %>
 
     <%# Badge sport — coin haut gauche de l'image %>
     <% if match.sport %>

--- a/app/views/shared/_mobile_sub_navbar.html.erb
+++ b/app/views/shared/_mobile_sub_navbar.html.erb
@@ -21,7 +21,8 @@
           <button class="mobile-sport-btn d-flex align-items-center gap-2"
                   type="button"
                   data-bs-toggle="dropdown"
-                  aria-expanded="false">
+                  aria-expanded="false"
+                  aria-label="Sport actif : <%= multisport_mode? ? 'Multisport' : (current_sport&.name || 'Sport') %>. Changer de sport">
             <% if multisport_mode? %>
               <%# Icône multisport %>
               <%= image_tag sport_misc_image(:multisports),

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -197,7 +197,8 @@
                   class="d-flex align-items-center gap-2 text-decoration-none btn-reset"
                   id="userDropdown"
                   data-bs-toggle="dropdown"
-                  aria-expanded="false">
+                  aria-expanded="false"
+                  aria-label="Menu utilisateur">
             <% display_name = current_user.profil &&
                 [current_user.profil.first_name, current_user.profil.last_name]
                   .compact.join(" ").presence %>

--- a/app/views/shared/_notification_bell.html.erb
+++ b/app/views/shared/_notification_bell.html.erb
@@ -10,7 +10,8 @@
 <%# Bouton (pas un lien) car il n'y a pas de navigation — centrage flex de l'icône %>
 <button type="button"
         class="nav-link px-2 d-flex align-items-center justify-content-center border-0 bg-transparent"
-        id="notifDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+        id="notifDropdown" data-bs-toggle="dropdown" aria-expanded="false"
+        aria-label="<%= unread_count > 0 ? "#{unread_count} notification#{'s' if unread_count > 1} non lue#{'s' if unread_count > 1}" : "Notifications" %>">
   <%# Le span position-relative est collé à la taille de l'icône (inline-flex)
       pour que le badge se positionne par rapport à la cloche et non au lien entier %>
   <span class="position-relative d-inline-flex">


### PR DESCRIPTION
Performance
Lucide Icons — Le script était chargé dans le <head> et bloquait le rendu de toute la page. Déplacé en bas du <body>, juste avant son initialisation. Gain estimé : -200 à -400ms sur FCP/LCP.

Google Fonts — 3 problèmes corrigés en un :

Suppression des 2 @import url() dans le SCSS (les @import CSS bloquent le rendu)
Suppression du doublon Bebas Neue qui était chargé deux fois
Remplacement par preconnect + une seule <link> consolidée, placée avant le stylesheet principal pour un chargement en parallèle
Lazy loading images — Ajout de loading="lazy" sur les images des match cards. Les images hors écran ne sont plus téléchargées au chargement initial. Gain estimé : -1 à -3 MiB.

Accessibilité
lang="fr" — Attribut manquant sur la balise <html>. Les lecteurs d'écran utilisent maintenant la bonne voix française.

3 boutons sans nom accessible — Ajout d'aria-label sur :

La cloche notifications (dynamique : "3 notifications non lues")
Le dropdown utilisateur ("Menu utilisateur")
Le sélecteur de sport mobile (dynamique : "Sport actif : Football. Changer de sport")
Best Practices
Bug Service Worker — Correction d'un TypeError: Failed to convert value to 'Response' qui s'affichait dans la console Chrome à chaque chargement de page. caches.match() retournait undefined quand rien n'était en cache — remplacé par Response.error() comme filet de sécurité valide.

7 fichiers modifiés, aucune fonctionnalité touchée.