### PR TITLE
Fix contraste banner match show (RGAA NC 1/10)

### DIFF
--- a/app/assets/stylesheets/pages/_match_show.scss
+++ b/app/assets/stylesheets/pages/_match_show.scss
@@ -19,14 +19,15 @@
     background-position: center;
   }
 
-  // Calque sombre dégradé — sombre en bas, transparent en haut
+  // Calque sombre dégradé — renforcé en haut (0.80) pour garantir le contraste RGAA
+  // sur les textes et boutons, quelle que soit la luminosité de la photo de fond
   .match-banner-overlay {
     position: absolute;
     inset: 0;
     background: linear-gradient(
       to bottom,
-      rgba(#111111, 0.65) 0%,
-      rgba(#111111, 0.96) 100%
+      rgba(#111111, 0.80) 0%,
+      rgba(#111111, 0.97) 100%
     );
   }
 
@@ -119,15 +120,19 @@
   color: #fff;
   line-height: 1.2;
   margin-bottom: 0.6rem;
+  // Ombre portée : filet de sécurité si une image claire perce le gradient
+  text-shadow: 0 1px 6px rgba(0,0,0,0.55);
 }
 
 // Description courte
 .match-banner-desc {
-  color: rgba(255,255,255,0.7);
+  // 0.92 au lieu de 0.7 : garantit un ratio RGAA ≥ 4.5:1 quel que soit le fond
+  color: rgba(255,255,255,0.92);
   font-size: 0.9rem;
   line-height: 1.55;
   max-width: 560px;
   margin-bottom: 0.85rem;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.45);
 }
 
 // Date + heure — bloc icône + label + valeur
@@ -156,7 +161,8 @@
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: rgba(255,255,255,0.50);
+    // 0.75 au lieu de 0.50 : texte petit → contraste renforcé (RGAA NC 1/10)
+    color: rgba(255,255,255,0.75);
     line-height: 1;
     margin-bottom: 0.2rem;
   }


### PR DESCRIPTION
## Résumé

Correctifs d'accessibilité sur le banner de la page show d'un match, suite à l'audit RGAA 4.1 (NC 1/10 — critère 3.2, contraste des textes).

- **Overlay renforcé** : gradient en haut de `0.65` → `0.80` pour garantir un fond sombre suffisant sous le bouton Retour et les badges, quelle que soit la luminosité de la photo de fond
- **`.match-banner-desc`** : opacité de `0.7` → `0.92` pour atteindre un ratio ≥ 4.5:1 (RGAA AA)
- **`.match-banner-datetime-label`** : opacité de `0.50` → `0.75` (petit texte = exigence stricte)
- **`text-shadow`** ajouté sur le titre et la description comme filet de sécurité supplémentaire

## Fichier modifié

- `app/assets/stylesheets/pages/_match_show.scss`

## Plan de test

- [ ] Ouvrir `/matches/:id` avec une photo de fond claire (pelouse, ciel bleu)
- [ ] Vérifier la lisibilité du titre, de la description et du bouton Retour
- [ ] Passer un audit Lighthouse / axe DevTools → onglet Accessibility
- [ ] Vérifier que le rendu visuel reste cohérent avec le design dark du banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)