### PR TITLE
Ameliorationlogo

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,7 +93,8 @@ body {
 // IMPORTANT : "clip" sur le body coupe les débordements SANS créer de scroll container,
 // ce qui préserve position:sticky ET permet aux enfants (table-responsive) de scroller
 // horizontalement via leur propre overflow-x: auto.
-// On n'applique PAS overflow-x: hidden sur html car ça bloque les scroll containers enfants.
+// On n'applique PAS overflow-x: clip sur html car ça crée un clip container qui affecte
+// les éléments positionnés (fixed/absolute), cassant les icônes Lucide et autres overlays.
 body {
   overflow-x: clip;
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -20,6 +20,18 @@
   align-items: center;
   gap: 4rem; // Espace équivalent entre chaque section majeure
   flex-wrap: nowrap; // Empêche le retour à la ligne hérité de Bootstrap pour garder logo + icônes sur une seule ligne
+
+  // À 992px-1199px (lg) : réduire le gap pour éviter l'overflow du contenu navbar
+  // Container Bootstrap lg = 960px max-width
+  // Logo (~150px) + liens (~400px) + icônes (~290px sans pill) + gaps réduits doivent tenir
+  @media (min-width: 992px) and (max-width: 1199.98px) {
+    gap: 1rem;
+
+    // Logo légèrement réduit à lg pour laisser plus de place
+    .navbar-brand .navbar-logo {
+      height: 16px;
+    }
+  }
 }
 
 .navbar-dark-custom .navbar-brand {
@@ -51,9 +63,9 @@
   align-items: center;
   padding: 0;
 
-  // Taille desktop (≥ 992px) — réduit de 15%
+  // Taille desktop (≥ 992px) — réduit de 20%
   .navbar-logo {
-    height: 26px;
+    height: 21px;
     width: auto;
     display: block; // Force le SVG à respecter le viewBox (fix WebKit/Safari)
   }
@@ -77,6 +89,12 @@
   padding: 0.4rem 0.75rem !important;
   border-radius: 6px;
   transition: color 0.2s;
+
+  // À lg (992-1199px) : légère réduction pour gagner de la place
+  @media (min-width: 992px) and (max-width: 1199.98px) {
+    font-size: calc(0.9rem - 2px);
+    padding: 0.4rem 0.5rem !important; // paddings latéraux réduits aussi
+  }
 
   &:hover {
     color: var(--theme-text-nav-hover) !important;
@@ -136,8 +154,16 @@
     color: $green;
   }
 
+  // À lg (992-1199px) : masquer le label texte, garder uniquement l'icône
+  @media (min-width: 992px) and (max-width: 1199.98px) {
+    .nav-pwa-label {
+      display: none !important;
+    }
+  }
+
   // Desktop : apparence bouton pill vert (reste vert dans les deux thèmes)
-  @media (min-width: 992px) {
+  // À partir de 1200px (xl) uniquement pour éviter overflow à 992-1199px
+  @media (min-width: 1200px) {
     background-color: #1EDD88;
     color: #111111;
     border-radius: 8px;
@@ -478,18 +504,18 @@ body.modal-open {
   padding-right: 0 !important;
 }
 
-// ── Taille du logo : tablette (768px – 991px) ────────────────────────────────
+// ── Taille du logo : tablette (768px – 991px) — réduit de 20% ────────────────────────────────
 @media (min-width: 768px) and (max-width: 991.98px) {
   .navbar-dark-custom .navbar-brand .navbar-logo {
-    height: 34px;
+    height: 18px;
     width: auto; // Fix WebKit : forcer le SVG à utiliser le viewBox
   }
 }
 
-// ── Taille du logo : mobile (< 768px) ────────────────────────────────────────
+// ── Taille du logo : mobile (< 768px) — réduit de 20% ────────────────────────────────────────
 @media (max-width: 767.98px) {
   .navbar-dark-custom .navbar-brand .navbar-logo {
-    height: 14px;
+    height: 12px;
     width: auto; // Fix WebKit : forcer le SVG à utiliser le viewBox
   }
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -19,6 +19,7 @@
   display: flex;
   align-items: center;
   gap: 4rem; // Espace équivalent entre chaque section majeure
+  flex-wrap: nowrap; // Empêche le retour à la ligne hérité de Bootstrap pour garder logo + icônes sur une seule ligne
 }
 
 .navbar-dark-custom .navbar-brand {
@@ -36,8 +37,12 @@
 .navbar-dark-custom > .container > .d-flex.gap-2,
 .navbar-dark-custom > .container > .d-flex.gap-lg-3 {
   flex: 0 0 auto; // Ne pas grandir, taille au contenu
-  margin-left: 0 !important;
   margin-right: 0 !important;
+  // Sur desktop uniquement : annule le ms-auto (les liens prennent l'espace central)
+  @media (min-width: 992px) {
+    margin-left: 0 !important;
+  }
+  // Sur tablette/mobile : ms-auto de Bootstrap est préservé → icônes poussées à droite
 }
 
 // Logo image dans la navbar
@@ -46,10 +51,11 @@
   align-items: center;
   padding: 0;
 
-  // Taille desktop
+  // Taille desktop (≥ 992px) — réduit de 15%
   .navbar-logo {
-    height: 30px;
+    height: 26px;
     width: auto;
+    display: block; // Force le SVG à respecter le viewBox (fix WebKit/Safari)
   }
 
   // Par défaut (mode sombre) : logo blanc visible, logo noir caché
@@ -472,12 +478,29 @@ body.modal-open {
   padding-right: 0 !important;
 }
 
+// ── Taille du logo : tablette (768px – 991px) ────────────────────────────────
+@media (min-width: 768px) and (max-width: 991.98px) {
+  .navbar-dark-custom .navbar-brand .navbar-logo {
+    height: 34px;
+    width: auto; // Fix WebKit : forcer le SVG à utiliser le viewBox
+  }
+}
+
+// ── Taille du logo : mobile (< 768px) ────────────────────────────────────────
+@media (max-width: 767.98px) {
+  .navbar-dark-custom .navbar-brand .navbar-logo {
+    height: 14px;
+    width: auto; // Fix WebKit : forcer le SVG à utiliser le viewBox
+  }
+}
+
 // ── Alignement mobile : logo + cloche + avatar sur la même ligne ───────────
 @media (max-width: 991.98px) {
   // Force l'alignement vertical centré sur tous les éléments du container
   .navbar-dark-custom > .container {
     align-items: center;
     display: flex;
+    gap: 0.5rem; // Réduit de 4rem à 0.5rem sur tablette/mobile pour éviter débordement
   }
 
   // Supprime les paddings Bootstrap du brand qui décalent l'alignement
@@ -488,10 +511,7 @@ body.modal-open {
     align-items: center;
   }
 
-  // Logo réduit sur mobile — sans inline style bloquant
-  .navbar-dark-custom .navbar-brand .navbar-logo {
-    height: 45px;
-  }
+  // Les tailles du logo (tablette/mobile) sont gérées par les media queries dédiées ci-dessus
 }
 
 // ── Bande sous la navbar (mobile uniquement, d-lg-none) ────────────────────

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -13,6 +13,9 @@
   // padding-bottom large pour que la carte qui dépasse de l'image reste dans la section
   padding: 80px 0 120px;
   position: relative;
+  // Empêche le gradient ::before (left: -120px) de créer un scroll horizontal
+  // "clip" ne crée pas de scroll container → préserve position:sticky et les éléments fixed
+  overflow-x: clip;
 
   // Gradient décoratif vert en haut à gauche (comme la maquette)
   &::before {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -298,4 +298,6 @@
     </div><%# fin actions droite %>
 
   </div>
+
+
 </nav>


### PR DESCRIPTION
Récap des modifications — branche ameliorationlogo

# Le problème : bande blanche à 1024px (je l'ai eu aussi pour d'autres formats j'ai regardé pour tous les formats dans le devtool)
À 1024px, Bootstrap donne un container de 960px maximum. Le contenu de la navbar dépassait cette largeur car le gap entre les trois sections (logo / liens / icônes) était de 4rem de chaque côté soit 128px rien que pour les espaces, le bouton PWA "Installer l'app" avait un style pill vert avec son texte visible dès 992px ce qui ajoutait ~100px supplémentaires, et aucun élément ne pouvait rétrécir (flex-shrink: 0 partout). Résultat : overflow d'environ 100px vers la droite. Le overflow-x: clip sur le body coupait visuellement mais le body restait élargi, d'où la bande blanche sur toute la hauteur de la page.

# Les correctifs dans _navbar.scss
Le gap du container a été réduit de 4rem à 1rem uniquement entre 992px et 1199px, ce qui libère environ 96px. Le bouton PWA pill a été décalé à 1200px minimum au lieu de 992px. Le texte "Installer l'app" est maintenant masqué entre 992px et 1199px, seule l'icône reste visible. Le font-size des liens nav a été réduit de 2px et leur padding latéral réduit à ce breakpoint. Un bug de syntaxe a aussi été corrigé — flex: 0 0 auto était écrit sur deux lignes ce qui rendait la règle  invalide et ignorée par le navigateur.

# Les ajustements esthétiques du logo
Le logo desktop (≥1200px) est passé de 26px à 21px. À lg 992–1199px il est à 16px. Sur tablette 768–991px il est passé de 34px à 18px. Sur mobile (<768px) il est à 12px.