### PR TITLE
Ajout rejoindre une équipe + transmission du capitanat

### DIFF
--- a/app/assets/stylesheets/components/_teams.scss
+++ b/app/assets/stylesheets/components/_teams.scss
@@ -94,6 +94,76 @@
     &.captain { background: rgba(30, 221, 136, 0.15); color: #1EDD88; }
     &.member  { background: var(--theme-hover-bg); color: var(--theme-text-muted); } // adaptatif
   }
+
+  // Nom du capitaine sur les cartes d'exploration (section "Toutes les équipes")
+  &-captain {
+    font-size: 0.75rem;
+    color: var(--theme-text-muted);
+    margin: 0 0 0.15rem;
+    display: flex;
+    align-items: center;
+  }
+}
+
+// ── Titres de section (index : "Mes équipes" / "Toutes les équipes") ──────────
+.teams-section-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--theme-text-strong);
+  font-family: $headers-font;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+// État vide léger affiché quand l'user n'a encore aucune équipe
+.teams-empty-inline {
+  border: 1px dashed var(--theme-border);
+  border-radius: 14px;
+  padding: 1.5rem;
+  text-align: center;
+  background: var(--theme-bg-card);
+}
+
+// ── Carte équipe à rejoindre (section "Toutes les équipes") ───────────────────
+// On bascule en colonne : blason + infos en haut, bouton d'action en bas.
+.team-browse-card {
+  flex-direction: column;
+  align-items: stretch;
+  text-align: center;
+
+  // Le bloc cliquable (blason + infos) reste centré
+  > a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .team-card-captain,
+  .team-card-meta { justify-content: center; }
+
+  // Zone du bouton d'action, séparée par un léger filet
+  &-action {
+    margin-top: 0.5rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid var(--theme-border);
+  }
+
+  // Le hover de translation est géré par .team-card ; on neutralise l'effet
+  // de soulèvement ici pour ne pas perturber le clic sur le bouton.
+  &:hover { transform: none; }
+}
+
+// Bouton "Demande envoyée" — état désactivé informatif
+.team-browse-btn-pending {
+  background: var(--theme-hover-bg);
+  color: var(--theme-text-muted);
+  border: 1px solid var(--theme-border);
+  font-weight: 600;
+  cursor: default;
+
+  &:disabled { opacity: 1; } // garde le style lisible malgré disabled
 }
 
 // ── Bannière de couverture (show) ─────────────────────────────────────────────

--- a/app/controllers/team_invitations_controller.rb
+++ b/app/controllers/team_invitations_controller.rb
@@ -136,24 +136,18 @@ class TeamInvitationsController < ApplicationController
 
     case params[:decision]
     when "approve"
-      # Transforme la proposition en vraie invitation pending → l'invité reçoit la notif
-      @invitation.update!(status: "pending", proposed_by: @invitation.proposed_by)
-
-      # Notifie l'invité via notification in-app
-      Notification.create(
-        user: @invitation.invitee,
-        actor: current_user,
-        message: "#{current_user.profil&.first_name} t'a invité à rejoindre l'équipe \"#{@team.name}\".",
-        link: team_path(@team)
-      )
-
-      # Envoie un email à l'invité (proposition validée par le captain = invitation officielle)
-      UserMailer.team_invitation_received(@invitation).deliver_later
-
-      redirect_to @team, notice: "Invitation envoyée à #{@invitation.invitee.profil&.first_name} !"
+      if @invitation.requested?
+        # Demande spontanée du joueur : il veut déjà rejoindre, on l'ajoute
+        # directement comme membre (inutile de le ré-inviter).
+        approve_join_request
+      else
+        # Proposition d'un membre : on la transforme en invitation officielle
+        # pending → l'invité doit encore accepter.
+        approve_proposal
+      end
     when "decline"
       @invitation.destroy
-      redirect_to @team, notice: "Proposition refusée."
+      redirect_to @team, notice: @invitation.requested? ? "Demande refusée." : "Proposition refusée."
     else
       redirect_to @team, alert: "Action invalide."
     end
@@ -212,5 +206,46 @@ class TeamInvitationsController < ApplicationController
   def refuse_invitation
     @invitation.update!(status: "refused")
     redirect_to teams_path, notice: "Invitation refusée."
+  end
+
+  # Le captain approuve une demande d'adhésion spontanée : on crée directement
+  # le TeamMember (le joueur veut déjà rejoindre) et on le notifie.
+  def approve_join_request
+    ActiveRecord::Base.transaction do
+      @invitation.update!(status: "accepted")
+      @team.team_members.create!(
+        user: @invitation.invitee,
+        role: "member",
+        joined_at: Time.current
+      )
+    end
+
+    Notification.create(
+      user: @invitation.invitee,
+      actor: current_user,
+      message: "Ta demande pour rejoindre l'équipe \"#{@team.name}\" a été acceptée !",
+      link: team_path(@team)
+    )
+
+    redirect_to @team, notice: "#{@invitation.invitee.profil&.first_name} a rejoint l'équipe !"
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to @team, alert: "Erreur : #{e.message}"
+  end
+
+  # Le captain valide une proposition d'un membre : on la transforme en
+  # invitation officielle pending → l'invité reçoit une notif et un email.
+  def approve_proposal
+    @invitation.update!(status: "pending", proposed_by: @invitation.proposed_by)
+
+    Notification.create(
+      user: @invitation.invitee,
+      actor: current_user,
+      message: "#{current_user.profil&.first_name} t'a invité à rejoindre l'équipe \"#{@team.name}\".",
+      link: team_path(@team)
+    )
+
+    UserMailer.team_invitation_received(@invitation).deliver_later
+
+    redirect_to @team, notice: "Invitation envoyée à #{@invitation.invitee.profil&.first_name} !"
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,11 +1,23 @@
 class TeamsController < ApplicationController
-  before_action :set_team, only: %i[show edit update destroy transfer_captain leave]
+  before_action :set_team, only: %i[show edit update destroy transfer_captain leave join]
 
-  # GET /teams — liste des équipes dont l'user est membre
+  # GET /teams — mes équipes (mises en avant) + toutes les autres (à rejoindre)
   def index
+    # Équipes dont l'user est membre — mises en avant en haut de page.
     # preload (au lieu de includes) pour éviter que le JOIN du policy_scope
-    # ne filtre les team_members et n'affiche que 1 membre par équipe
-    @teams = policy_scope(Team).preload(:captain, :team_members).order(created_at: :desc)
+    # ne filtre les team_members et n'affiche que 1 membre par équipe.
+    @my_teams = policy_scope(Team).preload(:captain, :team_members).order(created_at: :desc)
+
+    # Toutes les AUTRES équipes — section "exploration / rejoindre".
+    # On exclut celles déjà dans @my_teams via une sous-requête sur leurs ids.
+    @other_teams = Team.where.not(id: @my_teams.select(:id))
+                       .preload(:captain, :team_members)
+                       .order(created_at: :desc)
+
+    # Ids des équipes où l'user a déjà une demande en attente → bouton "Demande envoyée"
+    @requested_team_ids = current_user.team_invitations_received.requested.pluck(:team_id)
+    # Ids des équipes où l'user a une invitation reçue en attente → bouton "Tu es invité·e"
+    @invited_team_ids   = current_user.team_invitations_received.pending.pluck(:team_id)
   end
 
   # GET /teams/:id — page détail de l'équipe
@@ -19,6 +31,9 @@ class TeamsController < ApplicationController
 
       # Propositions en attente envoyées par les membres (visible par le captain)
       @pending_proposals = @team.team_invitations.proposed.includes(invitee: :profil, proposed_by: :profil)
+
+      # Demandes d'adhésion spontanées des joueurs (visible par le captain)
+      @pending_requests = @team.team_invitations.requested.includes(invitee: :profil)
 
       # Amis du captain qui peuvent encore être invités (pas membres, pas déjà invités)
       excluded_ids = @team.members.pluck(:id) + @team.team_invitations.pending.pluck(:invitee_id)
@@ -127,6 +142,41 @@ class TeamsController < ApplicationController
 
     @team.team_members.find_by(user: current_user)&.destroy
     redirect_to teams_path, notice: "Tu as quitté l'équipe \"#{@team.name}\"."
+  end
+
+  # POST /teams/:id/join — un joueur demande à rejoindre l'équipe
+  # La demande doit être validée par le capitaine (statut "requested").
+  def join
+    authorize @team
+
+    # Garde-fous : déjà membre, ou une demande/invitation est déjà en cours
+    if @team.member?(current_user)
+      redirect_to teams_path, alert: "Tu es déjà membre de cette équipe." and return
+    end
+    if @team.join_request_pending_for?(current_user) || @team.invitation_pending_for?(current_user)
+      redirect_to teams_path, alert: "Une demande ou une invitation est déjà en cours pour cette équipe." and return
+    end
+
+    # inviter = capitaine (cohérent avec le flux des propositions), invitee = le demandeur
+    invitation = TeamInvitation.new(
+      team: @team,
+      inviter: @team.captain,
+      invitee: current_user,
+      status: "requested"
+    )
+
+    if invitation.save
+      # Notifie le capitaine de la nouvelle demande
+      Notification.create(
+        user: @team.captain,
+        actor: current_user,
+        message: "#{current_user.profil&.first_name} demande à rejoindre l'équipe \"#{@team.name}\".",
+        link: team_path(@team)
+      )
+      redirect_to teams_path, notice: "Demande envoyée au capitaine de \"#{@team.name}\" !"
+    else
+      redirect_to teams_path, alert: invitation.errors.full_messages.to_sentence
+    end
   end
 
   private

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -85,6 +85,12 @@ class Team < ApplicationRecord
     team_invitations.exists?(invitee: user, status: "pending")
   end
 
+  # Retourne vrai si l'user a déjà une demande d'adhésion en attente pour cette équipe
+  # (demande spontanée du joueur, en attente de validation par le capitaine)
+  def join_request_pending_for?(user)
+    team_invitations.exists?(invitee: user, status: "requested")
+  end
+
   # Nombre total de membres
   def members_count
     team_members.count

--- a/app/models/team_invitation.rb
+++ b/app/models/team_invitation.rb
@@ -7,7 +7,12 @@ class TeamInvitation < ApplicationRecord
   belongs_to :proposed_by, class_name: "User", optional: true
 
   # ── Constantes ─────────────────────────────────────────────────────────────
-  STATUSES = %w[pending accepted refused proposed].freeze
+  # pending   : invitation envoyée par le capitaine, en attente de réponse de l'invité
+  # accepted  : invitation/demande acceptée (un TeamMember a été créé)
+  # refused   : invitation refusée par l'invité
+  # proposed  : un membre propose un ami au capitaine (en attente de validation captain)
+  # requested : un joueur demande spontanément à rejoindre l'équipe (en attente captain)
+  STATUSES = %w[pending accepted refused proposed requested].freeze
 
   # ── Validations ────────────────────────────────────────────────────────────
   validates :status, inclusion: { in: STATUSES }
@@ -26,16 +31,25 @@ class TeamInvitation < ApplicationRecord
     message: "a déjà une proposition en attente pour cette équipe"
   }
 
+  # Un user ne peut avoir qu'une seule demande d'adhésion en attente par équipe
+  validates :invitee_id, uniqueness: {
+    scope: :team_id,
+    conditions: -> { where(status: "requested") },
+    message: "a déjà une demande en attente pour cette équipe"
+  }
+
   # ── Scopes ─────────────────────────────────────────────────────────────────
-  scope :pending,  -> { where(status: "pending") }
-  scope :accepted, -> { where(status: "accepted") }
-  scope :refused,  -> { where(status: "refused") }
-  scope :proposed, -> { where(status: "proposed") }
+  scope :pending,   -> { where(status: "pending") }
+  scope :accepted,  -> { where(status: "accepted") }
+  scope :refused,   -> { where(status: "refused") }
+  scope :proposed,  -> { where(status: "proposed") }
+  scope :requested, -> { where(status: "requested") }
 
   # ── Méthodes d'instance ────────────────────────────────────────────────────
 
-  def pending?  = status == "pending"
-  def accepted? = status == "accepted"
-  def refused?  = status == "refused"
-  def proposed? = status == "proposed"
+  def pending?   = status == "pending"
+  def accepted?  = status == "accepted"
+  def refused?   = status == "refused"
+  def proposed?  = status == "proposed"
+  def requested? = status == "requested"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,6 +134,18 @@ class User < ApplicationRecord
     full.present? ? full : email
   end
 
+  # Retourne "Prénom N." (prénom + initiale du nom) pour les contextes compacts
+  # où l'on n'affiche que le prénom : l'initiale du nom permet de distinguer
+  # deux joueurs homonymes (ex. deux "Williame"). Si aucun prénom n'est
+  # renseigné, on retombe sur display_name (email en dernier recours).
+  def short_name
+    first   = profil&.first_name.to_s.strip
+    initial = profil&.last_name.to_s.strip.first
+    return display_name if first.blank?
+
+    initial.present? ? "#{first} #{initial.upcase}." : first
+  end
+
   # Méthode appelée lors du retour depuis Google OAuth
   # Elle cherche un user existant avec le même uid+provider, ou le crée
   def self.from_omniauth(auth)

--- a/app/policies/team_invitation_policy.rb
+++ b/app/policies/team_invitation_policy.rb
@@ -9,9 +9,11 @@ class TeamInvitationPolicy < ApplicationPolicy
     record.invitee_id == user.id
   end
 
-  # Seul le captain peut annuler une invitation en attente
+  # Le captain peut annuler une invitation en attente ;
+  # un joueur peut annuler sa propre demande d'adhésion (statut "requested").
   def destroy?
-    record.team.captain_id == user.id
+    record.team.captain_id == user.id ||
+      (record.requested? && record.invitee_id == user.id)
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -33,6 +33,11 @@ class TeamPolicy < ApplicationPolicy
     member? && !captain?
   end
 
+  # Tout utilisateur connecté qui n'est pas déjà membre peut demander à rejoindre
+  def join?
+    user.present? && !member?
+  end
+
   class Scope < ApplicationPolicy::Scope
     # Retourne toutes les équipes dont l'user est membre
     # (ou toutes si non connecté — liste publique)

--- a/app/views/teams/_team_browse_card.html.erb
+++ b/app/views/teams/_team_browse_card.html.erb
@@ -1,0 +1,65 @@
+<%# ── Carte d'une équipe à explorer / rejoindre — affichée dans /equipes ──────
+    Variables attendues :
+      team               (Team)
+      requested_team_ids (Array<Integer>) → équipes où l'user a déjà une demande
+      invited_team_ids   (Array<Integer>) → équipes où l'user a une invitation reçue %>
+
+<div class="team-card team-browse-card">
+
+  <%# Blason cliquable → permet de consulter l'équipe avant de la rejoindre.
+      Priorité : SVG généré > image uploadée > placeholder (même logique que _team_card). %>
+  <%= link_to team_path(team), style: "text-decoration:none;" do %>
+    <div class="team-card-badge">
+      <% if team.badge_svg.present? %>
+        <div class="team-card-badge-svg"><%= team.badge_svg.html_safe %></div>
+      <% elsif team.badge_image.attached? %>
+        <%= image_tag team.badge_image, alt: "Blason #{team.name}", class: "team-card-badge-img" %>
+      <% else %>
+        <div class="team-card-badge-placeholder">
+          <i data-lucide="shield" style="width:32px;height:32px;color:var(--theme-text-muted);"></i>
+        </div>
+      <% end %>
+    </div>
+
+    <%# Infos %>
+    <div class="team-card-body">
+      <h3 class="team-card-name"><%= team.name %></h3>
+
+      <%# Capitaine — prénom + initiale du nom (distingue les homonymes) %>
+      <p class="team-card-captain">
+        <i data-lucide="crown" style="width:12px;height:12px;margin-right:3px;"></i>
+        <%= team.captain.short_name %>
+      </p>
+
+      <p class="team-card-meta">
+        <i data-lucide="users" style="width:12px;height:12px;margin-right:3px;"></i>
+        <%= team.team_members.size %> membre<%= team.team_members.size > 1 ? "s" : "" %>
+      </p>
+    </div>
+  <% end %>
+
+  <%# ── Zone d'action — état du bouton selon la situation de l'utilisateur ──── %>
+  <div class="team-browse-card-action">
+    <% if invited_team_ids.include?(team.id) %>
+      <%# Le capitaine a déjà invité l'user → l'inviter à répondre sur la page équipe %>
+      <%= link_to team_path(team), class: "btn btn-sm btn-cta-secondary w-100" do %>
+        <i data-lucide="mail" style="width:13px;height:13px;margin-right:4px;"></i>
+        Tu es invité·e
+      <% end %>
+    <% elsif requested_team_ids.include?(team.id) %>
+      <%# Demande déjà envoyée → bouton désactivé informatif %>
+      <button type="button" class="btn btn-sm w-100 team-browse-btn-pending" disabled>
+        <i data-lucide="clock" style="width:13px;height:13px;margin-right:4px;"></i>
+        Demande envoyée
+      </button>
+    <% else %>
+      <%# Aucune relation → bouton pour demander à rejoindre %>
+      <%= button_to join_team_path(team), method: :post,
+            class: "btn btn-sm btn-primary btn-cta-primary w-100" do %>
+        <i data-lucide="user-plus" style="width:13px;height:13px;margin-right:4px;"></i>
+        Rejoindre
+      <% end %>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,4 +1,4 @@
-<%# ── Liste des équipes de l'utilisateur connecté ───────────────────────── %>
+<%# ── Page équipes : mes équipes (en avant) + toutes les autres (à rejoindre) ── %>
 
 <div class="teams-page">
 <div class="container py-4">
@@ -7,8 +7,8 @@
   <div class="d-flex align-items-center justify-content-between mb-4">
     <div>
       <%= render "shared/nav_button", url: root_path, label: "Retour", direction: "back", extra_class: "mb-2" %>
-      <h1 class="matches-index-title mb-1">Mes équipes</h1>
-      <p class="matches-index-subtitle mb-0">Les équipes dont tu fais partie.</p>
+      <h1 class="matches-index-title mb-1">Équipes</h1>
+      <p class="matches-index-subtitle mb-0">Retrouve tes équipes et rejoins-en de nouvelles.</p>
     </div>
     <%= link_to new_team_path, class: "btn btn-primary btn-cta-primary px-3" do %>
       <i data-lucide="plus" style="width:15px;height:15px;margin-right:4px;"></i>
@@ -16,24 +16,56 @@
     <% end %>
   </div>
 
-  <%# Liste des équipes %>
-  <% if @teams.any? %>
-    <div class="row g-3">
-      <% @teams.each do |team| %>
-        <div class="col-12 col-md-6 col-lg-4">
-          <%= render "teams/team_card", team: team %>
-        </div>
-      <% end %>
-    </div>
+  <%# ── Section 1 : Mes équipes (mises en avant) ────────────────────────────── %>
+  <section class="mb-5">
+    <h2 class="teams-section-title">
+      <i data-lucide="shield" style="width:18px;height:18px;margin-right:6px;"></i>
+      Mes équipes
+    </h2>
 
-  <%# État vide %>
-  <% else %>
-    <div class="text-center py-5">
-      <i data-lucide="users" style="width:48px;height:48px;color:var(--theme-text-muted);margin-bottom:1rem;"></i>
-      <p style="color:var(--theme-text-muted); font-size:1rem;">Tu n'es encore membre d'aucune équipe.</p>
-      <%= link_to "Créer ma première équipe", new_team_path, class: "btn btn-primary btn-cta-primary mt-2" %>
-    </div>
-  <% end %>
+    <% if @my_teams.any? %>
+      <div class="row g-3">
+        <% @my_teams.each do |team| %>
+          <div class="col-12 col-md-6 col-lg-4">
+            <%= render "teams/team_card", team: team %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <%# État vide léger — l'utilisateur peut quand même explorer les autres équipes %>
+      <div class="teams-empty-inline">
+        <i data-lucide="users" style="width:32px;height:32px;color:var(--theme-text-muted);"></i>
+        <p style="color:var(--theme-text-muted); font-size:0.9rem; margin:0.5rem 0 0;">
+          Tu n'es encore membre d'aucune équipe. Crées-en une ou rejoins celles ci-dessous.
+        </p>
+      </div>
+    <% end %>
+  </section>
+
+  <%# ── Section 2 : Toutes les autres équipes (à rejoindre) ─────────────────── %>
+  <section>
+    <h2 class="teams-section-title">
+      <i data-lucide="compass" style="width:18px;height:18px;margin-right:6px;"></i>
+      Toutes les équipes
+    </h2>
+
+    <% if @other_teams.any? %>
+      <div class="row g-3">
+        <% @other_teams.each do |team| %>
+          <div class="col-12 col-md-6 col-lg-4">
+            <%= render "teams/team_browse_card",
+                  team: team,
+                  requested_team_ids: @requested_team_ids,
+                  invited_team_ids: @invited_team_ids %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p style="color:var(--theme-text-muted); font-size:0.9rem;">
+        Aucune autre équipe pour le moment.
+      </p>
+    <% end %>
+  </section>
 
 </div>
 </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -50,7 +50,8 @@
         <%= link_to user_profil_path(@team.captain),
               style: "color:inherit; font-weight:600;",
               data: { turbo_frame: "_top" } do %>
-          <%= @team.captain.profil&.first_name %>
+          <%# Prénom + initiale du nom pour distinguer deux capitaines homonymes %>
+          <%= @team.captain.short_name %>
         <% end %>
       </p>
       <% if @team.description.present? %>
@@ -73,6 +74,29 @@
           Modifier
         <% end %>
 
+        <%# Transmettre le capitanat — toujours visible pour le capitaine.
+            Actif s'il existe au moins un autre membre (ouvre la modale de choix),
+            sinon désactivé avec un message invitant à recruter d'abord. %>
+        <% if @team.team_members.size > 1 %>
+          <button type="button"
+                  class="team-banner-btn team-banner-btn--edit"
+                  data-bs-toggle="modal"
+                  data-bs-target="#transferCaptainModal"
+                  title="Transmettre le capitanat à un autre membre">
+            <i data-lucide="award" style="width:13px;height:13px;"></i>
+            Transmettre le capitanat
+          </button>
+        <% else %>
+          <button type="button"
+                  class="team-banner-btn team-banner-btn--edit"
+                  disabled
+                  style="opacity:0.5; cursor:not-allowed;"
+                  title="Invite d'abord un membre pour pouvoir lui transmettre le capitanat">
+            <i data-lucide="award" style="width:13px;height:13px;"></i>
+            Transmettre le capitanat
+          </button>
+        <% end %>
+
         <%# Supprimer — icône seule pour ne pas surcharger la bannière %>
         <%= button_to team_path(@team), method: :delete,
             class: "team-banner-btn team-banner-btn--delete",
@@ -81,6 +105,67 @@
           <i data-lucide="trash-2" style="width:13px;height:13px;"></i>
         <% end %>
       </div>
+
+      <%# ── Modale « Transmettre le capitanat » ───────────────────────────────
+          Le capitaine choisit ici le membre à qui passer le brassard. Chaque
+          ligne soumet l'action transfer_captain avec l'id du nouveau capitaine.
+          Hissée via content_for :modals pour éviter les conflits CSS (cf. CLAUDE.md). %>
+      <% if @team.team_members.size > 1 %>
+        <% content_for :modals do %>
+          <div class="modal fade" id="transferCaptainModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content" style="background:var(--theme-bg-card); border:1px solid var(--theme-border); border-radius:12px;">
+
+                <div class="modal-header" style="border-bottom:1px solid var(--theme-border); padding:1rem 1.25rem;">
+                  <h5 style="font-size:1rem; font-weight:700; color:var(--theme-text-strong); margin:0;">
+                    🎖️ Transmettre le capitanat
+                  </h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                </div>
+
+                <div class="modal-body" style="padding:1.25rem;">
+                  <p style="font-size:0.85rem; color:var(--theme-text-muted); margin-bottom:1rem;">
+                    Choisis le membre qui deviendra capitaine. Tu deviendras simple membre et
+                    perdras les droits de gestion de l'équipe.
+                  </p>
+
+                  <%# Liste des membres éligibles (tous sauf le capitaine actuel) %>
+                  <ul class="team-members-list">
+                    <% @team_members.reject(&:captain?).each do |tm| %>
+                      <li class="team-member-item">
+                        <%# Avatar + nom %>
+                        <div style="display:flex; align-items:center; gap:0.6rem; flex:1; min-width:0;">
+                          <% if tm.user.profil&.avatar&.attached? %>
+                            <%= image_tag tm.user.profil.avatar, class: "team-member-avatar", alt: tm.user.profil.first_name, width: 28, height: 28, loading: "lazy" %>
+                          <% else %>
+                            <div class="team-member-avatar-placeholder">
+                              <i data-lucide="user" style="width:18px;height:18px;color:var(--theme-text-muted);"></i>
+                            </div>
+                          <% end %>
+                          <span class="team-member-name">
+                            <%= tm.user.profil&.first_name %> <%= tm.user.profil&.last_name %>
+                          </span>
+                        </div>
+
+                        <%# Bouton « Donner le brassard » — confirmation avant transfert %>
+                        <%= button_to transfer_captain_team_path(@team),
+                              method: :patch,
+                              params: { new_captain_id: tm.user_id },
+                              class: "btn btn-xs btn-outline-warning",
+                              data: { confirm: "Transmettre le capitanat à #{tm.user.profil&.first_name} ? Tu deviendras simple membre." } do %>
+                          <i data-lucide="award" style="width:11px;height:11px;margin-right:3px;"></i>
+                          Donner le brassard
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
+
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
     <% elsif policy(@team).leave? %>
       <%# Bouton Quitter — ouvre une modale de confirmation %>
       <button type="button"
@@ -183,18 +268,11 @@
               <% rank_class = "rank-#{tm.user.rank}" %>
               <div class="team-member-card <%= rank_class %>">
 
-                <%# Actions capitaine (coin haut droit) — visibles uniquement pour le captain %>
+                <%# Action capitaine (coin haut droit) — retirer un membre.
+                    La transmission du capitanat se fait via le bouton groupé
+                    « Transmettre le capitanat » dans la bannière (modale dédiée). %>
                 <% if @team.captain?(current_user) && !tm.captain? %>
-                  <% modal_id = "transferCapitanModal#{tm.user_id}" %>
                   <div class="team-member-card-actions">
-                    <%# Bouton transférer le capitanat %>
-                    <button type="button"
-                            class="btn btn-xs btn-outline-light"
-                            data-bs-toggle="modal"
-                            data-bs-target="#<%= modal_id %>"
-                            title="Transférer le capitanat">
-                      <i data-lucide="star" style="width:10px;height:10px;"></i>
-                    </button>
                     <%# Bouton retirer le membre %>
                     <%= button_to team_team_member_path(@team, tm),
                           method: :delete,
@@ -204,42 +282,6 @@
                       <i data-lucide="user-minus" style="width:10px;height:10px;"></i>
                     <% end %>
                   </div>
-
-                  <%# Modale de confirmation transfert capitanat — hissée via content_for %>
-                  <% content_for :modals do %>
-                    <div class="modal fade" id="<%= modal_id %>" tabindex="-1" aria-hidden="true">
-                      <div class="modal-dialog modal-dialog-centered modal-sm">
-                        <div class="modal-content" style="background:var(--theme-bg-card); border:1px solid var(--theme-border); border-radius:12px;">
-                          <div class="modal-body text-center" style="padding:1.5rem 1.5rem 1rem;">
-                            <div style="font-size:2rem; margin-bottom:0.75rem;">⚡</div>
-                            <p style="color:var(--theme-text-strong); font-weight:700; font-size:0.95rem; margin-bottom:0.3rem;">
-                              Transférer le capitanat à <%= tm.user.profil&.first_name %> ?
-                            </p>
-                            <p style="color:var(--theme-text-muted); font-size:0.8rem; margin:0;">
-                              Tu deviendras simple membre et tu perdras les droits de gestion de l'équipe.
-                            </p>
-                          </div>
-                          <div class="modal-footer" style="border-top:1px solid var(--theme-border); padding:0.75rem 1.5rem; gap:0.5rem; justify-content:center;">
-                            <button type="button"
-                                    data-bs-dismiss="modal"
-                                    style="font-size:0.8rem; font-weight:600; color:var(--theme-text-muted);
-                                           background:var(--theme-hover-bg); border:1px solid var(--theme-border);
-                                           border-radius:20px; padding:0.4rem 1rem; cursor:pointer;">
-                              Annuler
-                            </button>
-                            <%= button_to transfer_captain_team_path(@team),
-                                  method: :patch,
-                                  params: { new_captain_id: tm.user_id },
-                                  style: "font-size:0.8rem; font-weight:700; color:#fff;
-                                          background:rgba(255,193,7,0.8); border:1px solid rgba(255,193,7,0.5);
-                                          border-radius:20px; padding:0.4rem 1rem; cursor:pointer;" do %>
-                              ⚡ Confirmer
-                            <% end %>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  <% end %>
                 <% end %>
 
                 <%# Avatar + nom cliquables → profil du membre %>
@@ -392,6 +434,47 @@
             <p style="color:var(--theme-text-muted); font-size:0.85rem;">Aucune invitation en attente.</p>
           <% end %>
         </div>
+
+        <%# Demandes d'adhésion spontanées des joueurs (en attente de validation) %>
+        <% if @pending_requests&.any? %>
+          <div class="team-section-card mb-3">
+            <h2 class="team-section-title">
+              <i data-lucide="user-plus" style="width:16px;height:16px;margin-right:6px;"></i>
+              Demandes pour rejoindre
+            </h2>
+            <ul class="team-invitations-list">
+              <% @pending_requests.each do |req| %>
+                <li class="team-invitation-item" style="flex-direction:column; align-items:flex-start; gap:0.5rem;">
+                  <%# Joueur qui demande à rejoindre %>
+                  <%= link_to user_profil_path(req.invitee),
+                        style: "text-decoration:none;",
+                        data: { turbo_frame: "_top" } do %>
+                    <span class="team-member-name">
+                      <%= req.invitee.profil&.first_name %> <%= req.invitee.profil&.last_name %>
+                    </span>
+                  <% end %>
+                  <%# Boutons accepter / refuser → réutilisent l'action review %>
+                  <div class="d-flex gap-2">
+                    <%= button_to review_team_team_invitation_path(@team, req),
+                          method: :patch,
+                          params: { decision: "approve" },
+                          class: "btn btn-xs btn-outline-success" do %>
+                      <i data-lucide="check" style="width:11px;height:11px;margin-right:3px;"></i>
+                      Accepter
+                    <% end %>
+                    <%= button_to review_team_team_invitation_path(@team, req),
+                          method: :patch,
+                          params: { decision: "decline" },
+                          class: "btn btn-xs btn-outline-danger" do %>
+                      <i data-lucide="x" style="width:11px;height:11px;margin-right:3px;"></i>
+                      Refuser
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
 
         <%# Propositions des membres en attente de validation %>
         <% if @pending_proposals&.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
       patch :transfer_captain
       # DELETE /teams/:id/leave → quitter l'équipe (membres non-captain)
       delete :leave
+      # POST /teams/:id/join → demander à rejoindre l'équipe (validation par le capitaine)
+      post :join
     end
 
     # Invitations imbriquées dans l'équipe

--- a/test/controllers/team_invitations_controller_test.rb
+++ b/test/controllers/team_invitations_controller_test.rb
@@ -198,4 +198,36 @@ class TeamInvitationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to @team
     assert_not_nil flash[:alert]
   end
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # PATCH .../review — captain valide/refuse une demande d'adhésion (requested)
+  # ════════════════════════════════════════════════════════════════════════════
+
+  # Approuver une demande "requested" ajoute directement le joueur comme membre
+  def test_review_approve_demande_ajoute_le_membre
+    request = TeamInvitation.create!(
+      team: @team, inviter: @captain, invitee: @invitee, status: "requested"
+    )
+    sign_in @captain
+    assert_difference "TeamMember.count", 1 do
+      patch review_team_team_invitation_path(@team, request), params: { decision: "approve" }
+    end
+    assert @team.reload.member?(@invitee), "Le joueur doit être devenu membre"
+    assert_equal "accepted", request.reload.status
+    assert_redirected_to @team
+  end
+
+  # Refuser une demande "requested" la supprime sans créer de membre
+  def test_review_decline_demande_supprime_sans_membre
+    request = TeamInvitation.create!(
+      team: @team, inviter: @captain, invitee: @invitee, status: "requested"
+    )
+    sign_in @captain
+    assert_no_difference "TeamMember.count" do
+      assert_difference "TeamInvitation.count", -1 do
+        patch review_team_team_invitation_path(@team, request), params: { decision: "decline" }
+      end
+    end
+    assert_redirected_to @team
+  end
 end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -253,4 +253,49 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_not_nil flash[:alert]
   end
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # POST /equipes/:id/join — demander à rejoindre une équipe
+  # ════════════════════════════════════════════════════════════════════════════
+
+  # Cas nominal : un non-membre crée une demande d'adhésion "requested"
+  test "POST /equipes/:id/join crée une demande requested pour un non-membre" do
+    sign_in @outsider
+    assert_difference -> { TeamInvitation.requested.count }, 1 do
+      post join_team_path(@team)
+    end
+    assert_redirected_to teams_path
+    assert_not_nil flash[:notice]
+    invitation = TeamInvitation.requested.find_by(team: @team, invitee: @outsider)
+    assert_equal @captain, invitation.inviter # l'inviteur officiel est le capitaine
+  end
+
+  # La demande notifie le capitaine de l'équipe
+  test "POST /equipes/:id/join notifie le capitaine" do
+    sign_in @outsider
+    assert_difference -> { Notification.where(user: @captain).count }, 1 do
+      post join_team_path(@team)
+    end
+  end
+
+  # Garde-fou : un membre existant ne peut pas demander à rejoindre.
+  # Pundit (join? = false pour un membre) bloque en amont → redirection root.
+  test "POST /equipes/:id/join refuse un membre déjà présent" do
+    sign_in @member
+    assert_no_difference "TeamInvitation.count" do
+      post join_team_path(@team)
+    end
+    assert_redirected_to root_path
+    assert_not_nil flash[:alert]
+  end
+
+  # Garde-fou : pas deux demandes en attente pour la même équipe
+  test "POST /equipes/:id/join refuse une seconde demande en attente" do
+    sign_in @outsider
+    post join_team_path(@team) # première demande OK
+    assert_no_difference "TeamInvitation.count" do
+      post join_team_path(@team) # seconde refusée
+    end
+    assert_not_nil flash[:alert]
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -245,6 +245,30 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "display2@example.com", user.display_name
   end
 
+  # ─── Méthode short_name ─────────────────────────────────────────────────────
+
+  # Cas nominal : "Prénom" + initiale majuscule du nom suivie d'un point.
+  test "short_name retourne Prénom + initiale du nom" do
+    user = create_user(email: "short1@example.com", first_name: "Williame", last_name: "laime")
+    assert_equal "Williame L.", user.short_name
+  end
+
+  # Sans nom de famille : on retourne juste le prénom (pas d'initiale orpheline).
+  test "short_name retourne juste le prénom si pas de nom" do
+    user = create_user(email: "short2@example.com", first_name: "Williame", last_name: "Laime")
+    user.profil.update_columns(last_name: nil)
+    user.reload
+    assert_equal "Williame", user.short_name
+  end
+
+  # Sans prénom : on retombe sur display_name (email en dernier recours).
+  test "short_name retombe sur display_name si pas de prénom" do
+    user = create_user(email: "short3@example.com", first_name: "Williame", last_name: "Laime")
+    user.profil.update_columns(first_name: nil, last_name: nil)
+    user.reload
+    assert_equal "short3@example.com", user.short_name
+  end
+
   # ─── Méthode rank ───────────────────────────────────────────────────────────
 
   # rank dépend de profil.xp_level → on crée un user avec profil via create_test_user.


### PR DESCRIPTION
- Page équipes : section "Mes équipes" (mises en avant) + "Toutes les équipes"
- Demande pour rejoindre une équipe (statut requested, validée par le capitaine)
- Bouton groupé "Transmettre le capitanat" dans la bannière (modale de choix)
- Affichage prénom + initiale du nom du capitaine (User#short_name)