### PR TITLE
logsprod

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,9 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  # Code d'autorisation OAuth renvoyé par Google dans l'URL de callback (peut être échangé contre un access_token)
+  :code,
+  # Tokens hCaptcha/reCaptcha soumis dans les formulaires auth — noms exacts utilisés par les widgets
+  "h-captcha-response", "g-recaptcha-response"
 ]


### PR DESCRIPTION
Ce qu'on vient de corriger
  - h-captcha-response et g-recaptcha-response → maintenant filtrés
  - code OAuth → maintenant filtré

  Ce qui était déjà correct
  - log_level en prod → info par défaut (pas debug, qui exposerait les requêtes SQL)
  - SecurityLog → écrit en base de données (pas dans les logs Rails), donc hors du scope du filtre params, et c'est
  intentionnel pour l'audit sécurité
  - Les autres Rails.logger dans l'app → ne loguent que des messages d'erreur génériques, rien de sensible