### PR TITLE
petite modif des typos H1 et H2 en bebas

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,21 @@
   opacity: 0.75 !important;
 }
 
+// ── Typographie globale ──────────────────────────────
+// H1 et H2 en Bebas Neue ($display-font) pour un style affirmé et cohérent
+// avec l'identité visuelle Team Up.
+// letter-spacing : Bebas Neue est une condensed, un léger tracking améliore
+// la lisibilité et donne de l'air aux titres.
+h1 {
+  font-family: $display-font;
+  letter-spacing: 0.04em;
+}
+
+h2 {
+  font-family: $display-font;
+  letter-spacing: 0.03em;
+}
+
 // ── Sticky footer ───────────────────────────────────
 // body en colonne flex → main prend tout l'espace libre
 // → footer toujours collé en bas, même sur les pages courtes

--- a/app/assets/stylesheets/components/_teams.scss
+++ b/app/assets/stylesheets/components/_teams.scss
@@ -10,10 +10,9 @@
   // Titre et sous-titre réutilisés depuis les pages matches
   .matches-index-title {
     font-size: 2rem;
-    font-weight: 800;
     color: #fff;
     margin-bottom: 0.35rem;
-    font-family: $headers-font;
+    font-family: $display-font;
   }
 
   .matches-index-subtitle {

--- a/app/assets/stylesheets/pages/_auth.scss
+++ b/app/assets/stylesheets/pages/_auth.scss
@@ -182,9 +182,8 @@
   // ── Titre du formulaire ──────────────────────────
   h2 {
     color: $dark-text;
-    font-family: $headers-font;
+    font-family: $display-font;
     font-size: 1.75rem;
-    font-weight: 700;
     margin-bottom: 1.75rem;
 
     // Accent vert sur le dernier mot (optionnel, utilisé via <span class="accent">)

--- a/app/assets/stylesheets/pages/_matches_index.scss
+++ b/app/assets/stylesheets/pages/_matches_index.scss
@@ -19,7 +19,7 @@
       font-weight: 800;
       color: #fff;
       margin-bottom: 0.35rem;
-      font-family: $headers-font;
+      font-family: $display-font;
     }
 
     // Sous-titre


### PR DESCRIPTION
1. Règle globale — ajout dans application.scss :
h1 → Bebas Neue + letter-spacing: 0.04em
h2 → Bebas Neue + letter-spacing: 0.03em

2. Corrections des overrides locaux — 4 fichiers avaient un font-family local qui écrasait la règle globale :
_matches_index.scss — titre "Trouver un match"
_teams.scss — titre "Mes équipes"
_auth.scss — titre des formulaires de connexion/inscription
Dans chaque cas, on a remplacé $headers-font (Nunito) par $display-font (Bebas Neue).