### PR TITLE
web push ok

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem "pagy", "~> 9.3" # Pagination légère pour les tableaux admin (v9 = derniè
 gem "active_storage_validations" # Validation du type et de la taille des fichiers uploadés
 gem "valid_email2" # Validation format + existence MX record des emails
 gem "csv"
+gem "web-push" # Envoi de notifications push navigateur (PWA) via protocole Web Push + VAPID
 
 # SEO — gestion centralisée des balises <title>, <meta description>, OpenGraph, Twitter Card
 gem "meta-tags"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ GEM
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    openssl (4.0.1)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     pagy (9.4.0)
@@ -522,6 +523,9 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
+    web-push (3.1.0)
+      jwt (~> 3.0)
+      openssl (>= 3.0)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -592,6 +596,7 @@ DEPENDENCIES
   tzinfo-data
   valid_email2
   web-console
+  web-push
   webmock
 
 CHECKSUMS
@@ -710,6 +715,7 @@ CHECKSUMS
   omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
   omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
+  openssl (4.0.1) sha256=e27974136b7b02894a1bce46c5397ee889afafe704a839446b54dc81cb9c5f7d
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   pagy (9.4.0) sha256=db3f2e043f684155f18f78be62a81e8d033e39b9f97b1e1a8d12ad38d7bce738
@@ -792,6 +798,7 @@ CHECKSUMS
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
+  web-push (3.1.0) sha256=501ab00340c58fb70dabda59f28a86b3cccb0930c6f1f30721b2a5b24de7187d
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -68,6 +68,48 @@
 }
 
 
+// ── Boutons Web Push ─────────────────────────────────
+// Trois états gérés par push_notification_controller.js
+.btn-push-inactive {
+  background: var(--theme-bg-card);
+  color: $green;
+  border: 1.5px solid $green;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3rem 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover { background: rgba($green, 0.1); }
+}
+
+.btn-push-active {
+  background: rgba($green, 0.12);
+  color: $green;
+  border: 1.5px solid $green;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3rem 0.85rem;
+  cursor: pointer;
+
+  &:hover { background: rgba($red, 0.1); color: $red; border-color: $red; }
+}
+
+.btn-push-blocked {
+  background: var(--theme-bg-card);
+  color: var(--theme-text-muted);
+  border: 1.5px solid var(--theme-border);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3rem 0.85rem;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+
 // ── Bouton Secondaire ────────────────────────────────
 // Fond adaptatif (sombre en dark, clair en light), bordure verte, texte vert
 // Hover : légère surbrillance + bordure forte

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -207,6 +207,10 @@ class MatchesController < ApplicationController
       reminder_time = @match.build_datetime - 24.5.hours
       MatchReminderJob.set(wait_until: reminder_time).perform_later(@match.id) if reminder_time > Time.current
 
+      # Notifie en Web Push les utilisateurs dont le profil correspond à ce match
+      # (sport + niveau + localisation). Exécuté en arrière-plan via SolidQueue.
+      MatchWebPushJob.perform_later(@match.id)
+
       redirect_to @match, notice: "Match créé avec succès !"
     else
       @my_captained_teams = current_user.captained_teams.order(:name)

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -1,0 +1,37 @@
+# Gère l'enregistrement et la suppression des subscriptions Web Push.
+# Appelé par le Stimulus controller `push_notification_controller.js` côté navigateur.
+class PushSubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
+  # POST /push_subscriptions
+  # Reçoit une subscription JSON du navigateur et la persiste en base.
+  # Utilise find_or_create_by pour gérer les doublons (même endpoint = même appareil).
+  def create
+    subscription = current_user.push_subscriptions.find_or_initialize_by(
+      endpoint: subscription_params[:endpoint]
+    )
+    subscription.assign_attributes(
+      p256dh: subscription_params[:p256dh],
+      auth:   subscription_params[:auth]
+    )
+
+    if subscription.save
+      render json: { status: "ok" }, status: :ok
+    else
+      render json: { error: subscription.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /push_subscriptions
+  # Supprime la subscription correspondant à l'endpoint fourni (désabonnement).
+  def destroy
+    current_user.push_subscriptions.find_by(endpoint: params[:endpoint])&.destroy
+    head :no_content
+  end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(:endpoint, :p256dh, :auth)
+  end
+end

--- a/app/javascript/controllers/push_notification_controller.js
+++ b/app/javascript/controllers/push_notification_controller.js
@@ -1,0 +1,153 @@
+// Controller Stimulus — Gestion des notifications push navigateur (Web Push API)
+// Permet à l'utilisateur d'activer ou désactiver les notifications push depuis son profil.
+// La clé VAPID publique est passée via data-push-notification-vapid-key-value.
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "status"]
+  static values  = { vapidKey: String, subscribed: Boolean }
+
+  connect() {
+    // On vérifie si le navigateur supporte les notifications push
+    if (!("Notification" in window) || !("serviceWorker" in navigator) || !("PushManager" in window)) {
+      this.#setUnsupported()
+      return
+    }
+    // Initialisation immédiate depuis l'état serveur (évite le flash "Activer" au rechargement)
+    if (Notification.permission === "denied") {
+      this.#setBlocked()
+    } else if (this.subscribedValue) {
+      this.#setActive()
+    }
+    // Puis on affine avec l'état réel du navigateur (async)
+    this.#updateUI()
+  }
+
+  // Demande la permission et souscrit au service worker
+  async subscribe() {
+    const permission = await Notification.requestPermission()
+    if (permission !== "granted") {
+      this.#setBlocked()
+      return
+    }
+
+    try {
+      const registration = await navigator.serviceWorker.ready
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly:      true,
+        applicationServerKey: this.#urlBase64ToUint8Array(this.vapidKeyValue)
+      })
+
+      // Extrait les clés du subscription object
+      const key  = subscription.getKey("p256dh")
+      const auth = subscription.getKey("auth")
+
+      await fetch("/push_subscriptions", {
+        method:  "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token":  document.querySelector("meta[name='csrf-token']")?.content
+        },
+        body: JSON.stringify({
+          subscription: {
+            endpoint: subscription.endpoint,
+            p256dh:   key  ? btoa(String.fromCharCode(...new Uint8Array(key)))  : null,
+            auth:     auth ? btoa(String.fromCharCode(...new Uint8Array(auth))) : null
+          }
+        })
+      })
+
+      this.#setActive()
+    } catch (err) {
+      console.error("Erreur lors de la souscription push :", err)
+    }
+  }
+
+  // Désabonne l'utilisateur et supprime la subscription en base
+  async unsubscribe() {
+    try {
+      const registration  = await navigator.serviceWorker.ready
+      const subscription  = await registration.pushManager.getSubscription()
+      if (!subscription) return
+
+      await fetch("/push_subscriptions", {
+        method:  "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token":  document.querySelector("meta[name='csrf-token']")?.content
+        },
+        body: JSON.stringify({ endpoint: subscription.endpoint })
+      })
+
+      await subscription.unsubscribe()
+      this.#setInactive()
+    } catch (err) {
+      console.error("Erreur lors du désabonnement push :", err)
+    }
+  }
+
+  // ── Méthodes privées ────────────────────────────────────────────────────────
+
+  async #updateUI() {
+    if (Notification.permission === "denied") {
+      this.#setBlocked()
+      return
+    }
+
+    const registration  = await navigator.serviceWorker.ready
+    const subscription  = await registration.pushManager.getSubscription()
+
+    if (subscription) {
+      this.#setActive()
+    } else if (this.subscribedValue) {
+      // La DB indique une subscription active mais le navigateur n'en a plus
+      // (SW réinstallé, cache vidé...) → on re-souscrit silencieusement
+      await this.subscribe()
+    } else {
+      this.#setInactive()
+    }
+  }
+
+  #setActive() {
+    if (this.hasButtonTarget) {
+      this.buttonTarget.textContent    = "Notifications activées"
+      this.buttonTarget.dataset.action = "click->push-notification#unsubscribe"
+      this.buttonTarget.classList.add("btn-push-active")
+      this.buttonTarget.classList.remove("btn-push-inactive")
+    }
+    if (this.hasStatusTarget) this.statusTarget.textContent = "✓ Vous recevrez des alertes pour les matchs correspondant à votre profil."
+  }
+
+  #setInactive() {
+    if (this.hasButtonTarget) {
+      this.buttonTarget.textContent    = "Activer les notifications"
+      this.buttonTarget.dataset.action = "click->push-notification#subscribe"
+      this.buttonTarget.classList.add("btn-push-inactive")
+      this.buttonTarget.classList.remove("btn-push-active")
+    }
+    if (this.hasStatusTarget) this.statusTarget.textContent = ""
+  }
+
+  #setBlocked() {
+    if (this.hasButtonTarget) {
+      this.buttonTarget.textContent  = "Notifications bloquées"
+      this.buttonTarget.disabled     = true
+      this.buttonTarget.classList.add("btn-push-blocked")
+    }
+    if (this.hasStatusTarget) this.statusTarget.textContent = "Autorisez les notifications dans les paramètres de votre navigateur."
+  }
+
+  #setUnsupported() {
+    if (this.hasButtonTarget) {
+      this.buttonTarget.style.display = "none"
+    }
+  }
+
+  // Convertit la clé VAPID Base64url en Uint8Array pour l'API PushManager
+  #urlBase64ToUint8Array(base64String) {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4)
+    const base64  = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/")
+    const raw     = atob(base64)
+    return Uint8Array.from([...raw].map((char) => char.charCodeAt(0)))
+  }
+}

--- a/app/jobs/match_web_push_job.rb
+++ b/app/jobs/match_web_push_job.rb
@@ -1,0 +1,95 @@
+# Envoie des notifications Web Push aux utilisateurs dont le profil correspond
+# au match qui vient d'être créé (sport + niveau + localisation).
+# Déclenché depuis MatchesController#create via perform_later.
+class MatchWebPushJob < ApplicationJob
+  queue_as :default
+
+  # Une subscription expirée (navigateur réinitialisé, etc.) → on la supprime proprement
+  retry_on WebPush::ExpiredSubscription, attempts: 1 do |job, error|
+    PushSubscription.find_by(endpoint: job.arguments.first)&.destroy
+  end
+
+  # Erreur réseau ou serveur push → on réessaie avec backoff exponentiel
+  retry_on WebPush::Error, wait: :polynomially_longer, attempts: 3
+
+  # Le match a été supprimé entre la planification et l'exécution → on abandonne
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(match_id)
+    match = Match.find(match_id)
+
+    # On n'envoie des notifications que pour les matchs publics avec des places disponibles
+    return unless match.visibility == "public"
+    return unless match.player_left.nil? || match.player_left > 0
+
+    candidates = find_candidates(match)
+    return if candidates.empty?
+
+    candidates.find_each do |user|
+      user.push_subscriptions.each do |subscription|
+        send_push(subscription, match)
+      end
+    end
+  end
+
+  private
+
+  # Trouve les utilisateurs intéressés par ce match selon 3 critères :
+  # 1. Pratiquent ce sport
+  # 2. Ont le bon niveau pour ce sport
+  # 3. Ont la ville ou le lieu dans leurs préférences
+  def find_candidates(match)
+    return User.none unless match.sport_id.present?
+
+    # Base : users qui pratiquent ce sport
+    candidates = User.joins(profil: :sport_profils)
+                     .where(sport_profils: { sport_id: match.sport_id })
+
+    # Filtre par niveau si le match a un niveau spécifique
+    if match.level.present? && match.level != "Tout niveau"
+      candidates = candidates.where(sport_profils: { level: [match.level, "Tout niveau"] })
+    end
+
+    # Filtre par localisation : lieu favori en priorité, sinon ville préférée
+    candidates = if match.venue_id.present?
+      candidates.joins(profil: :profil_favorite_venues)
+                .where(profil_favorite_venues: { venue_id: match.venue_id })
+    elsif match.place.present?
+      candidates.joins(:profil)
+                .where("profils.preferred_city ILIKE ?", "%#{match.place}%")
+    else
+      User.none # Pas de localisation → on n'envoie pas de push (risque de spam)
+    end
+
+    # Exclure le créateur du match (inutile de se notifier soi-même)
+    candidates.where.not(id: match.user_id).distinct
+  end
+
+  # Envoie une notification push à une subscription donnée via la gem web-push
+  def send_push(subscription, match)
+    sport_name = match.sport&.name || "Sport"
+    city       = match.venue&.city || match.place || "votre ville"
+    level_text = match.level.present? ? " — Niveau #{match.level}" : ""
+
+    payload = JSON.generate(
+      title: "Nouveau match de #{sport_name}",
+      body:  "Un match à #{city} vous correspond#{level_text}",
+      url:   Rails.application.routes.url_helpers.match_path(match)
+    )
+
+    WebPush.payload_send(
+      message:     payload,
+      endpoint:    subscription.endpoint,
+      p256dh:      subscription.p256dh,
+      auth:        subscription.auth,
+      vapid: {
+        subject:     "mailto:contact@teams-up-sport.fr",
+        public_key:  ENV.fetch("VAPID_PUBLIC_KEY"),
+        private_key: ENV.fetch("VAPID_PRIVATE_KEY")
+      }
+    )
+  rescue WebPush::ExpiredSubscription
+    # Subscription invalide → on la supprime pour ne plus gaspiller de requêtes
+    subscription.destroy
+  end
+end

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -1,0 +1,10 @@
+# Stocke les subscriptions Web Push d'un utilisateur.
+# Un user peut avoir plusieurs subscriptions (plusieurs appareils/navigateurs).
+# Chaque subscription est identifiée par son endpoint unique fourni par le navigateur.
+class PushSubscription < ApplicationRecord
+  belongs_to :user
+
+  validates :endpoint, presence: true, uniqueness: { scope: :user_id }
+  validates :p256dh,   presence: true
+  validates :auth,     presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,8 @@ class User < ApplicationRecord
   has_many :match_users, dependent: :destroy
   has_many :matchs, through: :match_users
   has_many :notifications, dependent: :destroy
+  # Subscriptions Web Push : un user peut avoir plusieurs appareils/navigateurs enregistrés
+  has_many :push_subscriptions, dependent: :destroy
   # Relation vers les achievements débloqués par cet utilisateur
   has_many :user_achievements, dependent: :destroy
   has_many :achievements, through: :user_achievements

--- a/app/views/profils/_profil_teams.html.erb
+++ b/app/views/profils/_profil_teams.html.erb
@@ -15,7 +15,7 @@
   <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
               text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.75rem;">
     <i data-lucide="shield" style="width:14px; height:14px;"></i>
-    <%= teams_title %> (<%= @profil_teams.size %>)
+    <%= teams_title %> (<%= @profil_teams.length %>)
   </div>
 
   <div class="match-block" style="padding:1rem;">

--- a/app/views/profils/show.html.erb
+++ b/app/views/profils/show.html.erb
@@ -342,6 +342,33 @@
                      friendship_initiated_by_me: @friendship_initiated_by_me %>
         </div>
 
+        <%# ── Notifications push — visible uniquement sur son propre profil ─── %>
+        <% if current_user == @profil_user %>
+          <div class="match-block" style="margin-top:1rem; padding:1rem 1.25rem;"
+               data-controller="push-notification"
+               data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>">
+            <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
+              <div>
+                <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
+                            text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.25rem;">
+                  <i data-lucide="bell" style="width:14px; height:14px;"></i>
+                  Alertes matchs
+                </div>
+                <p style="font-size:0.75rem; color:var(--theme-text-muted); margin:0;"
+                   data-push-notification-target="status">
+                  Recevez une alerte dès qu'un match correspond à votre profil.
+                </p>
+              </div>
+              <button class="btn btn-sm btn-push-inactive"
+                      data-push-notification-target="button"
+                      data-action="click->push-notification#subscribe"
+                      style="white-space:nowrap; flex-shrink:0;">
+                Activer les notifications
+              </button>
+            </div>
+          </div>
+        <% end %>
+
       </div><%# / col-lg-5 %>
 
 

--- a/app/views/profils/show_simple.html.erb
+++ b/app/views/profils/show_simple.html.erb
@@ -43,6 +43,32 @@
                    pending_received: @pending_received,
                    friendship_initiated_by_me: @friendship_initiated_by_me %>
 
+        <%# ── Notifications push ─────────────────────────────────────────────── %>
+        <div class="match-block" style="margin-top:1rem; padding:1rem 1.25rem;"
+             data-controller="push-notification"
+             data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>"
+             data-push-notification-subscribed-value="<%= current_user.push_subscriptions.any? %>">
+          <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
+            <div>
+              <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
+                          text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.25rem;">
+                <i data-lucide="bell" style="width:14px; height:14px;"></i>
+                Alertes matchs
+              </div>
+              <p style="font-size:0.75rem; color:var(--theme-text-muted); margin:0;"
+                 data-push-notification-target="status">
+                Recevez une alerte dès qu'un match correspond à votre profil.
+              </p>
+            </div>
+            <button class="btn btn-sm btn-push-inactive"
+                    data-push-notification-target="button"
+                    data-action="click->push-notification#subscribe"
+                    style="white-space:nowrap; flex-shrink:0;">
+              Activer les notifications
+            </button>
+          </div>
+        </div>
+
       </div>
       <%# / col-lg-4 %>
 

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -78,6 +78,13 @@ self.addEventListener("fetch", (event) => {
     return; // le navigateur gère la requête normalement
   }
 
+  // ── CAS 2b : Requêtes push_subscriptions (JSON) ──────────────────────────
+  // On ignore les requêtes vers notre endpoint de souscription — elles passent
+  // toujours en réseau (create/destroy subscription).
+  if (url.pathname.startsWith("/push_subscriptions")) {
+    return;
+  }
+
   // ── CAS 3 : Assets statiques (JS, CSS, fonts, images de l'app) ───────────
   // Network First : on essaie le réseau, on met en cache si succès.
   // En cas d'échec réseau → on utilise le cache (mode offline).
@@ -100,5 +107,40 @@ self.addEventListener("fetch", (event) => {
         const cached = await caches.match(event.request);
         return cached || Response.error();
       })
+  );
+});
+
+// ── Événement "push" ─────────────────────────────────────────────────────────
+// Déclenché quand le serveur envoie une notification Web Push.
+// Affiche la notification système même si l'app est en arrière-plan ou fermée.
+self.addEventListener("push", (event) => {
+  const data = event.data?.json() ?? {};
+  event.waitUntil(
+    self.registration.showNotification(data.title ?? "Teams-up", {
+      body:  data.body  ?? "Un nouveau match vous correspond !",
+      icon:  "/icon-192.png",
+      badge: "/icon-192.png",
+      data:  { url: data.url ?? "/matchs" }
+    })
+  );
+});
+
+// ── Événement "notificationclick" ────────────────────────────────────────────
+// Clic sur la notification → ferme la notification et ouvre la page du match.
+self.addEventListener("notificationclick", (event) => {
+  const path = event.notification.data?.url || "/matchs";
+  const url  = path.startsWith("http") ? path : self.location.origin + path;
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((clientList) => {
+      // Si un onglet Teams-up est déjà ouvert → on le focus et on navigue dedans
+      const existing = clientList.find((c) => c.url.startsWith(self.location.origin));
+      if (existing) {
+        existing.focus();
+        return existing.navigate(url);
+      }
+      // Sinon → nouvel onglet
+      return clients.openWindow(url);
+    })
   );
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,12 @@ Rails.application.routes.draw do
   # Page Plan du site — RGAA 12.1 (deuxième système de navigation)
   get "sitemap", to: "pages#sitemap", as: :sitemap
 
+  # ── Web Push Subscriptions ─────────────────────────────────────────────────
+  # POST   /push_subscriptions → enregistre une subscription navigateur
+  # DELETE /push_subscriptions → supprime la subscription (endpoint dans le body)
+  post   "push_subscriptions",        to: "push_subscriptions#create",  as: :push_subscriptions
+  delete "push_subscriptions",        to: "push_subscriptions#destroy"
+
   # ── Équipes ────────────────────────────────────────────────────────────────
   # GET    /equipes              → mes équipes
   # GET    /equipes/new          → formulaire création

--- a/db/migrate/20260423064149_create_push_subscriptions.rb
+++ b/db/migrate/20260423064149_create_push_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreatePushSubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :push_subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :endpoint, null: false  # URL unique fournie par le navigateur
+      t.string :p256dh,   null: false  # Clé publique chiffrée du navigateur
+      t.string :auth,     null: false  # Secret d'authentification du navigateur
+      t.timestamps
+    end
+
+    # Un user ne peut pas avoir deux fois le même endpoint (même appareil)
+    add_index :push_subscriptions, [:user_id, :endpoint], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_104616) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_064149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -251,6 +251,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_104616) do
     t.index ["user_id"], name: "index_profils_on_user_id"
   end
 
+  create_table "push_subscriptions", force: :cascade do |t|
+    t.string "auth", null: false
+    t.datetime "created_at", null: false
+    t.string "endpoint", null: false
+    t.string "p256dh", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "endpoint"], name: "index_push_subscriptions_on_user_id_and_endpoint", unique: true
+    t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
+  end
+
   create_table "security_logs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.jsonb "details", default: {}
@@ -409,6 +420,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_104616) do
   add_foreign_key "profil_favorite_venues", "profils"
   add_foreign_key "profil_favorite_venues", "venues"
   add_foreign_key "profils", "users"
+  add_foreign_key "push_subscriptions", "users"
   add_foreign_key "security_logs", "users", on_delete: :nullify
   add_foreign_key "sport_profils", "profils"
   add_foreign_key "sport_profils", "sports"


### PR DESCRIPTION
 Web Push Notifications — Alertes matchs personnalisées

  Mise en place d'un système de notifications push navigateur (PWA) qui alerte les utilisateurs dès qu'un nouveau match
  correspond à leur profil.

  Fonctionnement
  - Quand un match est créé, un job SolidQueue (MatchWebPushJob) cherche les utilisateurs dont le sport, le niveau et la
   localisation (ville préférée ou lieu favori) correspondent
  - Une notification push est envoyée à chaque appareil enregistré de ces utilisateurs
  - Le clic sur la notification ouvre directement la page du match (onglet existant ou nouvel onglet)

  Ce qui a été ajouté
  - Gem web-push + clés VAPID pour l'authentification des notifications
  - Table push_subscriptions pour stocker les subscriptions par utilisateur et par appareil
  - Endpoint POST/DELETE /push_subscriptions pour s'abonner/désabonner
  - Stimulus controller push_notification_controller.js avec gestion des 3 états (inactif, actif, bloqué) +
  re-souscription automatique si le SW se réinstalle
  - Bouton "Alertes matchs" sur la page profil (/profil)
  - Service Worker enrichi avec les événements push et notificationclick
  - Correction du bug Équipes ({5=>2, 6=>1}) dans _profil_teams.html.erb

  Testé sur
  - Chrome desktop (localhost)
  - Chrome mobile (via ngrok)