### PR TITLE
addtomodale

### DIFF
--- a/app/assets/stylesheets/components/_onboarding.scss
+++ b/app/assets/stylesheets/components/_onboarding.scss
@@ -66,6 +66,60 @@
   }
 }
 
+// Bloc "Activer les notifications" dans la modale d'onboarding
+// Séparé visuellement des bénéfices profil par une bordure top
+.onboarding-push-block {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--theme-border);
+
+  &__info {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.65rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  // Cercle vert autour de l'icône cloche — cohérent avec .onboarding-modal-icon
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    background: rgba(30, 221, 136, 0.1);
+    border: 1px solid rgba(30, 221, 136, 0.25);
+    border-radius: 50%;
+  }
+
+  &__title {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--theme-text-strong);
+    margin-bottom: 0.1rem;
+  }
+
+  // Phrase d'accroche — urgence et bénéfice, mise en avant avec la couleur primaire
+  &__hook {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: $green;
+    margin-bottom: 0.15rem;
+  }
+
+  &__desc {
+    font-size: 0.775rem;
+    color: var(--theme-text-muted);
+    line-height: 1.4;
+  }
+}
+
 .onboarding-modal-footer {
   padding: 0 2rem 1.75rem;
 }
@@ -143,6 +197,29 @@
     color: #1EDD88;
     text-decoration: none;
   }
+
+  // Variante bouton (pas un lien) pour le déclencheur push — annule les styles Bootstrap btn
+  &--notif {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: transparent;
+    cursor: pointer;
+
+    // Quand les notifs sont activées, on efface le bouton : l'user n'a rien à faire de plus
+    &.btn-push-active {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    // Quand les notifs sont bloquées, on indique l'impossibilité sans casser le layout
+    &.btn-push-blocked {
+      color: var(--theme-text-muted);
+      border-color: var(--theme-border);
+      opacity: 0.7;
+      pointer-events: none;
+    }
+  }
 }
 
 .profile-reminder-banner__close {
@@ -178,5 +255,15 @@
 
   .profile-reminder-banner__content {
     font-size: 0.8rem;
+  }
+
+  // Sur mobile, le bloc notif passe en colonne pour éviter l'écrasement du bouton
+  .onboarding-push-block {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .btn {
+      align-self: flex-end;
+    }
   }
 }

--- a/app/javascript/controllers/push_notification_controller.js
+++ b/app/javascript/controllers/push_notification_controller.js
@@ -115,7 +115,7 @@ export default class extends Controller {
       this.buttonTarget.classList.add("btn-push-active")
       this.buttonTarget.classList.remove("btn-push-inactive")
     }
-    if (this.hasStatusTarget) this.statusTarget.textContent = "✓ Vous recevrez des alertes pour les matchs correspondant à votre profil."
+    if (this.hasStatusTarget) this.statusTarget.textContent = "✓ Tu recevras des alertes pour les matchs correspondant à ton profil."
   }
 
   #setInactive() {
@@ -134,7 +134,7 @@ export default class extends Controller {
       this.buttonTarget.disabled     = true
       this.buttonTarget.classList.add("btn-push-blocked")
     }
-    if (this.hasStatusTarget) this.statusTarget.textContent = "Autorisez les notifications dans les paramètres de votre navigateur."
+    if (this.hasStatusTarget) this.statusTarget.textContent = "Autorise les notifications dans les paramètres de ton navigateur."
   }
 
   #setUnsupported() {

--- a/app/views/shared/_onboarding_modal.html.erb
+++ b/app/views/shared/_onboarding_modal.html.erb
@@ -44,6 +44,41 @@
             <span>Tes <strong>salles et terrains favoris</strong> en priorité</span>
           </li>
         </ul>
+
+        <%# ── Bloc activation notifications push ─────────────────────────────────
+            Le controller Stimulus push-notification gère l'état du bouton en temps
+            réel : inactif → permission OS → actif (ou bloqué si l'user refuse).
+            La clé VAPID publique est injectée via data attribute côté serveur. %>
+        <div class="onboarding-push-block"
+             data-controller="push-notification"
+             data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>">
+
+          <div class="onboarding-push-block__info">
+            <%# Icône + texte explicatif %>
+            <div class="onboarding-push-block__icon">
+              <i data-lucide="bell" style="width:16px;height:16px;color:#1EDD88;"></i>
+            </div>
+            <div>
+              <div class="onboarding-push-block__title">Ne rate plus aucun match !</div>
+              <%# Accroche : urgence + bénéfice avant le texte technique %>
+              <div class="onboarding-push-block__hook">
+                Active les notifications et sois le premier averti !
+              </div>
+              <%# Cette zone est mise à jour dynamiquement par #setActive / #setBlocked %>
+              <div class="onboarding-push-block__desc" data-push-notification-target="status">
+                Une alerte instantanée dès qu'un match correspond à ton sport, ton niveau et ta ville.
+              </div>
+            </div>
+          </div>
+
+          <%# Bouton géré entièrement par push_notification_controller.js %>
+          <button class="btn btn-sm btn-push-inactive"
+                  data-push-notification-target="button"
+                  data-action="click->push-notification#subscribe">
+            Activer
+          </button>
+
+        </div>
       </div>
 
       <%# ── Pied : deux actions ──────────────────────────────────────────────── %>

--- a/app/views/shared/_profile_reminder_banner.html.erb
+++ b/app/views/shared/_profile_reminder_banner.html.erb
@@ -8,20 +8,33 @@
 <div id="profile-reminder-banner" class="profile-reminder-banner">
   <div class="profile-reminder-banner__inner">
 
-    <%# Icône + message %>
+    <%# Icône + message — mentionne profil ET notifications pour maximiser l'action %>
     <div class="profile-reminder-banner__content">
       <i data-lucide="settings" style="width:18px;height:18px;color:#1EDD88;flex-shrink:0;"></i>
       <span>
-        <strong>Améliore tes suggestions de matchs !</strong>
-        Ajoute ta ville et tes lieux favoris pour trouver des matchs près de chez toi.
+        <strong>Ne rate plus aucun match !</strong>
+        Complète ton profil et active les alertes pour être le premier averti près de chez toi.
       </span>
     </div>
 
-    <%# Actions %>
+    <%# Actions : deux CTAs + fermeture %>
     <div class="profile-reminder-banner__actions">
+
       <%= link_to "Compléter mon profil",
                   edit_profil_path,
                   class: "profile-reminder-banner__cta" %>
+
+      <%# Bouton d'activation des notifications push — géré par push_notification_controller.js.
+          Compact et autonome : l'OS demande la permission au clic, le texte se met à jour. %>
+      <div data-controller="push-notification"
+           data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>">
+        <button class="profile-reminder-banner__cta profile-reminder-banner__cta--notif btn-push-inactive"
+                data-push-notification-target="button"
+                data-action="click->push-notification#subscribe">
+          <i data-lucide="bell" style="width:13px;height:13px;"></i>
+          Activer les alertes
+        </button>
+      </div>
 
       <%# Bouton de fermeture — DELETE /profil/dismiss_reminder via Turbo %>
       <%= button_to dismiss_reminder_profil_path,
@@ -31,6 +44,7 @@
                     data: { turbo_stream: true } do %>
         <i data-lucide="x" style="width:16px;height:16px;"></i>
       <% end %>
+
     </div>
 
   </div>


### PR DESCRIPTION
Récap PR — Activation des notifications dans les points d'entrée post-inscription

  Contexte

  Les notifications web push sont essentielles pour alerter les users dès qu'un match correspond à leur profil.
  Jusqu'ici, le bouton d'activation était uniquement visible sur la page profil — peu de trafic, donc peu d'activations.

  Objectif

  Exposer l'activation des notifications aux deux moments clés où l'user est le plus réceptif : juste après
  l'inscription et lors du rappel de complétion de profil.

  ---
  Fichiers modifiés (4)

  app/views/shared/_onboarding_modal.html.erb
  Ajout d'un bloc "Alertes matchs" dans le body de la modale post-inscription. Il embarque directement le controller
  Stimulus push-notification : l'OS demande la permission au clic, sans quitter la modale. L'user peut activer ses
  alertes avant même de compléter son profil.

  app/views/shared/_profile_reminder_banner.html.erb
  Ajout d'un bouton "Activer les alertes" (avec icône cloche) dans le bandeau de rappel affiché 7 jours après
  l'inscription. Le message a aussi été revu pour mentionner les deux actions : compléter le profil et activer les
  alertes.

  app/assets/stylesheets/components/_onboarding.scss
  Nouveaux styles BEM pour .onboarding-push-block (layout, icône en cercle vert, accroche verte, responsive mobile).
  Variante .profile-reminder-banner__cta--notif pour le bouton push dans le bandeau, avec gestion des états
  actif/bloqué.

  app/javascript/controllers/push_notification_controller.js
  Uniformisation du tutoiement dans les messages d'état : "Tu recevras…" et "Autorise les notifications dans les
  paramètres de ton navigateur."

  ---
  Wording clé

  - Modale : "Ne rate plus aucun match !" / "Active les notifications et sois le premier averti !"
  - Bandeau : "Ne rate plus aucun match ! Complète ton profil et active les alertes pour être le premier averti près de
  chez toi."