### PR TITLE
Fix UI : inputs équipe, thème déconnexion, bouton Annuler, tiret PWA

### DIFF
--- a/app/assets/stylesheets/components/_teams.scss
+++ b/app/assets/stylesheets/components/_teams.scss
@@ -278,6 +278,26 @@
   border: 1px solid var(--theme-border);        // était rgba(255,255,255,0.08) — adaptatif
   border-radius: 14px;
   padding: 1.25rem;
+
+  // Champs texte et textarea — fond gris adaptatif comme les autres formulaires
+  .form-control,
+  .form-select {
+    background-color: var(--theme-bg-surface) !important; // fond gris selon le thème
+    border: 1px solid var(--theme-border);
+    color: var(--theme-text-primary) !important;
+    border-radius: 0.5rem;
+
+    &::placeholder {
+      color: var(--theme-text-muted);
+    }
+
+    &:focus {
+      background-color: var(--theme-bg-surface) !important;
+      border-color: rgba(30, 221, 136, 0.5);
+      box-shadow: 0 0 0 0.2rem rgba(30, 221, 136, 0.15);
+      color: var(--theme-text-primary) !important;
+    }
+  }
 }
 
 // Titre de section (INFORMATIONS, BLASON, etc.) — adaptatif

--- a/app/javascript/controllers/theme_toggle_controller.js
+++ b/app/javascript/controllers/theme_toggle_controller.js
@@ -62,6 +62,10 @@ export default class extends Controller {
     // Met à jour l'attribut data-theme sur <html> — tout le CSS réagit à cet attribut
     document.documentElement.setAttribute("data-theme", theme)
 
+    // Sauvegarde dans localStorage pour conserver la préférence après déconnexion.
+    // Le script inline du layout lit cette valeur en priorité pour les visiteurs.
+    localStorage.setItem("theme", theme)
+
     // Met à jour l'icône du bouton (soleil en mode sombre, lune en mode clair)
     this.updateButtonIcon(theme)
   }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,15 +78,31 @@
     <% end %>
 
     <%# ── RGESN 4.11 — Respect de la préférence système de l'OS (prefers-color-scheme) ──────────
-        Pour les visiteurs non-connectés, data-theme est toujours "dark" (valeur par défaut serveur).
-        Ce script inline, exécuté AVANT le CSS, lit la préférence OS et bascule data-theme="light"
-        si l'OS est en mode clair — sans flash de thème. Les utilisateurs connectés ont leur thème
-        géré côté serveur via current_user.profil.theme (ce script ne s'applique pas à eux). %>
-    <% unless user_signed_in? %>
+        Pour les utilisateurs connectés : le thème vient de la BDD (posé ligne 9 via data-theme).
+        On le sauvegarde aussi dans localStorage pour qu'il soit connu après déconnexion.
+
+        Pour les visiteurs non-connectés : on lit localStorage en priorité (préférence issue d'une
+        session précédente), puis on fait fallback sur la préférence OS.
+        Ce script est synchrone et s'exécute AVANT le CSS → pas de flash de thème. %>
+    <% if user_signed_in? %>
+      <%# Sauvegarde le thème BDD dans localStorage pour le conserver après déconnexion %>
       <script>
-        if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-          document.documentElement.setAttribute('data-theme', 'light');
-        }
+        localStorage.setItem('theme', '<%= current_theme %>');
+      </script>
+    <% else %>
+      <%# Visiteur : priorité localStorage → sinon préférence OS → sinon dark (défaut) %>
+      <script>
+        (function() {
+          var saved = localStorage.getItem('theme');
+          if (saved === 'light' || saved === 'dark') {
+            // Préférence explicitement sauvegardée lors d'une session précédente
+            document.documentElement.setAttribute('data-theme', saved);
+          } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+            // Aucune préférence sauvegardée → on respecte la préférence OS
+            document.documentElement.setAttribute('data-theme', 'light');
+          }
+          // Sinon : on garde "dark" posé par le serveur (valeur par défaut)
+        })();
       </script>
     <% end %>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -245,7 +245,7 @@
         <div class="modal-body px-4 py-4">
           <h5 class="pwa-modal-title">Installe Teams-up sur ton appareil</h5>
           <p class="pwa-modal-desc">
-            Accède à Teams-up directement depuis ton écran d'accueil, comme une vraie application — sans passer par le navigateur.
+            Accède à Teams-up directement depuis ton écran d'accueil, comme une vraie application, sans passer par le navigateur.
           </p>
           <ul class="pwa-modal-list">
             <li class="pwa-modal-list-item">

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -139,7 +139,7 @@
       <div class="d-flex gap-3 mt-4">
         <%= f.submit f.object.persisted? ? "Enregistrer les modifications" : "Créer l'équipe",
             class: "btn btn-primary btn-cta-primary px-4" %>
-        <%= link_to "Annuler", f.object.persisted? ? f.object : teams_path, class: "btn btn-outline-light" %>
+        <%= link_to "Annuler", f.object.persisted? ? f.object : teams_path, class: "btn btn-outline-secondary" %>
       </div>
     </div>
 


### PR DESCRIPTION
## Corrections

- **Inputs formulaire équipe** : fond gris adaptatif (`var(--theme-bg-surface)`) cohérent avec les autres pages
- **Thème après déconnexion** : sauvegarde dans `localStorage` pour conserver dark mode quand on se déconnecte (évite le flash blanc si l'OS est en mode clair)
- **Bouton Annuler équipe** : `btn-outline-secondary` au lieu de `btn-outline-light` (style cohérent avec le reste de l'app)
- **Modale PWA iOS** : suppression du tiret cadratin `—` dans la description d'installation

## Test
- Aller sur `/equipes/new` → les inputs doivent avoir un fond gris
- Être en dark mode, se déconnecter → la home doit rester en dark
- Vérifier le bouton Annuler sur le formulaire équipe
- Ouvrir la modale d'installation PWA sur iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)