### PR TITLE
Optimisation tokens : CLAUDE.md en index léger + docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,92 +2,41 @@
 
 ## Rôle
 
-Tu es un développeur web Senior expérimenté travaillant sur ce projet Rails. Tu écris du code propre, maintenable, commenté de façon pédagogique pour qu'un développeur junior puisse le lire et le comprendre. Stack : Rails, Stimulus, HTML/SCSS, Bootstrap, JavaScript.
+Tu es un développeur web **Senior** sur ce projet Rails. Code propre, maintenable, commenté de façon pédagogique (lisible par un junior). Stack : Rails 8.1, Hotwire (Turbo Drive + Stimulus), Bootstrap 5.3, SCSS, PostgreSQL.
+
+Application de mise en relation pour sportifs amateurs : créer/rejoindre des matchs, former des équipes, tchat temps réel, suivre ses stats.
+
+**Stack détaillée :** Devise (confirmable + Google OAuth2) — Pundit (11 policies) — Pagy — pg_search — Active Storage + Cloudinary — ActionCable — Rack::Attack — hCaptcha — Lucide icons (CDN unpkg) — Work Sans / Nunito / Bebas Neue.
 
 ---
 
-## Projet
+## Documentation de référence (lire **selon la tâche**)
 
-Application de mise en relation pour sportifs amateurs. Permet de créer et rejoindre des matchs, former des équipes, tchatter en temps réel et suivre ses stats.
+- **Architecture** — modèles, associations, structure des dossiers, zones complexes (matchs, profil, temps réel) → `docs/ARCHITECTURE.md`
+- **Design system** — couleurs, typographie, boutons, avatars, breakpoints → `docs/DESIGN-SYSTEM.md`
 
-**Stack :**
-- Rails 8.1 — PostgreSQL — Hotwire (Turbo Drive + Stimulus) — Bootstrap 5.3 — SCSS
-- Devise (confirmable + Google OAuth2) — Pundit (11 policies) — Pagy — pg_search
-- Active Storage + Cloudinary — ActionCable — Rack::Attack — hCaptcha
-- Lucide icons (CDN unpkg, init sur `turbo:load`) — Work Sans / Nunito / Bebas Neue
+> Ne charge ces fichiers que si la tâche les concerne (UI/SCSS → design system ; modèles/flux → architecture). Inutile pour un fix back isolé.
 
 ---
 
-## Architecture
-
-### Modèles clés
-
-```
-User
-├── has_one    :profil              → prénom, nom, avatar (Active Storage)
-├── has_many   :sports              → via user_sports
-├── has_many   :matchs              → via match_users
-├── has_many   :teams               → via team_members
-├── has_many   :captained_teams     → FK: captain_id
-├── has_many   :notifications
-├── has_many   :achievements        → via user_achievements (XP)
-├── has_many   :friendships         → bidirectionnel via inverse_friendships
-├── has_many   :avis_donnes/recus   → FK: reviewer_id / reviewed_user_id
-└── belongs_to :current_sport       → sport actif sélectionné
-
-Match
-├── belongs_to :user                → créateur
-├── belongs_to :sport, :venue
-├── belongs_to :team                → optionnel
-├── belongs_to :homme_du_match      → User, optionnel
-├── has_many   :match_users, :messages, :match_votes
-
-Team
-├── belongs_to :captain             → User
-├── has_many   :team_members, :team_invitations, :matches, :messages
-└── has_one_attached :badge_image
-
-Profil
-├── belongs_to :user
-├── has_one_attached :avatar
-├── has_many   :sport_profils       → niveau/XP par sport
-└── has_many   :favorite_venues     → via profil_favorite_venues
-```
-
-### Structure fichiers
-
-| Dossier | Contenu |
-|---|---|
-| `app/controllers/users/` | Surcharges Devise (sessions, registrations, passwords, omniauth_callbacks) |
-| `app/policies/` | Policies Pundit — **toujours** `authorize @resource` dans les controllers |
-| `app/views/shared/` | Partials réutilisables (`_btn_primary`, `_btn_secondary`, `_match_card`, etc.) |
-| `app/javascript/controllers/` | 38 controllers Stimulus — snake_case, suffixe `_controller.js` |
-| `app/assets/stylesheets/config/` | Variables SCSS (`_colors`, `_fonts`, `_bootstrap_variables`) |
-| `app/assets/stylesheets/components/` | Un fichier SCSS par composant |
-| `app/assets/stylesheets/pages/` | Un fichier SCSS par page |
-
----
-
-## Règles de développement
+## Règles de développement (toujours actives)
 
 ### Rails
-- Formulaires : toujours `simple_form` avec `f.input` — jamais `form_tag` brut
+- Formulaires : toujours `simple_form` (`f.input`) — jamais `form_tag` brut
 - Autorisations : toujours Pundit (`authorize`, `policy_scope`) — ne jamais filtrer manuellement dans le controller
-- Pagination : `include Pagy::Backend` (controller) + `include Pagy::Frontend` (ApplicationHelper)
+- Pagination : `Pagy::Backend` (controller) + `Pagy::Frontend` (ApplicationHelper)
 - Recherche full-text : `pg_search` (`PgSearch::Model`)
 - Nouveaux endpoints publics : protéger via Rack::Attack si applicable
 
-### Turbo / Stimulus
-- Lucide icons : déjà ré-initialisé après `turbo:frame-render` et `turbo:render` dans `application.js` — ne pas dupliquer
-- Pages avec hCaptcha : ajouter `<meta name="turbo-cache-control" content="no-cache">` dans `content_for :head` pour éviter que Turbo restaure un snapshot avec un widget expiré
-- Bootstrap modales + Turbo Drive : Bootstrap stocke `_isAppended = true` en interne. Après navigation Turbo, le `body` est remplacé mais le flag reste → le backdrop n'est plus inséré. Toujours `dispose()` l'instance Bootstrap sur `turbo:before-render`
+### Turbo / Stimulus — pièges qui causent des bugs
+- **Lucide** : déjà ré-initialisé après `turbo:frame-render` et `turbo:render` dans `application.js` — ne pas dupliquer
+- **hCaptcha** : ajouter `<meta name="turbo-cache-control" content="no-cache">` dans `content_for :head` (évite un widget expiré restauré par Turbo)
+- **Modales Bootstrap + Turbo Drive** : toujours `dispose()` l'instance Bootstrap sur `turbo:before-render` — sinon le `_isAppended` interne reste à `true` après remplacement du `body` et le backdrop ne s'insère plus
 - Ne jamais supposer qu'un script `async`/`defer` est prêt sur `turbo:load` — utiliser les listeners déjà en place dans `application.js`
 
 ### Nommage
-- Modèles/classes : `PascalCase` — Fichiers Ruby : `snake_case` — Méthodes/variables : `snake_case`
-- Classes CSS : `kebab-case` BEM-like (`auth-card`, `btn-cta-primary`)
-- Stimulus : `snake_case` + suffixe `_controller` (`password_toggle_controller.js`)
-- Tables SQL : `snake_case` pluriel (`match_users`, `sport_profils`)
+- Classes : `PascalCase` — Fichiers Ruby & Stimulus : `snake_case` (Stimulus suffixe `_controller`) — Méthodes/variables : `snake_case`
+- CSS : `kebab-case` BEM-like (`auth-card`, `btn-cta-primary`) — Tables SQL : `snake_case` pluriel (`match_users`, `sport_profils`)
 
 ### Git
 - Commits en français, impératif court ("Fix bug inscription", "Ajout modale profil")
@@ -95,98 +44,28 @@ Profil
 
 ---
 
-## Design System
-
-### Couleurs — `config/_colors.scss`
-
-| Variable | Valeur | Usage |
-|---|---|---|
-| `$green` | `#1EDD88` | Primaire — CTA, liens actifs, badges |
-| `$red` | `#FD1015` | Danger, erreurs, urgence |
-| `$orange` | `#E67E22` | Warning, accent |
-| `$yellow` | `#FFC65A` | Info |
-| `$blue` | `#0D6EFD` | Secondaire |
-| `$dark-bg` | `#111111` | Fond navbar / hero / footer |
-| `$dark-card-bg` | `#1a1c1a` | Fond cartes dark |
-| `$dark-surface` | `#242624` | Surface légèrement plus claire |
-| `$dark-text` | `#f0f0f0` | Texte sur fond sombre |
-| `$dark-muted` | `rgba(255,255,255,0.55)` | Texte secondaire sur fond sombre |
-| `$light-gray` | `#F4F4F4` | Fond body (pages claires) |
-
-Bootstrap overrides dans `config/_bootstrap_variables.scss` : `$primary` → `$green`, `$danger` → `$red`, `$warning` → `$orange`, `$body-bg` → `$light-gray`.
-
-### Typographie — `config/_fonts.scss`
-
-| Variable | Police | Usage |
-|---|---|---|
-| `$body-font` | Work Sans | Corps du texte (`1rem`) |
-| `$headers-font` | Nunito | Titres h1–h6 |
-| `$display-font` | Bebas Neue | Titres hero / display |
-
-Tailles courantes : nav `0.9rem/500`, labels `0.75rem/700/uppercase`, sous-texte `0.875rem`.
-
-### Boutons — toujours utiliser les partials existants
-
-```erb
-<%= render 'shared/btn_primary' %>   → .btn-cta-primary  (fond $green, texte #111)
-<%= render 'shared/btn_secondary' %> → .btn-cta-secondary (fond dark, bordure $green)
-```
-
-Classes Bootstrap associées : `btn btn-primary btn-lg px-4 btn-cta-primary` / `btn btn-lg px-4 btn-cta-secondary`.
-
-### Avatars
-
-| Usage | Taille |
-|---|---|
-| Standard / profil | `40px` |
-| Page profil large | `56px` |
-| Navbar | `34px` (border 2px blanc) |
-| Match card empilés | `26px` (overlap `-6px`) |
-| Chat preview | `30px` |
-
-### Responsive
-
-| Breakpoint | Largeur |
-|---|---|
-| Desktop | `≥ 992px` |
-| Tablette | `< 992px` |
-| Mobile | `< 768px` |
-| Petit téléphone | `< 576px` |
-
----
-
-## Commandes utiles
+## Commandes
 
 ```bash
-rails server          # Lancer le serveur
-rails db:migrate      # Lancer les migrations
-rails test            # Lancer les tests
+rails server      # serveur
+rails db:migrate  # migrations
+rails test        # tests
 ```
 
 ---
 
-## Comportements attendus de Claude
+## Frugalité tokens (économise le contexte à chaque requête)
 
-### Planification
-- Activer le mode planification pour toute tâche complexe (3 étapes ou plus, décision architecturale)
-- Rédiger un plan dans `tasks/todo.md` avec des cases cochables avant de coder
-- En cas d'imprévu : s'arrêter et replanifier immédiatement
+- Pour fouiller de **gros fichiers** (`matches/show.html.erb` ~1570 l., `matches/_form.html.erb` ~1045 l., `_match_form.scss` / `_match_show.scss` ~36 Ko), **déléguer à un sous-agent Explore** plutôt que tout lire dans la fenêtre principale
+- Lire des **plages de lignes ciblées** dans les méga-fichiers, pas l'intégralité
+- Les commandes bash passent déjà par RTK (proxy économe) — ne rien changer
 
-### Sous-agents
-- Déléguer la recherche, l'exploration et l'analyse aux sous-agents pour préserver la fenêtre principale
-- Une tâche ciblée par sous-agent
+---
 
-### Qualité
-- Ne jamais marquer une tâche terminée sans avoir prouvé son fonctionnement
-- Se demander : « Un ingénieur senior approuverait-il cela ? »
-- Pour les changements importants, chercher la solution la plus élégante et simple
+## Comportements attendus
 
-### Bugs
-- Corriger autonomement sans demander d'assistance constante
-- Trouver la cause racine — pas de correctifs temporaires
-- Mettre à jour `tasks/lessons.md` après chaque correction pour ne pas répéter l'erreur
-
-### Principes
-- **Simplicité** : impact minimal sur le code existant
-- **Commentaires** : commenter tout le code de façon pédagogique
-- **Sécurité** : ne jamais introduire d'injection SQL, XSS, ou exposition de données sensibles
+- **Planification** : mode plan pour toute tâche complexe (≥ 3 étapes ou décision archi) ; plan dans `tasks/todo.md` avant de coder ; en cas d'imprévu, s'arrêter et replanifier
+- **Sous-agents** : déléguer recherche / exploration / analyse — une tâche ciblée par agent
+- **Qualité** : ne jamais marquer terminé sans preuve de fonctionnement ; se demander « un ingénieur senior approuverait-il cela ? » ; viser la solution simple et élégante
+- **Bugs** : corriger en autonomie, trouver la **cause racine** (pas de rustine), noter l'apprentissage dans `tasks/lessons.md`
+- **Sécurité** : jamais d'injection SQL, XSS, ni exposition de données sensibles

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,72 @@
+# Team Up — Architecture
+
+> Référence consultée **à la demande** pour comprendre les modèles, associations et flux.
+> Pour fouiller les fichiers volumineux cités plus bas, **déléguer la lecture à un sous-agent Explore**.
+
+## Modèles clés
+
+```
+User
+├── has_one    :profil              → prénom, nom, avatar (Active Storage)
+├── has_many   :sports              → via user_sports
+├── has_many   :matchs              → via match_users
+├── has_many   :teams               → via team_members
+├── has_many   :captained_teams     → FK: captain_id
+├── has_many   :notifications
+├── has_many   :achievements        → via user_achievements (XP)
+├── has_many   :friendships         → bidirectionnel via inverse_friendships
+├── has_many   :avis_donnes/recus   → FK: reviewer_id / reviewed_user_id
+└── belongs_to :current_sport       → sport actif sélectionné
+
+Match
+├── belongs_to :user                → créateur
+├── belongs_to :sport, :venue
+├── belongs_to :team                → optionnel
+├── belongs_to :homme_du_match      → User, optionnel
+├── has_many   :match_users, :messages, :match_votes
+
+Team
+├── belongs_to :captain             → User
+├── has_many   :team_members, :team_invitations, :matches, :messages
+└── has_one_attached :badge_image
+
+Profil
+├── belongs_to :user
+├── has_one_attached :avatar
+├── has_many   :sport_profils       → niveau/XP par sport
+└── has_many   :favorite_venues     → via profil_favorite_venues
+```
+
+## Structure fichiers
+
+| Dossier | Contenu |
+|---|---|
+| `app/controllers/users/` | Surcharges Devise (sessions, registrations, passwords, omniauth_callbacks) |
+| `app/controllers/admin/` | Dashboard, modération, logs |
+| `app/policies/` | Policies Pundit — **toujours** `authorize @resource` dans les controllers |
+| `app/views/shared/` | Partials réutilisables (`_btn_primary`, `_btn_secondary`, `_match_card`, etc.) |
+| `app/javascript/controllers/` | Controllers Stimulus — snake_case, suffixe `_controller.js` |
+| `app/services/image_moderation/` | Modération d'images (checker + adapters, Sightengine) |
+| `app/assets/stylesheets/` | SCSS — voir `docs/DESIGN-SYSTEM.md` |
+
+## Autorisations
+
+11 policies Pundit dans `app/policies/`. `ApplicationController` impose `verify_authorized` + `verify_policy_scoped` → toujours `authorize` / `policy_scope`, jamais de filtrage manuel.
+
+## Zones complexes (lecture ciblée recommandée)
+
+Ces fichiers sont volumineux — lire des plages ciblées ou passer par un sous-agent Explore plutôt que de tout charger.
+
+| Domaine | Fichiers | Points d'attention |
+|---|---|---|
+| **Recherche / création de matchs** | `MatchesController` (~580 l.), `Match` (~280 l.) | Préfiltres issus des préférences du profil **vs** filtres manuels du formulaire de recherche ; scopes (upcoming, publicly_visible, visible_for_genre…) ; votes & validations |
+| **Détail match** | `app/views/matches/show.html.erb` (~1570 l.) | Méga-vue : infos, chat, participants, votes, actions |
+| **Formulaire match** | `app/views/matches/_form.html.erb` (~1045 l.) + `match_form_controller.js` (~565 l.) | Synchronisation temps réel formulaire ↔ récap sidebar, boutons de niveau par sport, calcul du prix |
+| **Profil** | `ProfilesController` (~535 l.), `Profil` | Upload d'images + modération via `app/services/image_moderation/` (concern `Moderatable`) |
+| **Recherche de lieux** | `place_search_controller.js` (~550 l.) | Autocomplétion géolocalisée (Mapbox / OSM) |
+
+## Temps réel (ActionCable + Turbo Streams)
+
+- `Match` diffuse via `broadcasts_to` (callbacks) — messages de chat et mises à jour live de la page match.
+- Les vues s'abonnent via `turbo_stream_from`.
+- Toute modale Bootstrap doit être `dispose()` sur `turbo:before-render` (voir pièges Turbo dans `CLAUDE.md`).

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -1,0 +1,68 @@
+# Team Up — Design System
+
+> Référence consultée **à la demande** pour les tâches UI / SCSS.
+> Source : `app/assets/stylesheets/config/`.
+
+## Couleurs — `config/_colors.scss`
+
+| Variable | Valeur | Usage |
+|---|---|---|
+| `$green` | `#1EDD88` | Primaire — CTA, liens actifs, badges |
+| `$red` | `#FD1015` | Danger, erreurs, urgence |
+| `$orange` | `#E67E22` | Warning, accent |
+| `$yellow` | `#FFC65A` | Info |
+| `$blue` | `#0D6EFD` | Secondaire |
+| `$dark-bg` | `#111111` | Fond navbar / hero / footer |
+| `$dark-card-bg` | `#1a1c1a` | Fond cartes dark |
+| `$dark-surface` | `#242624` | Surface légèrement plus claire |
+| `$dark-text` | `#f0f0f0` | Texte sur fond sombre |
+| `$dark-muted` | `rgba(255,255,255,0.55)` | Texte secondaire sur fond sombre |
+| `$light-gray` | `#F4F4F4` | Fond body (pages claires) |
+
+Bootstrap overrides dans `config/_bootstrap_variables.scss` : `$primary` → `$green`, `$danger` → `$red`, `$warning` → `$orange`, `$body-bg` → `$light-gray`.
+
+## Typographie — `config/_fonts.scss`
+
+| Variable | Police | Usage |
+|---|---|---|
+| `$body-font` | Work Sans | Corps du texte (`1rem`) |
+| `$headers-font` | Nunito | Titres h1–h6 |
+| `$display-font` | Bebas Neue | Titres hero / display |
+
+Tailles courantes : nav `0.9rem/500`, labels `0.75rem/700/uppercase`, sous-texte `0.875rem`.
+
+## Boutons — toujours utiliser les partials existants
+
+```erb
+<%= render 'shared/btn_primary' %>   → .btn-cta-primary  (fond $green, texte #111)
+<%= render 'shared/btn_secondary' %> → .btn-cta-secondary (fond dark, bordure $green)
+```
+
+Classes Bootstrap associées : `btn btn-primary btn-lg px-4 btn-cta-primary` / `btn btn-lg px-4 btn-cta-secondary`.
+
+## Avatars
+
+| Usage | Taille |
+|---|---|
+| Standard / profil | `40px` |
+| Page profil large | `56px` |
+| Navbar | `34px` (border 2px blanc) |
+| Match card empilés | `26px` (overlap `-6px`) |
+| Chat preview | `30px` |
+
+## Responsive
+
+| Breakpoint | Largeur |
+|---|---|
+| Desktop | `≥ 992px` |
+| Tablette | `< 992px` |
+| Mobile | `< 768px` |
+| Petit téléphone | `< 576px` |
+
+## Organisation SCSS
+
+| Dossier | Contenu |
+|---|---|
+| `config/` | Variables (`_colors`, `_fonts`, `_bootstrap_variables`) |
+| `components/` | Un fichier SCSS par composant |
+| `pages/` | Un fichier SCSS par page |

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,11 @@
+# Leçons — erreurs à ne pas répéter
+
+> Après chaque correction de bug, ajouter ici une entrée courte : **symptôme → cause racine → correctif**.
+> Objectif : ne pas répéter la même erreur deux fois.
+
+<!-- Exemple de format :
+## YYYY-MM-DD — Titre court du bug
+- **Symptôme** : ce qui était cassé / observé
+- **Cause racine** : la vraie cause (pas le symptôme)
+- **Correctif** : ce qui a été changé, et fichier(s) concerné(s)
+-->


### PR DESCRIPTION
- Découpe le CLAUDE.md (192 → 71 l.) en index toujours chargé
- Déplace design system et architecture dans docs/ (lus à la demande)
- Ajoute zones complexes, filtrage matchs et temps réel dans l'archi
- Ajoute une section frugalité tokens (Explore sur gros fichiers)
- Crée tasks/lessons.md (référencé mais manquant)