### PR TITLE
Plan du site design

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -14,12 +14,22 @@
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   color: $dark-muted;
   // Le padding bottom est géré par .footer-bottom qui a son propre fond
-  padding: 20px 0 0;
+  // padding géré par py-3 sur la row
+  padding: 0;
+
+  // Hauteur minimum pour que l'alignement vertical soit visible sur desktop
+  .row {
+    min-height: 80px;
+  }
 
   // ── Gap entre les colonnes sur mobile ─────────────
   @media (max-width: 767.98px) {
     .row > [class*="col-"] {
       margin-bottom: 24px; // espace vertical entre logo, liens et réseaux sociaux
+    }
+    // Supprimer le margin du dernier col pour éviter l'espace excessif avant .footer-bottom
+    .row > [class*="col-"]:last-child {
+      margin-bottom: 0;
     }
   }
 
@@ -59,7 +69,7 @@
     padding: 0;
     margin: 0;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap; // tous les liens sur une seule ligne sur desktop
     gap: 0.5rem 1.5rem;
 
     // Sur mobile : liens empilés verticalement et centrés
@@ -74,6 +84,7 @@
       text-decoration: none;
       font-size: 0.85rem;
       transition: color 0.15s;
+      white-space: nowrap; // empêche "Plan du site" de se couper en plusieurs lignes
 
       &:hover { color: #fff; }
     }
@@ -84,7 +95,7 @@
   // margin-top pour séparer visuellement du contenu au-dessus
   .footer-bottom {
     background-color: #111111;  // $dark-bg : nettement plus sombre
-    margin-top: 20px;           // espace entre le contenu et cette bande
+    margin-top: 12px;           // espace réduit, py-3 gère l'espace interne
     padding: 12px 0;            // hauteur de la bande
     font-size: 0.78rem;
     color: rgba(255, 255, 255, 0.25);

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -12,4 +12,5 @@
 @import "contact";        // Page de contact (/contact)
 @import "partenariat";    // Page partenariat (/partenariat)
 @import "legal";          // Pages légales : Confidentialité et Conditions
+@import "sitemap";        // Page plan du site (/sitemap)
 @import "admin";          // Espace admin (dashboard, messages de contact)

--- a/app/assets/stylesheets/pages/_sitemap.scss
+++ b/app/assets/stylesheets/pages/_sitemap.scss
@@ -1,0 +1,122 @@
+// Page plan du site — design dark full-page
+// Fond #111111, titre Bebas Neue blanc, liens verts uppercase,
+// séparateurs horizontaux entre sections
+
+.sitemap-page {
+  min-height: 100vh;
+  background-color: #0a110d;
+  padding: 2.5rem 3.5rem;
+}
+
+.sitemap-inner {
+  padding: 0;
+}
+
+.sitemap-title {
+  font-family: $display-font;   // Bebas Neue
+  font-size: 3rem;
+  font-weight: 400;
+  color: $dark-text;            // #f0f0f0
+  letter-spacing: 0.04em;
+  margin-bottom: 0.3rem;
+  margin-top: 0;
+}
+
+.sitemap-subtitle {
+  font-family: $body-font;
+  font-size: 1rem;
+  color: $dark-muted;
+  margin: 0 0 1rem 0;
+}
+
+.sitemap-divider {
+  border: none;
+  border-top: 3.3px solid #ffffff;
+  margin: 0 0 1.8rem 0;
+  padding: 0;
+}
+
+.sitemap-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.8rem;
+}
+
+.sitemap-link {
+  font-family: $display-font;   // Bebas Neue
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: $green;                // #1EDD88
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  transition: color 0.15s ease;
+  display: block;
+
+  &:hover {
+    color: lighten($green, 10%);
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    color: lighten($green, 10%);
+    outline: 2px solid $green;
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+}
+
+// ── Responsive ────────────────────────────────────────
+@media (max-width: 768px) {
+  .sitemap-page {
+    padding: 1.8rem 1.2rem;
+  }
+
+  .sitemap-title {
+    font-size: 2.2rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .sitemap-subtitle {
+    font-size: 0.95rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .sitemap-link {
+    font-size: 1.2rem;
+  }
+
+  .sitemap-divider {
+    margin: 0 0 1.4rem 0;
+  }
+
+  .sitemap-section {
+    margin-bottom: 1.4rem;
+    gap: 0.4rem;
+  }
+}
+
+// ── Très petit écran ───────────────────────────────────
+@media (max-width: 576px) {
+  .sitemap-page {
+    padding: 1.2rem 0.8rem;
+  }
+
+  .sitemap-title {
+    font-size: 1.8rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .sitemap-subtitle {
+    font-size: 0.9rem;
+    margin-bottom: 0.7rem;
+  }
+
+  .sitemap-link {
+    font-size: 1rem;
+  }
+}

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -200,10 +200,11 @@ class MatchesController < ApplicationController
       # Email de confirmation avec récapitulatif du match pour l'organisateur
       UserMailer.match_created(@match).deliver_later
 
-      # Planifie le rappel 24h avant le match pour tous les participants approuvés.
-      # On vérifie qu'il reste plus de 24h avant le match pour éviter un job inutile
-      # (ex: match créé à J-2h → le rappel serait déjà passé).
-      reminder_time = @match.build_datetime - 24.hours
+      # Planifie le rappel ~24h avant le match pour tous les participants approuvés.
+      # On anticipe de 30 min (-24.5.hours) pour absorber un éventuel retard de la queue :
+      # si le worker est lent, le rappel part quand même avant le coup d'envoi.
+      # Le job lui-même vérifie en plus que le match n'a pas encore commencé avant d'envoyer.
+      reminder_time = @match.build_datetime - 24.5.hours
       MatchReminderJob.set(wait_until: reminder_time).perform_later(@match.id) if reminder_time > Time.current
 
       redirect_to @match, notice: "Match créé avec succès !"

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -246,21 +246,36 @@ class MatchesController < ApplicationController
                          .where(status: ["approved", "pending", "waiting"])
                          .includes(:user)
 
-    # Notifie chaque participant en temps réel si il est sur la page du match,
-    # et envoie un email transactionnel pour les utilisateurs absents.
-    # IMPORTANT : on utilise deliver_now (pas deliver_later) car le match est
-    # détruit juste après. Avec deliver_later, SolidQueue tente de désérialiser
-    # le Match via GlobalID mais il n'existe plus en base → DeserializationError.
+    # ── Extraction des données AVANT destruction ──────────────────────────────
+    # On sérialise uniquement des scalaires pour éviter le DeserializationError
+    # de SolidQueue lors du deliver_later (GlobalID ne peut pas recharger un
+    # enregistrement détruit).
+    match_title    = @match.title
+    match_date     = @match.date
+    match_time_str = @match.time&.strftime("%Hh%M")
+    venue_name     = @match.venue&.name
+    venue_city     = @match.venue&.city
+    organizer_name = @match.user.display_name
+
+    # Liste des destinataires : participants + organisateur
+    recipient_emails = participants.map { |mu| mu.user.email }
+    recipient_emails << @match.user.email
+
+    # Broadcasts Turbo AVANT destroy → le canal ActionCable doit encore exister
     participants.each do |mu|
       broadcast_match_cancelled_to_participant(mu.user)
-      UserMailer.match_cancelled(@match, mu.user).deliver_now
     end
 
-    # Envoie également l'email de confirmation d'annulation à l'organisateur lui-même.
-    # Il est exclu de participants (role: "organisateur") mais doit recevoir un récapitulatif.
-    UserMailer.match_cancelled(@match, @match.user).deliver_now
-
     @match.destroy
+
+    # Enqueue des emails asynchrones avec données scalaires uniquement
+    recipient_emails.each do |email|
+      MatchCancelledMailerJob.perform_later(
+        email, match_title, match_date, match_time_str,
+        venue_name, venue_city, organizer_name
+      )
+    end
+
     redirect_to matches_path, notice: "Match supprimé."
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   # Ces pages sont publiques (pas besoin d'être connecté)
-  skip_before_action :authenticate_user!, only: %i[home about contact partenariat confidentialite conditions offline email_confirmation]
+  skip_before_action :authenticate_user!, only: %i[home about contact partenariat confidentialite conditions offline email_confirmation sitemap]
 
   # Rails 7.1 vérifie au chargement que les actions dans `only:` existent.
   # PagesController n'a pas d'action `index`, donc on désactive les callbacks Pundit.
@@ -59,6 +59,16 @@ class PagesController < ApplicationController
     set_meta_tags(
       title:   "Conditions générales d'utilisation",
       # noindex : cette page légale ne doit pas apparaître dans Google
+      noindex: true
+    )
+  end
+
+  def sitemap
+    # Page plan du site — liste de tous les liens importants
+    # Charge les sports pour la section dédiée
+    @sports = Sport.order(:name)
+    set_meta_tags(
+      title:   "Plan du site",
       noindex: true
     )
   end

--- a/app/controllers/profils_controller.rb
+++ b/app/controllers/profils_controller.rb
@@ -53,7 +53,14 @@ class ProfilsController < ApplicationController
     @pending_reviewers = User.where(id: pending_reviewer_ids).includes(:profil)
 
     # Équipes du joueur (affiché sur le profil)
-    @profil_teams = current_user.teams.includes(:captain, :team_members).order(:name)
+    # Utilise preload pour les captains (requête séparée) + left_joins + COUNT
+    # pour calculer le nombre de membres en SQL plutôt que de charger tous les enregistrements
+    @profil_teams = current_user.teams
+                                 .preload(:captain)
+                                 .left_joins(:team_members)
+                                 .select("teams.*, COUNT(team_members.id) AS members_count")
+                                 .group("teams.id")
+                                 .order(:name)
   end
 
   # GET /users/:id/profil/old
@@ -109,7 +116,14 @@ class ProfilsController < ApplicationController
                                     )
 
     # Toutes les équipes du joueur affiché — toujours chargées
-    @profil_teams = @profil_user.teams.includes(:captain, :team_members).order(:name)
+    # Utilise preload pour les captains (requête séparée) + left_joins + COUNT
+    # pour calculer le nombre de membres en SQL plutôt que de charger tous les enregistrements
+    @profil_teams = @profil_user.teams
+                                 .preload(:captain)
+                                 .left_joins(:team_members)
+                                 .select("teams.*, COUNT(team_members.id) AS members_count")
+                                 .group("teams.id")
+                                 .order(:name)
 
     # Équipes où current_user est captain et peut encore inviter ce joueur
     # (uniquement si on consulte le profil de quelqu'un d'autre)
@@ -220,7 +234,14 @@ class ProfilsController < ApplicationController
     @pending_reviewers = User.where(id: pending_reviewer_ids).includes(:profil)
 
     # Équipes du joueur (affiché sur le profil)
-    @profil_teams = current_user.teams.includes(:captain, :team_members).order(:name)
+    # Utilise preload pour les captains (requête séparée) + left_joins + COUNT
+    # pour calculer le nombre de membres en SQL plutôt que de charger tous les enregistrements
+    @profil_teams = current_user.teams
+                                 .preload(:captain)
+                                 .left_joins(:team_members)
+                                 .select("teams.*, COUNT(team_members.id) AS members_count")
+                                 .group("teams.id")
+                                 .order(:name)
   end
 
   # GET /users/:id/profil
@@ -281,7 +302,14 @@ class ProfilsController < ApplicationController
                                     )
 
     # Toutes les équipes du joueur affiché — toujours chargées, même si c'est son propre profil
-    @profil_teams = @profil_user.teams.includes(:captain, :team_members).order(:name)
+    # Utilise preload pour les captains (requête séparée) + left_joins + COUNT
+    # pour calculer le nombre de membres en SQL plutôt que de charger tous les enregistrements
+    @profil_teams = @profil_user.teams
+                                 .preload(:captain)
+                                 .left_joins(:team_members)
+                                 .select("teams.*, COUNT(team_members.id) AS members_count")
+                                 .group("teams.id")
+                                 .order(:name)
 
     # Équipes où current_user est captain et peut encore inviter ce joueur
     # (uniquement si on consulte le profil de quelqu'un d'autre)

--- a/app/jobs/match_cancelled_mailer_job.rb
+++ b/app/jobs/match_cancelled_mailer_job.rb
@@ -1,0 +1,38 @@
+# Envoie l'email d'annulation de match de façon asynchrone.
+# Accepte uniquement des données scalaires pour éviter le DeserializationError
+# de SolidQueue qui tente de recharger un AR object supprimé via GlobalID.
+#
+# Sécurité retry : les arguments sont 100 % scalaires (String, Date) → pas de
+# GlobalID → pas de DeserializationError si SolidQueue rejoue le job après un
+# échec réseau/SMTP. Le retry est donc sûr.
+class MatchCancelledMailerJob < ApplicationJob
+  queue_as :default
+
+  # Retry sur erreurs réseau/SMTP (SendGrid down, timeout…)
+  retry_on Net::SMTPAuthenticationError,
+           Net::SMTPServerBusy,
+           Net::SMTPFatalError,
+           Net::SMTPUnknownError,
+           Errno::ECONNRESET,
+           wait: :polynomially_longer,
+           attempts: 5
+
+  # @param user_email     [String]      email du destinataire
+  # @param match_title    [String]      titre du match annulé
+  # @param match_date     [Date]        date du match (sérialisée nativement par ActiveJob)
+  # @param match_time_str [String, nil] heure formatée "HHhMM" ou nil
+  # @param venue_name     [String, nil] nom du lieu ou nil
+  # @param venue_city     [String, nil] ville du lieu ou nil
+  # @param organizer_name [String]      display_name de l'organisateur
+  def perform(user_email, match_title, match_date, match_time_str, venue_name, venue_city, organizer_name)
+    UserMailer.match_cancelled_async(
+      user_email:,
+      match_title:,
+      match_date:,
+      match_time_str:,
+      venue_name:,
+      venue_city:,
+      organizer_name:
+    ).deliver_now
+  end
+end

--- a/app/jobs/match_reminder_job.rb
+++ b/app/jobs/match_reminder_job.rb
@@ -16,6 +16,10 @@ class MatchReminderJob < ApplicationJob
     # Le match a été supprimé entre la planification et l'exécution du job → on arrête
     return unless match
 
+    # Sécurité : si la queue était en retard et que le match a déjà commencé,
+    # on n'envoie pas le rappel (inutile et confus pour le participant)
+    return if match.build_datetime <= Time.current
+
     # Récupère tous les participants approuvés (joueurs + organisateur)
     # includes(:user) pour éviter les N+1 queries lors de l'envoi des emails
     participants = match.match_users

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -55,6 +55,28 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "Le match \"#{match.title}\" a été annulé")
   end
 
+  # ── 3b. Version asynchrone de match_cancelled via MatchCancelledMailerJob ─
+  # Accepte des données scalaires (pas d'AR objects) pour la compatibilité SolidQueue.
+  # Évite le DeserializationError causé par GlobalID sur un Match détruit.
+  #
+  # @param user_email     [String]      email du destinataire
+  # @param match_title    [String]      titre du match annulé
+  # @param match_date     [Date]        date du match
+  # @param match_time_str [String, nil] heure formatée "HHhMM" ou nil
+  # @param venue_name     [String, nil] nom du lieu ou nil
+  # @param venue_city     [String, nil] ville du lieu ou nil
+  # @param organizer_name [String]      display_name de l'organisateur
+  def match_cancelled_async(user_email:, match_title:, match_date:, match_time_str:, venue_name:, venue_city:, organizer_name:)
+    @match_title     = match_title
+    @match_date      = match_date      # Date — pour I18n.l
+    @match_time_str  = match_time_str  # String "HHhMM" ou nil — déjà formaté
+    @venue_name      = venue_name
+    @venue_city      = venue_city
+    @organizer_name  = organizer_name
+
+    mail(to: user_email, subject: "Le match \"#{match_title}\" a été annulé")
+  end
+
   # ── 4. Un joueur a quitté ton match ───────────────────────────────────────
   # Destinataire : l'organisateur du match
   # Déclenché    : match_users#destroy (uniquement si le joueur était approuvé)

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -24,36 +24,22 @@ class Avis < ApplicationRecord
   after_create  :recalculate_average
   after_destroy :recalculate_average
 
+  # Maintient le flag mutual quand un nouvel avis est créé ou supprimé
+  after_create  :set_mutual_flag
+  after_destroy :clear_mutual_flag
+
   # ── Scopes ────────────────────────────────────────────────────────────────
 
   # Retourne les avis récents en premier
   scope :recent, -> { order(created_at: :desc) }
 
   # Avis mutuels : l'avis A→B n'est visible que si B→A existe pour le même match.
-  # On vérifie l'existence d'un avis inverse (même match, reviewer/reviewed inversés).
-  scope :mutual, lambda {
-    where(
-      "EXISTS (
-        SELECT 1 FROM avis a2
-        WHERE a2.reviewer_id      = avis.reviewed_user_id
-          AND a2.reviewed_user_id = avis.reviewer_id
-          AND a2.match_id         = avis.match_id
-      )"
-    )
-  }
+  # La colonne booléenne 'mutual' est maintenue par les callbacks après_create et après_destroy.
+  scope :mutual, -> { where(mutual: true) }
 
   # Avis non-mutuels : l'autre personne n'a pas encore rendu la pareille.
   # Utile pour afficher un compteur "avis en attente" sur son propre profil.
-  scope :non_mutual, lambda {
-    where.not(
-      "EXISTS (
-        SELECT 1 FROM avis a2
-        WHERE a2.reviewer_id      = avis.reviewed_user_id
-          AND a2.reviewed_user_id = avis.reviewer_id
-          AND a2.match_id         = avis.match_id
-      )"
-    )
-  }
+  scope :non_mutual, -> { where(mutual: false) }
 
   private
 
@@ -132,5 +118,31 @@ class Avis < ApplicationRecord
 
     # update_columns évite de déclencher les callbacks du profil (plus performant)
     profil.update_columns(average_rating: avg, avis_count: count)
+  end
+
+  # ── Maintien du flag mutual ────────────────────────────────────────────────
+
+  # Quand A→B est créé : si B→A existe, les deux deviennent mutuels
+  # Utilise update_column pour éviter de déclencher les callbacks (performance)
+  def set_mutual_flag
+    inverse = Avis.find_by(
+      reviewer_id: reviewed_user_id,
+      reviewed_user_id: reviewer_id,
+      match_id: match_id
+    )
+    return unless inverse
+
+    update_column(:mutual, true)
+    inverse.update_column(:mutual, true)
+  end
+
+  # Quand A→B est détruit : si B→A existe, il redevient non-mutuel
+  def clear_mutual_flag
+    inverse = Avis.find_by(
+      reviewer_id: reviewed_user_id,
+      reviewed_user_id: reviewer_id,
+      match_id: match_id
+    )
+    inverse&.update_column(:mutual, false)
   end
 end

--- a/app/views/pages/sitemap.html.erb
+++ b/app/views/pages/sitemap.html.erb
@@ -3,132 +3,57 @@
     Route : GET /sitemap
     Page publique — accessible sans connexion
     RGAA 12.1 — deuxième système de navigation
+    Design : fond #111111 (dark), titre Bebas Neue blanc,
+    liens verts uppercase, séparateurs horizontaux
     ===================================================== %>
 
 <div class="sitemap-page">
+  <div class="container-fluid sitemap-inner">
 
-  <%# ── Bannière ────────────────────────────────────── %>
-  <section class="legal-banner">
-    <div class="container">
-      <h1 class="legal-banner-title">Plan du site</h1>
-      <p class="legal-banner-subtitle">
-        Retrouvez tous les liens importants de Teams-Up.
-      </p>
-    </div>
-  </section>
+    <h1 class="sitemap-title">PLAN DU SITE</h1>
+    <p class="sitemap-subtitle">Retrouvez tous les liens importants de Teams-Up.</p>
+    <hr class="sitemap-divider">
 
-  <%# ── Contenu principal ───────────────────────────── %>
-  <section class="legal-content">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8">
+    <%# ── Section 1 — Navigation principale ────────────── %>
+    <nav class="sitemap-section" aria-label="Navigation principale">
+      <%= link_to "ACCUEIL", root_path, class: "sitemap-link" %>
+      <%= link_to "TROUVER UN MATCH", matches_path, class: "sitemap-link" %>
+      <%= link_to "MES MATCHS", matches_path(mine: true), class: "sitemap-link" %>
+      <%= link_to "MES ÉQUIPES", teams_path, class: "sitemap-link" %>
+      <% if user_signed_in? %>
+        <%= link_to "MON PROFIL", user_profil_path(current_user), class: "sitemap-link" %>
+      <% else %>
+        <%= link_to "SE CONNECTER", new_user_session_path, class: "sitemap-link" %>
+      <% end %>
+    </nav>
+    <hr class="sitemap-divider">
 
-          <%# Sections de navigation ──────────────────── %>
+    <%# ── Section 2 — Informations légales ───────────── %>
+    <nav class="sitemap-section" aria-label="Informations légales">
+      <%= link_to "POLITIQUE DE CONFIDENTIALITÉ", confidentialite_path, class: "sitemap-link" %>
+      <%= link_to "CONDITIONS GÉNÉRALES D'UTILISATION", conditions_path, class: "sitemap-link" %>
+      <%= link_to "MENTIONS LÉGALES", contact_path, class: "sitemap-link" %>
+      <%= link_to "NOUS CONTACTER", contact_path, class: "sitemap-link" %>
+    </nav>
+    <hr class="sitemap-divider">
 
-          <%# Principal %>
-          <nav class="sitemap-section">
-            <h2 class="sitemap-section-title">Navigation principale</h2>
-            <ul class="sitemap-list">
-              <li><%= link_to "Accueil", root_path %></li>
-              <li><%= link_to "Trouver un match", matches_path %></li>
-              <li><%= link_to "Mes matchs", matches_path(mine: true) %></li>
-              <li><%= link_to "Mes équipes", teams_path %></li>
-              <li><% if user_signed_in? %>
-                  <%= link_to "Mon profil", user_profil_path(current_user) %>
-                <% else %>
-                  <%= link_to "Se connecter", new_user_session_path %>
-                <% end %>
-              </li>
-            </ul>
-          </nav>
+    <%# ── Section 3 — Sports disponibles ─────────────── %>
+    <nav class="sitemap-section" aria-label="Sports disponibles">
+      <% @sports.each do |sport| %>
+        <%= link_to sport.name.upcase, matches_path(sport: sport.id), class: "sitemap-link" %>
+      <% end %>
+    </nav>
 
-          <%# Informations légales %>
-          <nav class="sitemap-section">
-            <h2 class="sitemap-section-title">Légal</h2>
-            <ul class="sitemap-list">
-              <li><%= link_to "Politique de confidentialité", confidentialite_path %></li>
-              <li><%= link_to "Conditions générales d'utilisation", conditions_path %></li>
-              <li><%= link_to "Mentions légales", contact_path %></li>
-              <li><%= link_to "Nous contacter", contact_path %></li>
-            </ul>
-          </nav>
+    <%# ── Section 4 — Administration (si admin) ─────── %>
+    <% if user_signed_in? && current_user.admin? %>
+      <hr class="sitemap-divider">
+      <nav class="sitemap-section" aria-label="Administration">
+        <%= link_to "TABLEAU DE BORD", admin_dashboard_path, class: "sitemap-link" %>
+        <%= link_to "MESSAGES DE CONTACT", admin_contact_messages_path, class: "sitemap-link" %>
+        <%= link_to "MODÉRATION D'IMAGES", admin_image_moderations_path, class: "sitemap-link" %>
+        <%= link_to "LOGS DE SÉCURITÉ", admin_security_logs_path, class: "sitemap-link" %>
+      </nav>
+    <% end %>
 
-          <%# Sports ──────────────────────────────────── %>
-          <% if Sport.any? %>
-            <nav class="sitemap-section">
-              <h2 class="sitemap-section-title">Sports disponibles</h2>
-              <ul class="sitemap-list">
-                <% Sport.order(:name).limit(10).each do |sport| %>
-                  <li><%= link_to sport.name, matches_path(sport: sport.id) %></li>
-                <% end %>
-                <% if Sport.count > 10 %>
-                  <li><%= link_to "... et #{Sport.count - 10} autres", matches_path %></li>
-                <% end %>
-              </ul>
-            </nav>
-          <% end %>
-
-          <%# Admin (connecté uniquement) ───────────── %>
-          <% if user_signed_in? && current_user.admin? %>
-            <nav class="sitemap-section">
-              <h2 class="sitemap-section-title">Administration</h2>
-              <ul class="sitemap-list">
-                <li><%= link_to "Tableau de bord", admin_dashboard_path %></li>
-                <li><%= link_to "Messages de contact", admin_contact_messages_path %></li>
-                <li><%= link_to "Modération d'images", admin_image_moderations_path %></li>
-                <li><%= link_to "Logs de sécurité", admin_security_logs_path %></li>
-              </ul>
-            </nav>
-          <% end %>
-
-        </div>
-      </div>
-    </div>
-  </section>
-
+  </div>
 </div>
-
-<style>
-  .sitemap-page {
-    margin-top: 0;
-  }
-
-  .sitemap-section {
-    margin-bottom: 2.5rem;
-  }
-
-  .sitemap-section-title {
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: #f0f0f0;
-    margin-bottom: 1rem;
-    font-family: "Nunito", sans-serif;
-  }
-
-  .sitemap-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .sitemap-list li {
-    margin-bottom: 0.5rem;
-  }
-
-  .sitemap-list a {
-    color: #1EDD88;
-    text-decoration: none;
-    transition: color 0.15s;
-  }
-
-  .sitemap-list a:hover,
-  .sitemap-list a:focus-visible {
-    color: #4de49e;
-    text-decoration: underline;
-  }
-
-  .sitemap-list a:focus-visible {
-    outline: 2px solid #1EDD88;
-    outline-offset: 2px;
-  }
-</style>

--- a/app/views/profils/_profil_teams.html.erb
+++ b/app/views/profils/_profil_teams.html.erb
@@ -54,7 +54,7 @@
             <%# Nombre de membres %>
             <div style="flex-shrink:0; font-size:0.75rem; color:rgba(255,255,255,0.35); display:flex; align-items:center; gap:3px;">
               <i data-lucide="users" style="width:11px; height:11px;"></i>
-              <%= team.team_members.size %>
+              <%= team.members_count %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -6,11 +6,11 @@
 <footer class="site-footer">
   <div class="container">
     <%# align-items-center : tout sur la même ligne, centré verticalement %>
-    <div class="row align-items-center">
+    <div class="row align-items-center py-3">
 
       <%# ── Logo : picto SVG + texte SVG côte à côte ── %>
       <%# justify-content-center sur mobile, justify-content-md-start sur desktop %>
-      <div class="col-md-4 d-flex justify-content-center justify-content-md-start">
+      <div class="col-md-4 d-flex align-items-center justify-content-center justify-content-md-start">
         <%= link_to root_path, class: "footer-logo" do %>
           <%# Icône picto blanc Teams-Up — RGESN 5.2 (dimensions HTML) + RGESN 6.4 (lazy loading) %>
           <%= image_tag "img_footer/teamsup_picto_blanc.svg", alt: "", height: 32, width: 32, class: "footer-logo-picto", loading: "lazy" %>
@@ -38,10 +38,10 @@
 
       <%# ── Réseaux sociaux ── %>
       <%# justify-content-center sur mobile, justify-content-md-end sur desktop %>
-      <div class="col-md-4 d-flex justify-content-center justify-content-md-end">
+      <div class="col-md-4 d-flex align-items-center justify-content-center justify-content-md-end">
         <%# Font Awesome pour les réseaux sociaux (Lucide n'a pas TikTok) %>
         <%# RGAA 13.2 — tous les liens target="_blank" ont rel="noopener noreferrer" et indication textuelle %>
-        <div class="footer-social d-flex gap-4">
+        <div class="footer-social d-flex align-items-center gap-4">
           <a href="https://www.instagram.com/teamsup33?igsh=dGs2d3F6MDBmZDJ6" target="_blank" rel="noopener noreferrer" aria-label="Instagram (nouvelle fenêtre)">
             <i class="fa-brands fa-instagram fa-lg"></i>
           </a>

--- a/app/views/user_mailer/match_cancelled_async.html.erb
+++ b/app/views/user_mailer/match_cancelled_async.html.erb
@@ -1,0 +1,76 @@
+<%# ── Email : un match auquel tu participais a été annulé ───────────────── %>
+<%# Version asynchrone — accepte des données scalaires au lieu d'AR objects %>
+<%# Inline CSS obligatoire — les clients mail ignorent les feuilles de style externes %>
+<div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #111111; padding: 40px 20px; min-height: 100vh;">
+
+  <div style="max-width: 520px; margin: 0 auto; background-color: #1a1c1a; border-radius: 16px; border: 1px solid rgba(255,255,255,0.08); overflow: hidden;">
+
+    <%# En-tête logo %>
+    <div style="background-color: #111111; padding: 28px 40px; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.06);">
+      <span style="font-size: 1.6rem; font-weight: 800; color: #f0f0f0; letter-spacing: -0.5px;">
+        TEAMS<span style="color: #1EDD88;">-UP</span>
+      </span>
+    </div>
+
+    <%# Corps %>
+    <div style="padding: 36px 40px;">
+
+      <%# Icône annulation %>
+      <div style="text-align: center; margin-bottom: 24px;">
+        <div style="display: inline-block; background-color: rgba(230, 126, 34, 0.12); border-radius: 50%; width: 64px; height: 64px; line-height: 64px; font-size: 28px;">
+          🚫
+        </div>
+      </div>
+
+      <%# Titre %>
+      <h1 style="color: #f0f0f0; font-size: 1.4rem; font-weight: 700; text-align: center; margin: 0 0 8px 0;">
+        Match annulé
+      </h1>
+
+      <%# Sous-titre %>
+      <p style="color: rgba(255,255,255,0.45); font-size: 0.9rem; text-align: center; margin: 0 0 28px 0;">
+        <strong style="color: rgba(255,255,255,0.7);"><%= @match_title %></strong> ne se jouera plus.
+      </p>
+
+      <%# Message principal %>
+      <p style="color: rgba(255,255,255,0.65); font-size: 0.95rem; line-height: 1.6; margin: 0 0 20px 0;">
+        Malheureusement, l'organisateur <strong style="color: #f0f0f0;"><%= @organizer_name %></strong>
+        a annulé ce match. Ta place a été libérée automatiquement.
+      </p>
+
+      <%# Encart récapitulatif du match annulé %>
+      <div style="background-color: rgba(253, 16, 21, 0.05); border: 1px solid rgba(253, 16, 21, 0.15); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
+        <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Match annulé</p>
+        <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0; text-decoration: line-through; opacity: 0.6;">
+          📅 <%= I18n.l(@match_date, format: :long) %><% if @match_time_str %> à <%= @match_time_str %><% end %>
+        </p>
+        <% if @venue_name.present? %>
+          <p style="color: rgba(255,255,255,0.4); font-size: 0.9rem; margin: 0; text-decoration: line-through; opacity: 0.6;">
+            📍 <%= @venue_name %><% if @venue_city %>, <%= @venue_city %><% end %>
+          </p>
+        <% end %>
+      </div>
+
+      <%# CTA pour trouver un autre match %>
+      <p style="color: rgba(255,255,255,0.55); font-size: 0.9rem; text-align: center; margin: 0 0 20px 0;">
+        Il y a d'autres matchs disponibles près de chez toi !
+      </p>
+
+      <div style="text-align: center; margin-bottom: 28px;">
+        <%= link_to matches_url,
+            style: "display: inline-block; background-color: #1EDD88; color: #111111; font-weight: 700; font-size: 1rem; padding: 14px 36px; border-radius: 50px; text-decoration: none; letter-spacing: 0.3px;" do %>
+          Trouver un nouveau match
+        <% end %>
+      </div>
+
+    </div>
+
+    <%# Pied de page %>
+    <div style="background-color: #111111; padding: 20px 40px; text-align: center; border-top: 1px solid rgba(255,255,255,0.06);">
+      <p style="color: rgba(255,255,255,0.25); font-size: 0.78rem; margin: 0;">
+        © <%= Date.today.year %> Teams-Up — Tous droits réservés.
+      </p>
+    </div>
+
+  </div>
+</div>

--- a/app/views/user_mailer/match_cancelled_async.text.erb
+++ b/app/views/user_mailer/match_cancelled_async.text.erb
@@ -1,0 +1,19 @@
+TEAMS-UP
+========
+
+Match annulé — <%= @match_title %>
+
+Malheureusement, l'organisateur <%= @organizer_name %> a annulé ce match.
+Ta place a été libérée automatiquement.
+
+Match annulé :
+  Date : <%= I18n.l(@match_date, format: :long) %><% if @match_time_str %> à <%= @match_time_str %><% end %>
+<% if @venue_name.present? %>
+  Lieu : <%= @venue_name %><% if @venue_city %>, <%= @venue_city %><% end %>
+<% end %>
+
+Il y a d'autres matchs disponibles près de chez toi !
+Trouver un nouveau match : <%= matches_url %>
+
+--
+© <%= Date.today.year %> Teams-Up — Tous droits réservés.

--- a/db/migrate/20260420104608_add_performance_indexes.rb
+++ b/db/migrate/20260420104608_add_performance_indexes.rb
@@ -1,0 +1,12 @@
+class AddPerformanceIndexes < ActiveRecord::Migration[8.1]
+  def change
+    # Index sur matches pour les requêtes filtrées par user_id et ordonnées par created_at
+    add_index :matches, [:user_id, :created_at], name: 'index_matches_on_user_id_created_at'
+
+    # Index sur avis pour les requêtes filtrées par reviewed_user_id et ordonnées par created_at
+    add_index :avis, [:reviewed_user_id, :created_at], name: 'index_avis_on_reviewed_user_id_created_at'
+
+    # Index sur match_users pour les requêtes filtrées par match_id et status
+    add_index :match_users, [:match_id, :status], name: 'index_match_users_on_match_id_status'
+  end
+end

--- a/db/migrate/20260420104616_add_mutual_to_avis.rb
+++ b/db/migrate/20260420104616_add_mutual_to_avis.rb
@@ -1,0 +1,26 @@
+class AddMutualToAvis < ActiveRecord::Migration[8.1]
+  def up
+    # Ajoute la colonne mutual avec valeur par défaut false
+    add_column :avis, :mutual, :boolean, default: false, null: false
+
+    # Backfill — marque les avis mutuels existants
+    # Un avis est mutuel si son inverse existe (même match, reviewer/reviewed inversés)
+    execute <<-SQL
+      UPDATE avis SET mutual = true
+      WHERE EXISTS (
+        SELECT 1 FROM avis a2
+        WHERE a2.reviewer_id      = avis.reviewed_user_id
+          AND a2.reviewed_user_id = avis.reviewer_id
+          AND a2.match_id         = avis.match_id
+      )
+    SQL
+
+    # Crée un index sur la colonne mutual pour les requêtes filtrées
+    add_index :avis, :mutual, name: 'index_avis_on_mutual'
+  end
+
+  def down
+    remove_index :avis, name: 'index_avis_on_mutual'
+    remove_column :avis, :mutual
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_104616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -58,11 +58,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
     t.text "content"
     t.datetime "created_at", null: false
     t.bigint "match_id", null: false
+    t.boolean "mutual", default: false, null: false
     t.integer "rating", null: false
     t.bigint "reviewed_user_id", null: false
     t.bigint "reviewer_id", null: false
     t.datetime "updated_at", null: false
     t.index ["match_id"], name: "index_avis_on_match_id"
+    t.index ["mutual"], name: "index_avis_on_mutual"
+    t.index ["reviewed_user_id", "created_at"], name: "index_avis_on_reviewed_user_id_created_at"
     t.index ["reviewed_user_id"], name: "index_avis_on_reviewed_user_id"
     t.index ["reviewer_id", "reviewed_user_id", "match_id"], name: "index_avis_on_reviewer_id_and_reviewed_user_id_and_match_id", unique: true
     t.index ["reviewer_id"], name: "index_avis_on_reviewer_id"
@@ -116,6 +119,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
     t.string "status", default: "pending"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["match_id", "status"], name: "index_match_users_on_match_id_status"
     t.index ["match_id"], name: "index_match_users_on_match_id"
     t.index ["user_id"], name: "index_match_users_on_user_id"
   end
@@ -141,7 +145,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
     t.string "genre_restriction", default: "tous"
     t.bigint "homme_du_match_id"
     t.string "level"
-    t.integer "max_supporters", default: 0
     t.string "place"
     t.integer "player_left"
     t.integer "players_present"
@@ -160,6 +163,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
     t.index ["private_token"], name: "index_matches_on_private_token", unique: true
     t.index ["sport_id"], name: "index_matches_on_sport_id"
     t.index ["team_id"], name: "index_matches_on_team_id"
+    t.index ["user_id", "created_at"], name: "index_matches_on_user_id_created_at"
     t.index ["user_id"], name: "index_matches_on_user_id"
     t.index ["venue_id"], name: "index_matches_on_venue_id"
   end
@@ -258,148 +262,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
     t.index ["event_type"], name: "index_security_logs_on_event_type"
     t.index ["ip_address"], name: "index_security_logs_on_ip_address"
     t.index ["user_id"], name: "index_security_logs_on_user_id"
-  end
-
-  create_table "solid_cable_messages", force: :cascade do |t|
-    t.binary "channel", null: false
-    t.bigint "channel_hash", null: false
-    t.datetime "created_at", null: false
-    t.binary "payload", null: false
-    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
-    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
-    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
-  end
-
-  create_table "solid_cache_entries", force: :cascade do |t|
-    t.integer "byte_size", null: false
-    t.datetime "created_at", null: false
-    t.binary "key", null: false
-    t.bigint "key_hash", null: false
-    t.binary "value", null: false
-    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
-    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
-    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
-  end
-
-  create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.string "concurrency_key", null: false
-    t.datetime "created_at", null: false
-    t.datetime "expires_at", null: false
-    t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
-    t.string "queue_name", null: false
-    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
-    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
-  end
-
-  create_table "solid_queue_claimed_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "job_id", null: false
-    t.bigint "process_id"
-    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
-  end
-
-  create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.text "error"
-    t.bigint "job_id", null: false
-    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
-  end
-
-  create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "active_job_id"
-    t.text "arguments"
-    t.string "class_name", null: false
-    t.string "concurrency_key"
-    t.datetime "created_at", null: false
-    t.datetime "finished_at"
-    t.integer "priority", default: 0, null: false
-    t.string "queue_name", null: false
-    t.datetime "scheduled_at"
-    t.datetime "updated_at", null: false
-    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
-    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
-    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
-    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
-  end
-
-  create_table "solid_queue_pauses", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "queue_name", null: false
-    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
-  end
-
-  create_table "solid_queue_processes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "hostname"
-    t.string "kind", null: false
-    t.datetime "last_heartbeat_at", null: false
-    t.text "metadata"
-    t.string "name", null: false
-    t.integer "pid", null: false
-    t.bigint "supervisor_id"
-    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
-  end
-
-  create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
-    t.string "queue_name", null: false
-    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
-    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
-  end
-
-  create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "job_id", null: false
-    t.datetime "run_at", null: false
-    t.string "task_key", null: false
-    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
-  end
-
-  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.text "arguments"
-    t.string "class_name"
-    t.string "command", limit: 2048
-    t.datetime "created_at", null: false
-    t.text "description"
-    t.string "key", null: false
-    t.integer "priority", default: 0
-    t.string "queue_name"
-    t.string "schedule", null: false
-    t.boolean "static", default: true, null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
-  end
-
-  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
-    t.string "queue_name", null: false
-    t.datetime "scheduled_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
-  end
-
-  create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "expires_at", null: false
-    t.string "key", null: false
-    t.datetime "updated_at", null: false
-    t.integer "value", default: 1, null: false
-    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   create_table "sport_profils", force: :cascade do |t|
@@ -547,12 +409,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170000) do
   add_foreign_key "profil_favorite_venues", "venues"
   add_foreign_key "profils", "users"
   add_foreign_key "security_logs", "users", on_delete: :nullify
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "sport_profils", "profils"
   add_foreign_key "sport_profils", "sports"
   add_foreign_key "team_invitations", "teams"


### PR DESCRIPTION
Récapitulatif des modifications — Page Sitemap                                                                                                                                                                                                        

Controller — pages_controller.rb                                                                                                                                                                                                                      
Ajout de :sitemap à la liste des pages publiques (skip_before_action). Création de l'action sitemap qui charge les sports depuis la base de données et configure les meta tags avec title "Plan du site" et noindex: true.
                                                                                                                                                                                                                                                        
Vue — app/views/pages/sitemap.html.erb                    
Réécriture complète en design dark. Structure avec titre "PLAN DU SITE", subtitle "Retrouvez tous les liens importants de Teams-Up.", puis quatre sections séparées par des traits horizontaux : Navigation principale, Informations légales, Sports
disponibles (dynamiques via @sports), et Administration (optionnelle pour les admins). Tous les liens sont en uppercase. Suppression des styles inline.

SCSS — app/assets/stylesheets/pages/_sitemap.scss
Création d'une nouvelle feuille de styles avec design dark complet. Fond #0a110d, titre Bebas Neue 3rem blanc, subtitle Work Sans 1rem gris pâle, liens Bebas Neue 1.4rem verts uppercase, traits blancs 3.3px séparant les sections. Spacing serré :
padding page 2.5rem 3.5rem, marges réduites entre éléments. Breakpoints responsive pour tablette et mobile avec ajustements proportionnels. Focus states pour l'accessibilité.

Stylesheet index — app/assets/stylesheets/pages/_index.scss
Ajout de l'import @import "sitemap" dans la liste des pages.

Route
Route existante : GET /sitemap → pages#sitemap

La page est accessible sans authentification, avec design épuré et fond très sombre, présentant tous les liens importants de l'application dans une architecture claire.