### PR TITLE
Matchremindermodif

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -200,10 +200,11 @@ class MatchesController < ApplicationController
       # Email de confirmation avec récapitulatif du match pour l'organisateur
       UserMailer.match_created(@match).deliver_later
 
-      # Planifie le rappel 24h avant le match pour tous les participants approuvés.
-      # On vérifie qu'il reste plus de 24h avant le match pour éviter un job inutile
-      # (ex: match créé à J-2h → le rappel serait déjà passé).
-      reminder_time = @match.build_datetime - 24.hours
+      # Planifie le rappel ~24h avant le match pour tous les participants approuvés.
+      # On anticipe de 30 min (-24.5.hours) pour absorber un éventuel retard de la queue :
+      # si le worker est lent, le rappel part quand même avant le coup d'envoi.
+      # Le job lui-même vérifie en plus que le match n'a pas encore commencé avant d'envoyer.
+      reminder_time = @match.build_datetime - 24.5.hours
       MatchReminderJob.set(wait_until: reminder_time).perform_later(@match.id) if reminder_time > Time.current
 
       redirect_to @match, notice: "Match créé avec succès !"

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -246,21 +246,36 @@ class MatchesController < ApplicationController
                          .where(status: ["approved", "pending", "waiting"])
                          .includes(:user)
 
-    # Notifie chaque participant en temps réel si il est sur la page du match,
-    # et envoie un email transactionnel pour les utilisateurs absents.
-    # IMPORTANT : on utilise deliver_now (pas deliver_later) car le match est
-    # détruit juste après. Avec deliver_later, SolidQueue tente de désérialiser
-    # le Match via GlobalID mais il n'existe plus en base → DeserializationError.
+    # ── Extraction des données AVANT destruction ──────────────────────────────
+    # On sérialise uniquement des scalaires pour éviter le DeserializationError
+    # de SolidQueue lors du deliver_later (GlobalID ne peut pas recharger un
+    # enregistrement détruit).
+    match_title    = @match.title
+    match_date     = @match.date
+    match_time_str = @match.time&.strftime("%Hh%M")
+    venue_name     = @match.venue&.name
+    venue_city     = @match.venue&.city
+    organizer_name = @match.user.display_name
+
+    # Liste des destinataires : participants + organisateur
+    recipient_emails = participants.map { |mu| mu.user.email }
+    recipient_emails << @match.user.email
+
+    # Broadcasts Turbo AVANT destroy → le canal ActionCable doit encore exister
     participants.each do |mu|
       broadcast_match_cancelled_to_participant(mu.user)
-      UserMailer.match_cancelled(@match, mu.user).deliver_now
     end
 
-    # Envoie également l'email de confirmation d'annulation à l'organisateur lui-même.
-    # Il est exclu de participants (role: "organisateur") mais doit recevoir un récapitulatif.
-    UserMailer.match_cancelled(@match, @match.user).deliver_now
-
     @match.destroy
+
+    # Enqueue des emails asynchrones avec données scalaires uniquement
+    recipient_emails.each do |email|
+      MatchCancelledMailerJob.perform_later(
+        email, match_title, match_date, match_time_str,
+        venue_name, venue_city, organizer_name
+      )
+    end
+
     redirect_to matches_path, notice: "Match supprimé."
   end
 

--- a/app/jobs/match_cancelled_mailer_job.rb
+++ b/app/jobs/match_cancelled_mailer_job.rb
@@ -1,0 +1,38 @@
+# Envoie l'email d'annulation de match de façon asynchrone.
+# Accepte uniquement des données scalaires pour éviter le DeserializationError
+# de SolidQueue qui tente de recharger un AR object supprimé via GlobalID.
+#
+# Sécurité retry : les arguments sont 100 % scalaires (String, Date) → pas de
+# GlobalID → pas de DeserializationError si SolidQueue rejoue le job après un
+# échec réseau/SMTP. Le retry est donc sûr.
+class MatchCancelledMailerJob < ApplicationJob
+  queue_as :default
+
+  # Retry sur erreurs réseau/SMTP (SendGrid down, timeout…)
+  retry_on Net::SMTPAuthenticationError,
+           Net::SMTPServerBusy,
+           Net::SMTPFatalError,
+           Net::SMTPUnknownError,
+           Errno::ECONNRESET,
+           wait: :polynomially_longer,
+           attempts: 5
+
+  # @param user_email     [String]      email du destinataire
+  # @param match_title    [String]      titre du match annulé
+  # @param match_date     [Date]        date du match (sérialisée nativement par ActiveJob)
+  # @param match_time_str [String, nil] heure formatée "HHhMM" ou nil
+  # @param venue_name     [String, nil] nom du lieu ou nil
+  # @param venue_city     [String, nil] ville du lieu ou nil
+  # @param organizer_name [String]      display_name de l'organisateur
+  def perform(user_email, match_title, match_date, match_time_str, venue_name, venue_city, organizer_name)
+    UserMailer.match_cancelled_async(
+      user_email:,
+      match_title:,
+      match_date:,
+      match_time_str:,
+      venue_name:,
+      venue_city:,
+      organizer_name:
+    ).deliver_now
+  end
+end

--- a/app/jobs/match_reminder_job.rb
+++ b/app/jobs/match_reminder_job.rb
@@ -16,6 +16,10 @@ class MatchReminderJob < ApplicationJob
     # Le match a été supprimé entre la planification et l'exécution du job → on arrête
     return unless match
 
+    # Sécurité : si la queue était en retard et que le match a déjà commencé,
+    # on n'envoie pas le rappel (inutile et confus pour le participant)
+    return if match.build_datetime <= Time.current
+
     # Récupère tous les participants approuvés (joueurs + organisateur)
     # includes(:user) pour éviter les N+1 queries lors de l'envoi des emails
     participants = match.match_users

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -55,6 +55,28 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "Le match \"#{match.title}\" a été annulé")
   end
 
+  # ── 3b. Version asynchrone de match_cancelled via MatchCancelledMailerJob ─
+  # Accepte des données scalaires (pas d'AR objects) pour la compatibilité SolidQueue.
+  # Évite le DeserializationError causé par GlobalID sur un Match détruit.
+  #
+  # @param user_email     [String]      email du destinataire
+  # @param match_title    [String]      titre du match annulé
+  # @param match_date     [Date]        date du match
+  # @param match_time_str [String, nil] heure formatée "HHhMM" ou nil
+  # @param venue_name     [String, nil] nom du lieu ou nil
+  # @param venue_city     [String, nil] ville du lieu ou nil
+  # @param organizer_name [String]      display_name de l'organisateur
+  def match_cancelled_async(user_email:, match_title:, match_date:, match_time_str:, venue_name:, venue_city:, organizer_name:)
+    @match_title     = match_title
+    @match_date      = match_date      # Date — pour I18n.l
+    @match_time_str  = match_time_str  # String "HHhMM" ou nil — déjà formaté
+    @venue_name      = venue_name
+    @venue_city      = venue_city
+    @organizer_name  = organizer_name
+
+    mail(to: user_email, subject: "Le match \"#{match_title}\" a été annulé")
+  end
+
   # ── 4. Un joueur a quitté ton match ───────────────────────────────────────
   # Destinataire : l'organisateur du match
   # Déclenché    : match_users#destroy (uniquement si le joueur était approuvé)

--- a/app/views/user_mailer/match_cancelled_async.html.erb
+++ b/app/views/user_mailer/match_cancelled_async.html.erb
@@ -1,0 +1,76 @@
+<%# ── Email : un match auquel tu participais a été annulé ───────────────── %>
+<%# Version asynchrone — accepte des données scalaires au lieu d'AR objects %>
+<%# Inline CSS obligatoire — les clients mail ignorent les feuilles de style externes %>
+<div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #111111; padding: 40px 20px; min-height: 100vh;">
+
+  <div style="max-width: 520px; margin: 0 auto; background-color: #1a1c1a; border-radius: 16px; border: 1px solid rgba(255,255,255,0.08); overflow: hidden;">
+
+    <%# En-tête logo %>
+    <div style="background-color: #111111; padding: 28px 40px; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.06);">
+      <span style="font-size: 1.6rem; font-weight: 800; color: #f0f0f0; letter-spacing: -0.5px;">
+        TEAMS<span style="color: #1EDD88;">-UP</span>
+      </span>
+    </div>
+
+    <%# Corps %>
+    <div style="padding: 36px 40px;">
+
+      <%# Icône annulation %>
+      <div style="text-align: center; margin-bottom: 24px;">
+        <div style="display: inline-block; background-color: rgba(230, 126, 34, 0.12); border-radius: 50%; width: 64px; height: 64px; line-height: 64px; font-size: 28px;">
+          🚫
+        </div>
+      </div>
+
+      <%# Titre %>
+      <h1 style="color: #f0f0f0; font-size: 1.4rem; font-weight: 700; text-align: center; margin: 0 0 8px 0;">
+        Match annulé
+      </h1>
+
+      <%# Sous-titre %>
+      <p style="color: rgba(255,255,255,0.45); font-size: 0.9rem; text-align: center; margin: 0 0 28px 0;">
+        <strong style="color: rgba(255,255,255,0.7);"><%= @match_title %></strong> ne se jouera plus.
+      </p>
+
+      <%# Message principal %>
+      <p style="color: rgba(255,255,255,0.65); font-size: 0.95rem; line-height: 1.6; margin: 0 0 20px 0;">
+        Malheureusement, l'organisateur <strong style="color: #f0f0f0;"><%= @organizer_name %></strong>
+        a annulé ce match. Ta place a été libérée automatiquement.
+      </p>
+
+      <%# Encart récapitulatif du match annulé %>
+      <div style="background-color: rgba(253, 16, 21, 0.05); border: 1px solid rgba(253, 16, 21, 0.15); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
+        <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Match annulé</p>
+        <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0; text-decoration: line-through; opacity: 0.6;">
+          📅 <%= I18n.l(@match_date, format: :long) %><% if @match_time_str %> à <%= @match_time_str %><% end %>
+        </p>
+        <% if @venue_name.present? %>
+          <p style="color: rgba(255,255,255,0.4); font-size: 0.9rem; margin: 0; text-decoration: line-through; opacity: 0.6;">
+            📍 <%= @venue_name %><% if @venue_city %>, <%= @venue_city %><% end %>
+          </p>
+        <% end %>
+      </div>
+
+      <%# CTA pour trouver un autre match %>
+      <p style="color: rgba(255,255,255,0.55); font-size: 0.9rem; text-align: center; margin: 0 0 20px 0;">
+        Il y a d'autres matchs disponibles près de chez toi !
+      </p>
+
+      <div style="text-align: center; margin-bottom: 28px;">
+        <%= link_to matches_url,
+            style: "display: inline-block; background-color: #1EDD88; color: #111111; font-weight: 700; font-size: 1rem; padding: 14px 36px; border-radius: 50px; text-decoration: none; letter-spacing: 0.3px;" do %>
+          Trouver un nouveau match
+        <% end %>
+      </div>
+
+    </div>
+
+    <%# Pied de page %>
+    <div style="background-color: #111111; padding: 20px 40px; text-align: center; border-top: 1px solid rgba(255,255,255,0.06);">
+      <p style="color: rgba(255,255,255,0.25); font-size: 0.78rem; margin: 0;">
+        © <%= Date.today.year %> Teams-Up — Tous droits réservés.
+      </p>
+    </div>
+
+  </div>
+</div>

--- a/app/views/user_mailer/match_cancelled_async.text.erb
+++ b/app/views/user_mailer/match_cancelled_async.text.erb
@@ -1,0 +1,19 @@
+TEAMS-UP
+========
+
+Match annulé — <%= @match_title %>
+
+Malheureusement, l'organisateur <%= @organizer_name %> a annulé ce match.
+Ta place a été libérée automatiquement.
+
+Match annulé :
+  Date : <%= I18n.l(@match_date, format: :long) %><% if @match_time_str %> à <%= @match_time_str %><% end %>
+<% if @venue_name.present? %>
+  Lieu : <%= @venue_name %><% if @venue_city %>, <%= @venue_city %><% end %>
+<% end %>
+
+Il y a d'autres matchs disponibles près de chez toi !
+Trouver un nouveau match : <%= matches_url %>
+
+--
+© <%= Date.today.year %> Teams-Up — Tous droits réservés.


### PR DESCRIPTION
Solution                                              
Double protection :
1. Buffer à la planification — anticiper de 30 min supplémentaires pour absorber les délais de queue
2. Guard dans le job — vérifier au moment de l'exécution que le match n'a pas encore commencé

Modifications
app/controllers/matches_controller.rb
# Avant
reminder_time = @match.build_datetime - 24.hours

# Après
reminder_time = @match.build_datetime - 24.5.hours

app/jobs/match_reminder_job.rb
return unless match

# Ajout
return if match.build_datetime <= Time.current  # match déjà commencé → on annule
participants = match.match_users...
