### PR TITLE
qques modifs

### DIFF
--- a/app/assets/stylesheets/components/_theme.scss
+++ b/app/assets/stylesheets/components/_theme.scss
@@ -354,27 +354,23 @@
       color: rgba(0, 0, 0, 0.55) !important;
     }
 
-    // Cards de matchs dans le profil
-    // !important nécessaire pour écraser le background-color inline qui restait sur ces divs
+    // Cards de matchs dans le profil — textes adaptés au thème clair
+    // Le fond est géré plus bas (hors .profil-page) via .profil-match-card → #f5f5f5
     .profil-match-card {
-      background-color: #ffffff !important;
-      border-color: rgba(0, 0, 0, 0.1) !important;
-
       &:hover { border-color: rgba(0, 0, 0, 0.2) !important; }
 
       // Textes inline (color:#fff, color:rgba(255,255,255,...)) dans les enfants directs
-      // Ces divs dans les vues ERB avaient des couleurs blanches en inline style
       div, span, a {
         color: $gray !important;
       }
 
-      // Exception : les icônes Lucide gardent leur couleur verte/orange
+      // Exception : les icônes Lucide
       i[data-lucide] { color: rgba(0, 0, 0, 0.35) !important; }
 
       // Exception : le badge de niveau garde ses couleurs de charte
       .match-badge-level { color: inherit !important; }
 
-      // Exception : textes de date/heure → muted sombre
+      // Exception : textes de date/heure
       span[style*="rgba(255,255,255"] { color: rgba(0, 0, 0, 0.5) !important; }
     }
 
@@ -399,7 +395,109 @@
     // Noms dans les listes (amis, avis, etc.)
     .profil-reviewer-name { color: $gray !important; }
     .profil-review-text   { color: rgba(0, 0, 0, 0.7) !important; }
+
+    // ── Player card : contenu fond blanc, textes sombres ──────────────────────
+    // Le gradient noir hardcodé dans _player_card.scss est écrasé ici.
+    .player-card {
+      border-color: rgba(0, 0, 0, 0.1);
+      // Redéfinit les CSS vars de la carte pour le thème clair
+      --c-accent: #{$green};
+      --c-star:   #{$green};
+
+      .player-card__inner {
+        background: linear-gradient(160deg, #ffffff 0%, #f8fdf8 60%, #f4f4f4 100%);
+      }
+
+      // Séparateurs internes (étaient rgba(255,255,255,0.06) — invisibles en clair)
+      .player-card__header,
+      .player-card__actions,
+      .player-card__rating,
+      .player-card__stats,
+      .player-card__sports { border-bottom-color: rgba(0, 0, 0, 0.07) !important; }
+
+      // Nom du joueur
+      .player-card__name { color: $gray !important; }
+
+      // Localisation
+      .player-card__location { color: rgba(0, 0, 0, 0.45) !important; }
+
+      // Bouton Modifier
+      .player-card__btn-modifier {
+        color: rgba(0, 0, 0, 0.55) !important;
+        background: rgba(0, 0, 0, 0.05) !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
+        &:hover { background: rgba(0, 0, 0, 0.1) !important; color: $gray !important; }
+      }
+
+      // Bouton Message
+      .player-card__btn-message {
+        color: rgba(0, 0, 0, 0.55) !important;
+        background: rgba(0, 0, 0, 0.05) !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
+        &:hover { background: rgba(0, 0, 0, 0.1) !important; color: $gray !important; }
+      }
+
+      // Avatar fallback (initiale)
+      .player-card__avatar {
+        background: linear-gradient(135deg, #e0e0e0, #d0d0d0) !important;
+        color: rgba(0, 0, 0, 0.5) !important;
+      }
+
+      // Cases de stats (matchs joués / créés)
+      .player-card__stat-box {
+        background: rgba(0, 0, 0, 0.04) !important;
+        border-color: rgba(0, 0, 0, 0.08) !important;
+      }
+      .player-card__stat-label { color: rgba(0, 0, 0, 0.5) !important; }
+      .player-card__stat-value { color: $gray !important; }
+
+      // Label "Sports" + tags de sport
+      .player-card__sports-label { color: rgba(0, 0, 0, 0.5) !important; }
+      .player-card__sport-tag {
+        color: $gray !important;
+        background: rgba(0, 0, 0, 0.05) !important;
+        border-color: rgba(0, 0, 0, 0.1) !important;
+      }
+
+      // Étoiles de notation
+      .player-card__stars {
+        .star { color: rgba(0, 0, 0, 0.15) !important; }
+        .star.filled { color: $green !important; }
+      }
+      .player-card__rating-label { color: rgba(0, 0, 0, 0.5) !important; }
+
+      // Description
+      .player-card__description p { color: rgba(0, 0, 0, 0.55) !important; }
+
+      // Badge "En attente" (était blanc sur fond sombre)
+      .friend-status-badge--pending {
+        color: rgba(0, 0, 0, 0.55) !important;
+        border-color: rgba(0, 0, 0, 0.15) !important;
+      }
+
+      // Bouton Retirer / Annuler (était blanc sur fond sombre)
+      .friend-action-btn--muted {
+        color: rgba(0, 0, 0, 0.55) !important;
+        background: rgba(0, 0, 0, 0.05) !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
+        &:hover { color: $gray !important; background: rgba(0, 0, 0, 0.1) !important; }
+      }
+    }
+
+    // ── Bloc "Mes matchs" : contraste profil-match-card sur fond blanc ────────
+    // Le .match-block est blanc en mode clair. Les .profil-match-card à l'intérieur
+    // seraient aussi blancs → pas de séparation visible.
+    // Correction : fond très légèrement grisé sur les cards internes.
+    .profil-match-card {
+      background-color: #f5f5f5 !important;
+      border-color: rgba(0, 0, 0, 0.1) !important;
+    }
   }
+
+  // ── Bouton de navigation (Retour / Tout voir) ────────────────────────────
+  // En dark : hover blanc (#fff) sur fond sombre → lisible.
+  // En clair : hover blanc serait illisible → on passe à un vert plus soutenu.
+  .nav-button:hover { color: darken($green, 12%) !important; }
 
   // ── Page About ────────────────────────────────────────────────────────────
   // La page "Qui sommes-nous ?" est intentionnellement 100% dark (design marketing).

--- a/app/views/profils/show_simple.html.erb
+++ b/app/views/profils/show_simple.html.erb
@@ -44,31 +44,33 @@
                    pending_received: @pending_received,
                    friendship_initiated_by_me: @friendship_initiated_by_me %>
 
-        <%# ── Notifications push ─────────────────────────────────────────────── %>
-        <div class="match-block" style="margin-top:1rem; padding:1rem 1.25rem;"
-             data-controller="push-notification"
-             data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>"
-             data-push-notification-subscribed-value="<%= current_user.push_subscriptions.any? %>">
-          <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
-            <div>
-              <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
-                          text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.25rem;">
-                <i data-lucide="bell" style="width:14px; height:14px;"></i>
-                Alertes matchs
+        <%# ── Notifications push — visible uniquement sur son propre profil ── %>
+        <% if user_signed_in? && current_user == @profil_user %>
+          <div class="match-block" style="margin-top:1rem; padding:1rem 1.25rem;"
+               data-controller="push-notification"
+               data-push-notification-vapid-key-value="<%= ENV['VAPID_PUBLIC_KEY'] %>"
+               data-push-notification-subscribed-value="<%= current_user.push_subscriptions.any? %>">
+            <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
+              <div>
+                <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
+                            text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.25rem;">
+                  <i data-lucide="bell" style="width:14px; height:14px;"></i>
+                  Alertes matchs
+                </div>
+                <p style="font-size:0.75rem; color:var(--theme-text-muted); margin:0;"
+                   data-push-notification-target="status">
+                  Recevez une alerte dès qu'un match correspond à votre profil.
+                </p>
               </div>
-              <p style="font-size:0.75rem; color:var(--theme-text-muted); margin:0;"
-                 data-push-notification-target="status">
-                Recevez une alerte dès qu'un match correspond à votre profil.
-              </p>
+              <button class="btn btn-sm btn-push-inactive"
+                      data-push-notification-target="button"
+                      data-action="click->push-notification#subscribe"
+                      style="white-space:nowrap; flex-shrink:0;">
+                Activer les notifications
+              </button>
             </div>
-            <button class="btn btn-sm btn-push-inactive"
-                    data-push-notification-target="button"
-                    data-action="click->push-notification#subscribe"
-                    style="white-space:nowrap; flex-shrink:0;">
-              Activer les notifications
-            </button>
           </div>
-        </div>
+        <% end %>
 
       </div>
       <%# / col-lg-4 %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -27,8 +27,8 @@
           <li><%= link_to "Conditions", conditions_path %></li>
           <%# Lien vers la vraie page de contact %>
           <li><%= link_to "Contact", contact_path %></li>
-          <%# Lien vers la page partenariat %>
-          <li><%= link_to "Partenariat", partenariat_path %></li>
+          <%# Lien vers la page partenariat — masqué temporairement, pas encore prête %>
+          <%#= link_to "Partenariat", partenariat_path %>
           <%# "Qui sommes-nous ?" visible uniquement sur mobile (d-md-none) %>
           <li class="d-md-none"><%= link_to "Qui sommes-nous ?", about_path %></li>
           <%# Plan du site — deuxième système de navigation pour RGAA 12.1 %>


### PR DESCRIPTION
 Branche blocalertenotif — résumé PR

  3 corrections apportées :

  1. Footer — lien "Partenariat" masqué temporairement
  Le lien est commenté (<%#=) dans _footer.html.erb. La page et la route sont intactes pour une réactivation facile.

  2. Bloc "Alertes matchs" — bug d'affichage sur les profils tiers
  Le bloc de notifications push apparaissait sur le profil de n'importe quel utilisateur. Ajout d'une condition if user_signed_in? && current_user ==
  @profil_user dans show_simple.html.erb pour le restreindre au profil personnel.

  3. Mode clair — correctifs visuels

  - Player card fond noir : le dégradé #141414 → #0a0a0a hardcodé dans _player_card.scss est écrasé en mode clair par un fond blanc/très léger dans
  _theme.scss. Tous les éléments internes (nom, boutons, stats, tags sport, étoiles, séparateurs) sont adaptés pour rester lisibles sur fond clair.
  - Bloc "Mes matchs" blanc sur blanc : les .profil-match-card passent à #f5f5f5 en mode clair pour se démarquer du .match-block blanc qui les contient.
  - Boutons "Retour" hover illisible : le hover était hardcodé color: #fff — invisible sur fond clair. Override dans _theme.scss vers un vert plus soutenu
  (darken($green, 12%)).