### PR TITLE
ratelimiting creation match/equipe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,10 @@ class ApplicationController < ActionController::Base
   # Avant chaque action : détermine si la modale ou le banner d'onboarding doit s'afficher
   before_action :set_onboarding_flags
 
+  # Avant chaque action : lit le cookie court-vivant posé par Rack::Attack
+  # lors d'un throttle de création (match ou équipe) et l'affiche comme flash.
+  before_action :check_throttle_cookie
+
   # Retourne true si l'utilisateur est en mode "Multisport" (tous les sports)
   def multisport_mode?
     user_signed_in? && session[:current_sport_id] == "all"
@@ -184,6 +188,19 @@ class ApplicationController < ActionController::Base
 
     # Trouve les matchs terminés récents avec des joueurs non encore notés
     @pending_review_matches = find_pending_reviews_for_modal
+  end
+
+  # ── Feedback throttle Rack::Attack ──────────────────────────────────────
+  #
+  # Rack::Attack s'exécute avant Rails et ne peut pas écrire dans la session
+  # chiffrée. Il pose à la place un cookie "throttle_alert" (Max-Age: 10s).
+  # Ce before_action le lit à chaque requête, l'affiche comme flash, puis le supprime.
+  # Le Max-Age court (10s) garantit qu'il disparaît même si Rails ne le lit pas.
+  def check_throttle_cookie
+    return unless cookies[:throttle_alert]
+
+    flash.now[:alert] = "Trop de créations en peu de temps. Attendez quelques minutes avant de réessayer."
+    cookies.delete(:throttle_alert)
   end
 
   # Retourne un tableau de { match:, users: [...] } pour la modal

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -101,6 +101,38 @@ class Rack::Attack
 
 
   # -----------------------------------------------------------------------
+  # THROTTLE 6 : Création de matchs par utilisateur
+  #
+  # But : empêcher un utilisateur connecté de spammer des créations de matchs.
+  # On utilise l'user_id (plus précis que l'IP) via Warden, qui est accessible
+  # dans le middleware Rack avant que Rails ne traite la requête.
+  # Limite : 5 créations sur 10 minutes.
+  # Route ciblée : POST /matches
+  # -----------------------------------------------------------------------
+  throttle("match_creation/user", limit: 5, period: 10.minutes) do |req|
+    if req.path == "/matches" && req.post?
+      # Warden est le middleware d'authentification utilisé par Devise.
+      # &.user(:user) renvoie l'utilisateur connecté, ou nil si non authentifié.
+      req.env["warden"]&.user(:user)&.id
+    end
+  end
+
+
+  # -----------------------------------------------------------------------
+  # THROTTLE 7 : Création d'équipes par utilisateur
+  #
+  # But : empêcher un utilisateur connecté de spammer des créations d'équipes.
+  # Limite : 3 créations sur 30 minutes.
+  # Route ciblée : POST /equipes
+  # -----------------------------------------------------------------------
+  throttle("team_creation/user", limit: 3, period: 30.minutes) do |req|
+    if req.path == "/equipes" && req.post?
+      req.env["warden"]&.user(:user)&.id
+    end
+  end
+
+
+  # -----------------------------------------------------------------------
   # Notification Rack::Attack → SecurityLog
   #
   # Quand rack-attack bloque une requête (throttle déclenché), il publie
@@ -144,7 +176,11 @@ class Rack::Attack
   # Si le referer n'est pas disponible, on redirige vers l'accueil.
   # -----------------------------------------------------------------------
   self.throttled_responder = lambda do |env|
-    req = Rack::Request.new(env)
+    # rack-attack 6.7+ / Rack 3 : `env` est un Rack::Attack::Request (sous-classe de
+    # Rack::Request). Rack 3 a supprimé `[]` sur Request, donc `env["clé"]` plante.
+    # On utilise directement l'objet Request et on accède au Hash via `.env`.
+    req     = env.is_a?(Rack::Request) ? env : Rack::Request.new(env)
+    matched = req.env["rack.attack.matched"]
 
     # Sécurité : on vérifie que le referer appartient au même domaine
     # pour éviter un open redirect (attaquant qui injecte un referer externe)
@@ -156,11 +192,20 @@ class Rack::Attack
       "/"
     end
 
-    [
-      302,
-      { "Location" => location, "Content-Type" => "text/html; charset=utf-8" },
-      [""]
-    ]
+    headers = {
+      "Location"     => location,
+      "Content-Type" => "text/html; charset=utf-8"
+    }
+
+    # Pour les throttles de création (match/équipe), on pose un cookie court-vivant
+    # (Max-Age: 10s). Rack::Attack s'exécute dans le middleware, AVANT Rails — on ne
+    # peut donc pas écrire dans la session chiffrée. Le cookie sera lu par
+    # ApplicationController#check_throttle_cookie et converti en flash d'alerte.
+    if matched&.start_with?("match_creation", "team_creation")
+      headers["Set-Cookie"] = "throttle_alert=true; Path=/; HttpOnly; SameSite=Lax; Max-Age=10"
+    end
+
+    [302, headers, [""]]
   end
 
 end


### PR DESCRIPTION
Résumé — branche ratelimiting                             
                                                                                                                                                                                                                                                        
Ce qui a été fait                                         
                                                                                                                                                                                                                                                      Objectif : empêcher un utilisateur connecté de créer des dizaines de matchs ou équipes en quelques secondes, et lui afficher un message d'erreur compréhensible.

config/initializers/rack_attack.rb

THROTTLE 6 — match_creation/user
Limite 5 créations / 10 minutes sur POST /matches. Clé : user_id via req.env["warden"]&.user(:user)&.id (plus précis que l'IP — un même user sur plusieurs appareils est quand même limité).

THROTTLE 7 — team_creation/user
Limite 3 créations / 30 minutes sur POST /equipes. Même logique user_id via Warden.

throttled_responder — deux corrections :
Bug Rack 3 corrigé : rack-attack 6.8 passe un Rack::Attack::Request (sous-classe de Rack::Request) au lieu d'un Hash brut. Rack::Request#[] a été supprimé en Rack 3, donc env["rack.attack.matched"] plantait avec NoMethodError. Fix :
req.env["rack.attack.matched"].

Cookie court-vivant : quand match_creation ou team_creation se déclenche, le responder pose Set-Cookie: throttle_alert=true; Max-Age=10. Rack::Attack ne peut pas écrire dans la session Rails chiffrée (middleware, avant Rails), donc le cookie est
le seul moyen de passer un signal à Rails.

app/controllers/application_controller.rb
before_action :check_throttle_cookie lu à chaque requête. Si le cookie throttle_alert est présent → flash.now[:alert] avec le message d'erreur + suppression du cookie. Le Max-Age: 10s garantit que le cookie disparaît seul si Rails ne le lit pas.

  ---
Tests effectués

Throttles bien enregistrés : rails runner "puts Rack::Attack.throttles.keys" → 7 throttles listés dont match_creation/user et team_creation/user. ✅

Throttle logins/ip fonctionne : 7× POST /users/sign_in → requêtes 1-5 passent (422), requête 6 → 302. ✅

SecurityLog créé au throttle : visible dans les logs dev (INSERT INTO security_logs à la requête 6). ✅

Throttle match + cookie : login + 6× POST /matches authentifié → requêtes 1-5 passent (422), requête 6 → 302 + Set-Cookie: throttle_alert=true. ✅

Bug découvert et corrigé pendant les tests : le throttled_responder retournait 500 au lieu de 302 à cause de l'incompatibilité Rack 3 / rack-attack 6.8 (undefined method '[]' for Rack::Attack::Request).