### PR TITLE
csp+match.time nil

### DIFF
--- a/app/views/user_mailer/match_cancelled.html.erb
+++ b/app/views/user_mailer/match_cancelled.html.erb
@@ -42,7 +42,7 @@
       <div style="background-color: rgba(253, 16, 21, 0.05); border: 1px solid rgba(253, 16, 21, 0.15); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
         <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Match annulé</p>
         <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0; text-decoration: line-through; opacity: 0.6;">
-          📅 <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+          📅 <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
         </p>
         <% if @match.venue.present? %>
           <p style="color: rgba(255,255,255,0.4); font-size: 0.9rem; margin: 0; text-decoration: line-through; opacity: 0.6;">

--- a/app/views/user_mailer/match_cancelled.text.erb
+++ b/app/views/user_mailer/match_cancelled.text.erb
@@ -7,7 +7,7 @@ Malheureusement, l'organisateur <%= @organizer.display_name %> a annulé ce matc
 Ta place a été libérée automatiquement.
 
 Match annulé :
-  Date : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Date : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Lieu : <%= @match.venue.name %>, <%= @match.venue.city %>
 <% end %>

--- a/app/views/user_mailer/match_created.html.erb
+++ b/app/views/user_mailer/match_created.html.erb
@@ -47,7 +47,7 @@
           <tr>
             <td style="color: rgba(255,255,255,0.4); font-size: 0.85rem; padding: 5px 0; width: 36%;">📅 Date</td>
             <td style="color: #f0f0f0; font-size: 0.85rem; padding: 5px 0;">
-              <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+              <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
             </td>
           </tr>
           <% if @match.venue.present? %>

--- a/app/views/user_mailer/match_created.text.erb
+++ b/app/views/user_mailer/match_created.text.erb
@@ -4,7 +4,7 @@ TEAMS-UP
 Votre match "<%= @match.title %>" a bien été créé !
 
 Récapitulatif :
-  Date       : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Date       : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Lieu       : <%= @match.venue.name %>, <%= @match.venue.city %>
 <% elsif @match.place.present? %>

--- a/app/views/user_mailer/match_joined.html.erb
+++ b/app/views/user_mailer/match_joined.html.erb
@@ -60,7 +60,7 @@
       <div style="background-color: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
         <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Récapitulatif</p>
         <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0;">
-          📅 <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+          📅 <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
         </p>
         <% if @match.venue.present? %>
           <p style="color: rgba(255,255,255,0.6); font-size: 0.9rem; margin: 0;">

--- a/app/views/user_mailer/match_joined.text.erb
+++ b/app/views/user_mailer/match_joined.text.erb
@@ -19,7 +19,7 @@ Il reste <%= @match.player_left %> place(s) disponible(s).
 <% end %>
 
 Récapitulatif :
-  Date : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Date : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Lieu : <%= @match.venue.name %>, <%= @match.venue.city %>
 <% end %>

--- a/app/views/user_mailer/match_player_left.html.erb
+++ b/app/views/user_mailer/match_player_left.html.erb
@@ -43,7 +43,7 @@
       <div style="background-color: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
         <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Récapitulatif</p>
         <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0;">
-          📅 <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+          📅 <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
         </p>
         <% if @match.venue.present? %>
           <p style="color: rgba(255,255,255,0.6); font-size: 0.9rem; margin: 0 0 6px 0;">

--- a/app/views/user_mailer/match_player_left.text.erb
+++ b/app/views/user_mailer/match_player_left.text.erb
@@ -7,7 +7,7 @@ Un joueur a quitté votre match — <%= @match.title %>
 Une place vient de se libérer.
 
 Récapitulatif :
-  Date             : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Date             : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Lieu             : <%= @match.venue.name %>, <%= @match.venue.city %>
 <% end %>

--- a/app/views/user_mailer/match_reminder.html.erb
+++ b/app/views/user_mailer/match_reminder.html.erb
@@ -45,7 +45,7 @@
           <tr>
             <td style="color: rgba(255,255,255,0.4); font-size: 0.85rem; padding: 5px 0; width: 36%;">📅 Quand</td>
             <td style="color: #f0f0f0; font-size: 0.85rem; font-weight: 600; padding: 5px 0;">
-              <%= I18n.l(@match.date, format: :long) %> à <span style="color: #1EDD88;"><%= @match.time&.strftime("%Hh%M") %></span>
+              <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <span style="color: #1EDD88;"><%= @match.time.strftime("%Hh%M") %></span><% end %>
             </td>
           </tr>
           <% if @match.venue.present? %>

--- a/app/views/user_mailer/match_reminder.text.erb
+++ b/app/views/user_mailer/match_reminder.text.erb
@@ -6,7 +6,7 @@ TEAMS-UP
 Prépare tes affaires, le match approche !
 
 Infos du match :
-  Quand  : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Quand  : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Où     : <%= @match.venue.name %>, <%= @match.venue.address %>, <%= @match.venue.city %>
 <% elsif @match.place.present? %>

--- a/app/views/user_mailer/match_status_changed.html.erb
+++ b/app/views/user_mailer/match_status_changed.html.erb
@@ -48,7 +48,7 @@
       <div style="background-color: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px 20px; margin-bottom: 28px;">
         <p style="color: rgba(255,255,255,0.4); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.8px; margin: 0 0 10px 0;">Récapitulatif</p>
         <p style="color: #f0f0f0; font-size: 0.9rem; margin: 0 0 6px 0;">
-          📅 <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+          📅 <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
         </p>
         <% if @match.venue.present? %>
           <p style="color: rgba(255,255,255,0.6); font-size: 0.9rem; margin: 0 0 6px 0;">

--- a/app/views/user_mailer/match_status_changed.text.erb
+++ b/app/views/user_mailer/match_status_changed.text.erb
@@ -19,7 +19,7 @@ Explorer d'autres matchs : <%= matches_url %>
 
 Récapitulatif :
   Match      : <%= @match.title %>
-  Date       : <%= I18n.l(@match.date, format: :long) %> à <%= @match.time&.strftime("%Hh%M") %>
+  Date       : <%= I18n.l(@match.date, format: :long) %><% if @match.time.present? %> à <%= @match.time.strftime("%Hh%M") %><% end %>
 <% if @match.venue.present? %>
   Lieu       : <%= @match.venue.name %>, <%= @match.venue.city %>
 <% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,11 +4,10 @@
 # quelles sources de contenu sont autorisées. Elle protège contre les attaques XSS
 # (injection de scripts malveillants).
 #
-# MODE ACTUEL : report_only = true
-# En mode "report only", les violations sont signalées dans la console du navigateur
-# MAIS le contenu n'est PAS bloqué. C'est idéal pour tester sans risquer de casser
-# le site. Une fois que tu as vérifié qu'il n'y a plus de violations dans la console,
-# tu pourras passer report_only à false pour enforcer la politique.
+# MODE ACTUEL : report_only = false → CSP ACTIVE EN PRODUCTION
+# La politique est appliquée : toute ressource non autorisée ci-dessous sera bloquée.
+# Si tu constates des régressions, repasse temporairement report_only à true,
+# ajoute la source manquante dans les règles ci-dessous, puis repasse à false.
 
 Rails.application.configure do
   config.content_security_policy do |policy|
@@ -63,12 +62,8 @@ Rails.application.configure do
   end
 
   # -----------------------------------------------------------------------
-  # IMPORTANT : mode "report only" activé
-  #
-  # En mode report_only, la politique est signalée mais PAS appliquée.
-  # Ouvre la console de ton navigateur (F12 > Console) et navigue dans le site.
-  # Si tu vois des erreurs CSP → ajuste les règles ci-dessus.
-  # Quand la console est propre → passe cette ligne à false pour activer la CSP.
+  # false = CSP activée et appliquée (bloque les violations)
+  # true  = mode "report only" (signale sans bloquer — utile pour déboguer)
   # -----------------------------------------------------------------------
   config.content_security_policy_report_only = false
 end


### PR DESCRIPTION
CSP — report_only était déjà false (CSP active). Seul le commentaire en haut du fichier était faux (disait true). Corrigé.

  match.time nil — 11 templates corrigés (6 HTML + 5 texte). Avant :  à <%= @match.time&.strftime(...) %> laissait un "à " orphelin si pas d'heure. Après : le "à" est dans le if @match.time.present?, identique au pattern déjà utilisé dans
  match_modified.