### PR TITLE
og:image

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,13 +103,17 @@ class ApplicationController < ActionController::Base
         # :title et :description font référence aux valeurs définies ci-dessus
         title:       :title,
         description: :description,
-        url:         -> { request.original_url }
+        url:         -> { request.original_url },
+        # Image affichée lors du partage sur Facebook, WhatsApp, LinkedIn, etc.
+        image:       -> { helpers.asset_url("logo_teams-up_logo_vert.png") }
       },
       # ── Twitter Card (partage sur X/Twitter) ──
       twitter: {
         card:        "summary",
         title:       :title,
-        description: :description
+        description: :description,
+        # Image affichée dans les aperçus Twitter/X
+        image:       -> { helpers.asset_url("logo_teams-up_logo_vert.png") }
       },
       # ── Canonical URL ──────────────────────────────────────────────────────
       # Pointe toujours vers l'URL propre sans query string.


### PR DESCRIPTION
Ajout du fallback og:image pour le partage social

  Sans image définie, le partage d'une page Teams-up sur Facebook, WhatsApp ou Twitter/X s'affichait sans visuel — les
  crawlers ignorent les aperçus incomplets, ce qui réduit le taux de clic.

  Le set_default_meta_tags dans ApplicationController génère désormais deux balises d'image de secours :
  - og:image — utilisée par Facebook, WhatsApp, LinkedIn
  - twitter:image — utilisée par X/Twitter (summary card)

  Les deux pointent vers le logo logo_teams-up_logo_vert.png via asset_url (URL complète avec fingerprint CDN). Les
  pages qui définissent déjà leur propre image via set_meta_tags ne sont pas affectées.

  Fichier modifié : app/controllers/application_controller.rb