### PR TITLE
destroy all messages : confirmation

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -67,3 +67,17 @@ document.addEventListener("turbo:load", rerenderHcaptchaWidgets)
 // turbo:load ne se déclenche PAS dans ce cas, c'est pour ça que le widget
 // disparaissait après une erreur et ne réapparaissait qu'au rechargement complet.
 document.addEventListener("turbo:render", rerenderHcaptchaWidgets)
+
+// ── Dispose toutes les modales Bootstrap avant que Turbo remplace le body ──────
+//
+// Problème : Bootstrap garde un flag interne _isAppended=true. Si le body est
+// remplacé par Turbo sans dispose(), le backdrop ne se ré-insère plus lors de la
+// prochaine ouverture de modale.
+//
+// Solution : Dispose toutes les modales actives avant turbo:before-render
+document.addEventListener("turbo:before-render", () => {
+  document.querySelectorAll(".modal").forEach(el => {
+    const instance = bootstrap.Modal.getInstance(el)
+    if (instance) instance.dispose()
+  })
+})

--- a/app/views/admin/contact_messages/_contact_message.html.erb
+++ b/app/views/admin/contact_messages/_contact_message.html.erb
@@ -83,15 +83,15 @@
         <% end %>
       <% end %>
 
-      <%# Bouton supprimer — même hauteur/largeur que les autres %>
-      <%= button_to admin_contact_message_path(msg),
-                    method: :delete,
-                    class: "btn btn-sm",
-                    style: "width:32px; height:32px; font-size:0.75rem; display:inline-flex; align-items:center; justify-content:center; background:rgba(220,53,69,0.12); color:#ff6b6b; border:1px solid rgba(220,53,69,0.3);",
-                    title: "Supprimer",
-                    data: { turbo_confirm: "Supprimer ce message définitivement ?" } do %>
+      <%# Bouton supprimer — ouvre la modale de confirmation %>
+      <button type="button"
+              class="btn btn-sm"
+              style="width:32px; height:32px; font-size:0.75rem; display:inline-flex; align-items:center; justify-content:center; background:rgba(220,53,69,0.12); color:#ff6b6b; border:1px solid rgba(220,53,69,0.3);"
+              title="Supprimer"
+              data-bs-toggle="modal"
+              data-bs-target="#deleteModal-<%= msg.id %>">
         <i data-lucide="trash-2" style="width:12px; height:12px;"></i>
-      <% end %>
+      </button>
 
     </div>
   </td>

--- a/app/views/admin/contact_messages/_contact_message_modal.html.erb
+++ b/app/views/admin/contact_messages/_contact_message_modal.html.erb
@@ -87,3 +87,43 @@
     </div>
   </div>
 </div>
+
+<%# Modale de confirmation — suppression du message de contact %>
+<div class="modal fade" id="deleteModal-<%= msg.id %>" tabindex="-1"
+     aria-labelledby="deleteModalLabel-<%= msg.id %>" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="background:#1a1c1a; border:1px solid rgba(220,53,69,0.3); color:#f0f0f0;">
+
+      <div class="modal-header" style="border-bottom:1px solid rgba(255,255,255,0.07);">
+        <div class="d-flex align-items-center gap-2">
+          <i data-lucide="triangle-alert" style="width:18px; height:18px; color:#ff6b6b;"></i>
+          <h5 class="modal-title" id="deleteModalLabel-<%= msg.id %>"
+              style="font-size:1rem; font-weight:700; color:#ff6b6b; margin:0;">
+            Supprimer ce message
+          </h5>
+        </div>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+      </div>
+
+      <div class="modal-body" style="font-size:0.875rem; color:rgba(255,255,255,0.75);">
+        <p>Êtes-vous sûr de vouloir supprimer ce message de <strong style="color:#f0f0f0;"><%= msg.prenom %> <%= msg.nom %></strong> ?</p>
+        <p class="mb-0" style="color:#ff6b6b;">
+          <i data-lucide="circle-x" style="width:13px; height:13px; margin-right:4px; vertical-align:-2px;"></i>
+          Cette action est irréversible et ne peut pas être annulée.
+        </p>
+      </div>
+
+      <div class="modal-footer" style="border-top:1px solid rgba(255,255,255,0.07);">
+        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Annuler</button>
+        <%= button_to admin_contact_message_path(msg),
+                      method: :delete,
+                      class: "btn btn-sm",
+                      style: "background:#dc3545; color:#fff; border:none;" do %>
+          <i data-lucide="trash-2" style="width:12px; height:12px; margin-right:4px;"></i>
+          Confirmer la suppression
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/admin/contact_messages/index.html.erb
+++ b/app/views/admin/contact_messages/index.html.erb
@@ -35,14 +35,14 @@
     <%# Bouton "Tout supprimer" — padding rétabli autour de ce bouton %>
     <% if @contact_messages.any? %>
       <div class="d-flex justify-content-end" style="padding: 1.25rem 1.35rem 0.75rem;">
-        <%= button_to destroy_all_admin_contact_messages_path,
-                      method: :delete,
-                      class: "btn btn-sm",
-                      style: "font-size:0.75rem; background:rgba(220,53,69,0.12); color:#ff6b6b; border:1px solid rgba(220,53,69,0.3);",
-                      data: { turbo_confirm: "Supprimer tous les messages définitivement ? Cette action est irréversible." } do %>
+        <button type="button"
+                class="btn btn-sm"
+                style="font-size:0.75rem; background:rgba(220,53,69,0.12); color:#ff6b6b; border:1px solid rgba(220,53,69,0.3);"
+                data-bs-toggle="modal"
+                data-bs-target="#destroyAllContactMessagesModal">
           <i data-lucide="trash-2" style="width:12px; height:12px; margin-right:4px;"></i>
           Tout supprimer
-        <% end %>
+        </button>
       </div>
     <% end %>
 
@@ -97,4 +97,44 @@
   <% @contact_messages.each do |msg| %>
     <%= render "admin/contact_messages/contact_message_modal", msg: msg %>
   <% end %>
+
+  <%# Modale de confirmation — suppression de tous les messages de contact %>
+  <div class="modal fade" id="destroyAllContactMessagesModal" tabindex="-1"
+       aria-labelledby="destroyAllContactMessagesModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content" style="background:#1a1c1a; border:1px solid rgba(220,53,69,0.3); color:#f0f0f0;">
+
+        <div class="modal-header" style="border-bottom:1px solid rgba(255,255,255,0.07);">
+          <div class="d-flex align-items-center gap-2">
+            <i data-lucide="triangle-alert" style="width:18px; height:18px; color:#ff6b6b;"></i>
+            <h5 class="modal-title" id="destroyAllContactMessagesModalLabel"
+                style="font-size:1rem; font-weight:700; color:#ff6b6b; margin:0;">
+              Supprimer tous les messages
+            </h5>
+          </div>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+        </div>
+
+        <div class="modal-body" style="font-size:0.875rem; color:rgba(255,255,255,0.75);">
+          <p>Cette action va supprimer <strong style="color:#f0f0f0;"><%= @contact_messages.count %> message(s)</strong> de contact définitivement.</p>
+          <p class="mb-0" style="color:#ff6b6b;">
+            <i data-lucide="circle-x" style="width:13px; height:13px; margin-right:4px; vertical-align:-2px;"></i>
+            Cette action est irréversible et ne peut pas être annulée.
+          </p>
+        </div>
+
+        <div class="modal-footer" style="border-top:1px solid rgba(255,255,255,0.07);">
+          <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Annuler</button>
+          <%= button_to destroy_all_admin_contact_messages_path,
+                        method: :delete,
+                        class: "btn btn-sm",
+                        style: "background:#dc3545; color:#fff; border:none;" do %>
+            <i data-lucide="trash-2" style="width:12px; height:12px; margin-right:4px;"></i>
+            Confirmer la suppression
+          <% end %>
+        </div>
+
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Remplacer les dialogs natifs du navigateur (window.confirm()) par des modales Bootstrap cohérentes avec le design system dark de l'app pour les suppressions dans /admin/contact_messages.
:white_check_mark: Modifications appliquées

1. Bouton "Tout supprimer" tous les messages

Fichier : app/views/admin/contact_messages/index.html.erb
- ✓ Remplacé button_to avec data-turbo-confirm par un <button> avec data-bs-toggle="modal"
- ✓ Ajouté modale Bootstrap dark avec :- Titre rouge "Supprimer tous les messages"
- Affichage du nombre exact de messages à supprimer
- Avertissement "irréversible"
- Boutons "Annuler" et "Confirmer la suppression"

2. Bouton supprimer un message individuel
Fichier : app/views/admin/contact_messages/_contact_message.html.erb
- ✓ Remplacé button_to avec data-turbo-confirm par un <button> avec data-bs-toggle="modal"

Fichier : app/views/admin/contact_messages/_contact_message_modal.html.erb

- ✓ Ajouté modale de confirmation pour chaque message avec :
- Titre rouge "Supprimer ce message"
- Affichage du nom du destinataire
- Avertissement "irréversible
- Boutons "Annuler" et "Confirmer la suppression"

3. Dispose global des modales Bootstrap
Fichier : app/javascript/application.js
- ✓ Ajouté listener turbo:before-render qui dispose() toutes les modales ouvertes
- ✓ Évite le bug où le backdrop Bootstrap ne se ré-insère pas après navigation Turbo

:closed_lock_with_key: Accès Admin
- ✓ Utilisateur anatole24@gmail.com promu admin via console Rails
- ✓ Un message de test créé pour tester les fonctionnalités