### PR TITLE
mise en place de Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,10 @@ gem "valid_email2" # Validation format + existence MX record des emails
 gem "csv"
 gem "web-push" # Envoi de notifications push navigateur (PWA) via protocole Web Push + VAPID
 
+# Monitoring des erreurs en production — capture exceptions Rails, jobs SolidQueue et JS front
+gem "sentry-ruby"
+gem "sentry-rails"
+
 # SEO — gestion centralisée des balises <title>, <meta description>, OpenGraph, Twitter Card
 gem "meta-tags"
 # SEO — génération automatique du sitemap.xml pour les moteurs de recherche

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (6.5.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.5.0)
+    sentry-ruby (6.5.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     sitemap_generator (6.3.0)
       builder (~> 3.0)
     snaky_hash (2.0.3)
@@ -584,6 +591,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   sassc-rails
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   simple_form!
   sitemap_generator
   solid_cable
@@ -768,6 +777,8 @@ CHECKSUMS
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
+  sentry-rails (6.5.0) sha256=ebf9d4d82c740c3e0e4a0840f11f7bbd0cf648a30afd9c67e5b50bb07018a0e4
+  sentry-ruby (6.5.0) sha256=3c57ae0d6a017aafcd9ac37114e38149a58534679dec5d4e9e8fc010b85f3a6b
   simple_form (5.4.1)
   sitemap_generator (6.3.0) sha256=1d803cbf03c44736bea05b9e3363d3523fec4e24f3abedad294d9c57cab994f3
   snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,24 @@ import "controllers"
 import "@popperjs/core"
 import * as bootstrap from "bootstrap"
 
+// ── Sentry Browser SDK — monitoring des erreurs JavaScript ───────────────────
+//
+// On lit le DSN depuis le meta tag injecté côté serveur (layout application.html.erb).
+// Cela évite d'écrire le DSN en dur dans le JS et reste compatible avec le CSP.
+// Sentry ne s'initialise que si le DSN est présent (= absent en dev/test).
+import * as Sentry from "@sentry/browser"
+
+const sentryDsn = document.querySelector("meta[name='sentry-dsn']")?.content
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    // browserTracingIntegration surveille les navigations Turbo et les requêtes fetch
+    integrations: [Sentry.browserTracingIntegration()],
+    // Echantillonne 20 % des transactions front (navigation, XHR) pour le perf monitoring
+    tracesSampleRate: 0.2,
+  })
+}
+
 // Ré-initialise les icônes Lucide après chaque mise à jour d'un turbo_frame ou turbo:render
 // (ex: le bouton ami se met à jour en live → les nouveaux <i data-lucide="..."> doivent être convertis en SVG)
 // RGAA 4.8 — masquer tous les SVG Lucide des lecteurs d'écran avec aria-hidden=true

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,13 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%# Sentry DSN passé au JS via meta tag — évite de l'écrire en dur dans le bundle.
+        Le SDK JS lit ce tag au démarrage et ne s'initialise que si le DSN est présent
+        (vide en dev/test, renseigné en production via variable d'environnement). %>
+    <% if ENV["SENTRY_DSN"].present? %>
+      <meta name="sentry-dsn" content="<%= ENV["SENTRY_DSN"] %>">
+    <% end %>
+
     <%= yield :head %>
 
     <%# ── PWA : manifeste + couleur de thème ──────────────────────────────── %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,7 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true
 pin "@rails/actioncable", to: "actioncable.esm.js"
+
+# Sentry Browser SDK — monitoring des erreurs JavaScript en production
+# Chargé via CDN jsDelivr (format ESM, compatible importmap-rails)
+pin "@sentry/browser", to: "https://cdn.jsdelivr.net/npm/@sentry/browser@8/+esm"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,8 +19,10 @@ Rails.application.configure do
     # Scripts : notre serveur + scripts inline (Stimulus/Turbo en ont besoin)
     # + unpkg.com pour la librairie d'icônes Lucide utilisée dans les vues
     # + hcaptcha.com et newassets.hcaptcha.com pour le widget captcha
+    # + cdn.jsdelivr.net pour le SDK Sentry Browser (chargé via importmap)
     policy.script_src :self, :unsafe_inline, "https://unpkg.com",
-                      "https://hcaptcha.com", "https://newassets.hcaptcha.com"
+                      "https://hcaptcha.com", "https://newassets.hcaptcha.com",
+                      "https://cdn.jsdelivr.net"
 
     # Styles : notre serveur + styles inline (Bootstrap en a besoin)
     # + Google Fonts pour charger les polices Nunito et Bebas Neue
@@ -45,9 +47,11 @@ Rails.application.configure do
     policy.connect_src :self,
                        "https://accounts.google.com",
                        "https://oauth2.googleapis.com",
-                       "https://unpkg.com",                   # source maps de Lucide (icônes)
-                       "https://nominatim.openstreetmap.org", # recherche de lieux (création de match)
-                       "https://hcaptcha.com"                 # vérification captcha
+                       "https://unpkg.com",                        # source maps de Lucide (icônes)
+                       "https://nominatim.openstreetmap.org",      # recherche de lieux (création de match)
+                       "https://hcaptcha.com",                     # vérification captcha
+                       "https://*.ingest.de.sentry.io",            # envoi des erreurs JS à Sentry (région EU)
+                       "https://cdn.jsdelivr.net"                  # chargement du SDK Sentry via importmap
 
     # Frames : Google OAuth + Google Maps (carte intégrée dans les pages de match)
     # + newassets.hcaptcha.com pour le challenge hcaptcha (affiché dans une iframe)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,30 @@
+# Initialise Sentry pour le monitoring des erreurs en production.
+# Le SDK capture automatiquement :
+#   - Les exceptions Rails (controllers, models, vues)
+#   - Les jobs ActiveJob / SolidQueue qui échouent
+#   - Les transactions HTTP (performance monitoring)
+#
+# RGPD : send_default_pii = false → aucune IP, cookie ou email n'est envoyé à Sentry.
+Sentry.init do |config|
+  # DSN fourni par sentry.io lors de la création du projet.
+  # À définir dans les variables d'environnement Railway/Heroku (jamais en dur ici).
+  config.dsn = ENV["SENTRY_DSN"]
+
+  # Active les breadcrumbs (fil d'Ariane) pour reproduire le chemin avant l'erreur.
+  # :active_support_logger → capture les logs Rails (requêtes SQL, callbacks, mailers)
+  # :http_logger → capture les appels HTTP sortants (ex: Cloudinary, SendGrid)
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  # Sentry ne s'active qu'en production et staging — jamais en développement ou test.
+  # Évite de polluer le projet Sentry avec des erreurs locales.
+  config.enabled_environments = %w[production staging]
+
+  # Performance monitoring : échantillonne 20 % des transactions HTTP.
+  # Permet d'identifier les endpoints lents sans surcharger le quota Sentry.
+  config.traces_sample_rate = 0.2
+
+  # RGPD : ne pas envoyer de données personnelles identifiables (IP, cookies, user agent).
+  # Si tu veux associer les erreurs à un utilisateur spécifique, active Sentry::Rails
+  # et configure set_user_context dans ApplicationController.
+  config.send_default_pii = false
+end


### PR DESCRIPTION
Intégration Sentry — monitoring des erreurs en production

  Contexte

  Sans monitoring, les erreurs en production sont invisibles jusqu'à ce qu'un utilisateur se plaigne. Cette PR configure
   Sentry (plan gratuit) pour capturer automatiquement toutes les exceptions dès le lancement.

  Ce qui est couvert

  - Exceptions Rails — controllers, models, mailers
  - Jobs SolidQueue — les jobs qui échouent silencieusement sont désormais visibles
  - Erreurs JavaScript — Turbo, Stimulus, Bootstrap (SDK Browser)
  - Performance — 20 % des transactions échantillonnées (traces HTTP)

  Notes

  - Sentry est désactivé en dev/test — ne pollue pas le dashboard avec des erreurs locales
  - send_default_pii = false — aucune IP ni donnée personnelle envoyée (RGPD)
  - .env.example créé avec toutes les variables nécessaires