### PR TITLE
Ouverture du site au public

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,6 @@ class ApplicationController < ActionController::Base
   # 301 = redirection permanente → Google transfère tout le "link juice" SEO vers le .fr
   before_action :redirect_com_to_fr
 
-  # Redirige les visiteurs non connectés vers la landing page.
-  # Doit être AVANT authenticate_user! pour intercepter la requête avant Devise.
-  # Exceptions : le contrôleur landing lui-même, Devise (login/signup), PWA et erreurs.
-  before_action :redirect_to_landing_if_visitor
   before_action :authenticate_user!
   # Initialise les meta tags SEO par défaut avant chaque action.
   # Chaque controller peut appeler set_meta_tags() pour surcharger ces valeurs.
@@ -151,18 +147,6 @@ class ApplicationController < ActionController::Base
 
   # ── Verrou pré-lancement ─────────────────────────────────────────────────────
   #
-  # Redirige tous les visiteurs non connectés vers la landing page.
-  # Les développeurs se connectent via /users/sign_in et ont accès à tout.
-  # Exceptions : landing controller (la page elle-même), Devise, PWA, erreurs, sitemap.
-  def redirect_to_landing_if_visitor
-    return if user_signed_in?
-    return if devise_controller?
-    return if %w[landing pwa errors].include?(controller_name)
-    # Le sitemap doit rester accessible aux robots Google même en mode pré-lancement
-    return if request.path.start_with?("/sitemap")
-
-    redirect_to root_path
-  end
 
   # ── Onboarding post-inscription ──────────────────────────────────────────
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,15 +14,8 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks"  # Controller pour gérer le retour de Google OAuth
   }
 
-  # Landing page "Bientôt disponible" — visible par tous les visiteurs non connectés.
-  # Les développeurs connectés sont redirigés vers /matches par LandingController#index.
-  root to: "landing#index"
-
-  # POST /inscription → enregistre l'email du visiteur dans la waitlist
-  post "inscription", to: "landing#subscribe", as: :waitlist_subscribe
-
-  # Ancienne page d'accueil — conservée pour les développeurs connectés
-  get "accueil", to: "pages#home", as: :home
+  # Page d'accueil publique — accessible à tous, connectés ou non
+  root to: "pages#home"
 
   # Page post-inscription : invite l'utilisateur à confirmer son email
   get "confirmation-en-attente", to: "pages#email_confirmation", as: :email_confirmation_pending


### PR DESCRIPTION
## Résumé

- Suppression du mur landing "Bientôt disponible" pour les visiteurs non connectés
- `root` pointe maintenant sur `pages#home` (vraie page d'accueil)
- Suppression du `before_action :redirect_to_landing_if_visitor` et de sa méthode
- Suppression des routes `/inscription` (waitlist) et `/accueil` (alias devenu inutile)

## Comportement après merge

- Les visiteurs voient la vraie homepage avec les matchs disponibles
- `/matches` et `/matches/:id` accessibles sans connexion (déjà configuré)
- Les pages protégées (équipes, profil, etc.) redirigent toujours vers le login

🤖 Generated with [Claude Code](https://claude.com/claude-code)