### PR TITLE
Modification pour le session-timeout

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,11 +1,22 @@
 # Controller de session personnalisé.
 # Il surcharge Devise::SessionsController pour :
 #   1. Enregistrer un log de sécurité en cas d'échec de connexion
+#   2. Afficher un message flash si la session a expiré (timeout 1h)
 #
 # Les connexions RÉUSSIES sont loguées dans application_controller.rb
 # via la méthode after_sign_in_path_for.
 module Users
   class SessionsController < Devise::SessionsController
+    # Affiche un message flash si la session a expiré (Devise :timeoutable)
+    def new
+      # Devise définit flash[:timedout] = true lors du timeout automatique
+      # On transforme cela en un message d'alerte lisible
+      if flash[:timedout]
+        flash[:alert] = I18n.t("devise.failure.timeout")
+      end
+      super
+    end
+
     # Surcharge de l'action POST /users/sign_in
     def create
       # super appelle la logique Devise normale

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable,  # Envoie un email de confirmation à l'inscription — bloque la connexion tant que l'email n'est pas vérifié
+         :timeoutable,  # Déconnexion automatique après 1h d'inactivité (session timeout) — RGPD
          :omniauthable, omniauth_providers: [:google_oauth2] # Activation de la connexion via Google
   # dependent: :destroy supprime le profil automatiquement quand l'user est supprimé
   has_one :profil, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -192,7 +192,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 1.hour  # Déconnexion automatique après 1 heure d'inactivité — RGPD
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
 Changements appliqués                                                                                                                                                                                                                                                           
  1. app/models/user.rb — Ajout de :timeoutable dans le devise call                                                                                                                                                                                     
    - Les utilisateurs seront maintenant déconnectés automatiquement après 1h d'inactivité                                                                                                                                                              
  2. config/initializers/devise.rb — Configuration du timeout                                                                                                                                                                                           
    - config.timeout_in = 1.hour activé (RGPD + sécurité)                                                                                                                                                                                               
  3. app/controllers/users/sessions_controller.rb — Gestion du flash                                                                                                                                                                                    
    - Affichage d'un message clair quand la session expire                                                                                                                                                                                              
                                                                                                                                                                                                                                                        
  ✅ Vérification en production                                                                                                                                                                                                                         
  J'ai testé avec un timeout réduit à 10 secondes :                                                                                                                                                                                                     
  - ✓ Connexion réussie                                                                                                                                                                                                                                 
  - ✓ Après 10 sec d'inactivité → redirection automatique vers /users/sign_in                                                                                                                                                                           
  - ✓ Message flash affiché (via Devise)                                                                                                                                                                                                                
                                                                                                                                                                                                                                                        
  🔒 Points importants                                                                                                                                                                                                                                                                  
  - Pas de migration DB : Devise stocke le timestamp dans le cookie de session                                                                                                                                                                          
  - "Se souvenir de moi" : Si activé, le timeout est ignoré (comportement Devise standard, acceptable)
  - ActionCable : Les websockets restent ouverts jusqu'à fermeture de la page (acceptable pour MVP)