### PR TITLE
Ajout lien de réservation terrain + suivi paiements par joueur

### DIFF
--- a/app/assets/stylesheets/pages/_match_show.scss
+++ b/app/assets/stylesheets/pages/_match_show.scss
@@ -1487,3 +1487,149 @@
 
   &:hover { background: rgba(255,255,255,0.1); color: #fff; }
 }
+
+// ══════════════════════════════════════════════════════════════
+// LIEN DE RÉSERVATION DU TERRAIN
+// ══════════════════════════════════════════════════════════════
+
+// Bloc contenant le bouton de réservation et les infos de paiement
+.match-booking-link-block {
+  border-top: 1px solid rgba(255,255,255,0.06);
+  padding-top: 0.85rem;
+}
+
+// Bouton principal "Réserver / Payer le terrain"
+.match-booking-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  background: rgba($green, 0.12);
+  border: 1.5px solid rgba($green, 0.35);
+  color: $green;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.88rem;
+  padding: 0.55rem 1rem;
+  transition: background 0.2s, border-color 0.2s;
+
+  &:hover {
+    background: rgba($green, 0.22);
+    border-color: rgba($green, 0.6);
+    color: $green;
+    text-decoration: none;
+  }
+}
+
+// Bouton "J'ai payé" — secondaire sous le bouton de réservation
+.match-booking-confirm-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.15);
+  color: $dark-muted;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.9rem;
+  transition: all 0.2s;
+
+  &:hover {
+    background: rgba($green, 0.1);
+    border-color: rgba($green, 0.3);
+    color: $green;
+  }
+}
+
+// Confirmation "Tu as payé" avec lien annuler
+.match-booking-paid-status {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: $green;
+  background: rgba($green, 0.08);
+  border: 1px solid rgba($green, 0.2);
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+}
+
+// Lien "Annuler" (undone) dans le statut payé
+.match-booking-undo-btn {
+  background: none;
+  border: none;
+  color: $dark-muted;
+  font-size: 0.72rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+
+  &:hover { color: $red; }
+}
+
+// Récap paiements affiché à l'organisateur
+.match-booking-organizer-recap {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: $dark-muted;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+}
+
+// ── Badges de paiement sur les cartes joueurs ──────────────────────────────
+
+// Wrapper incluant le lien profil + le badge de paiement
+.match-player-item-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  text-align: center;
+}
+
+// Badge "Payé" (vert) / "Non payé" (gris)
+.match-payment-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  line-height: 1;
+
+  &--paid {
+    background: rgba($green, 0.15);
+    color: $green;
+    border: 1px solid rgba($green, 0.25);
+  }
+
+  &--unpaid {
+    background: rgba(255,255,255,0.05);
+    color: rgba(255,255,255,0.35);
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+}
+
+// Bouton de bascule rapide (icône check/x) à côté du badge
+.match-payment-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: $dark-muted;
+  cursor: pointer;
+  padding: 0 0.2rem;
+  font-size: 0;
+  transition: color 0.15s;
+
+  &:hover { color: $green; }
+}

--- a/app/controllers/match_users_controller.rb
+++ b/app/controllers/match_users_controller.rb
@@ -194,6 +194,28 @@ class MatchUsersController < ApplicationController
     redirect_to @match, notice: "Tu es inscrit au match !"
   end
 
+  # PATCH /matches/:match_id/match_users/:id/toggle_payment
+  # Bascule le statut de paiement d'un joueur (payé / non payé)
+  # Accessible à l'organisateur (pour tous les joueurs) ou au joueur lui-même
+  def toggle_payment
+    authorize @match_user
+
+    # Inverse le statut : payé → non payé, non payé → payé
+    @match_user.update!(payment_confirmed: !@match_user.payment_confirmed)
+
+    respond_to do |format|
+      format.turbo_stream do
+        # Met à jour uniquement le badge de paiement du joueur concerné sans recharger la page
+        render turbo_stream: turbo_stream.replace(
+          "payment_badge_#{@match_user.id}",
+          partial: "match_users/payment_badge",
+          locals: { match_user: @match_user, match: @match, current_match_user: current_user.match_users.find_by(match: @match) }
+        )
+      end
+      format.html { redirect_to @match }
+    end
+  end
+
   private
 
   # Retrouve le match parent via l'id dans l'URL

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -521,7 +521,8 @@ class MatchesController < ApplicationController
       :level, :player_left, :players_present, :validation_mode, :price_per_player,
       :sport_id, :format, :banner_image, :visibility,
       :genre_restriction, # Restriction de genre : "tous" ou "feminin"
-      :team_id            # Équipe organisatrice (optionnel)
+      :team_id,           # Équipe organisatrice (optionnel)
+      :booking_link       # Lien de réservation/paiement du terrain (optionnel)
     )
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -157,6 +157,12 @@ class Match < ApplicationRecord
   # Validation : le match doit être prévu au minimum 30 minutes à l'avance
   validate :match_must_be_at_least_30min_in_future, on: %i[create update]
 
+  # Validation : le lien de réservation doit être une URL valide si renseigné
+  validates :booking_link, format: {
+    with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
+    message: "doit être une URL valide (commençant par http:// ou https://)"
+  }, allow_blank: true
+
   # Vérifie que le niveau choisi appartient à la grille du sport sélectionné.
   # Tolère les niveaux hérités ("Tout niveau", "Avancé", etc.) sur les anciens matchs.
   def level_valid_for_sport

--- a/app/models/match_user.rb
+++ b/app/models/match_user.rb
@@ -33,6 +33,11 @@ class MatchUser < ApplicationRecord
     status == "waiting"
   end
 
+  # Retourne vrai si le joueur a confirmé son paiement
+  def paid?
+    payment_confirmed?
+  end
+
   private
 
   # Ajoute la nouvelle conversation en haut de la sidebar sticky chat de l'utilisateur.

--- a/app/policies/match_user_policy.rb
+++ b/app/policies/match_user_policy.rb
@@ -24,6 +24,12 @@ class MatchUserPolicy < ApplicationPolicy
     record.user == user
   end
 
+  # L'organisateur peut marquer n'importe quel joueur comme payé/non payé
+  # Un joueur peut aussi basculer son propre statut de paiement
+  def toggle_payment?
+    organizer? || record.user == user
+  end
+
   private
 
   # Vérifie si l'utilisateur connecté est l'organisateur du match

--- a/app/views/match_users/_payment_badge.html.erb
+++ b/app/views/match_users/_payment_badge.html.erb
@@ -1,0 +1,61 @@
+<%# ═══════════════════════════════════════════════════════════════
+    Partial : _payment_badge.html.erb
+    Affiche le badge de paiement d'un match_user avec le bouton de bascule.
+
+    Locals :
+      - match_user        : l'inscription du joueur (MatchUser)
+      - match             : le match parent (Match)
+      - current_match_user : l'inscription de l'utilisateur connecté (MatchUser ou nil)
+
+    Logique d'affichage :
+      - Si le joueur a payé → badge vert "Payé" avec icône check
+      - Si le joueur n'a pas payé → badge gris/rouge "Non payé"
+      - Le bouton de bascule est visible si :
+          · l'utilisateur connecté est l'organisateur, OU
+          · c'est le propre badge du joueur connecté
+    ═══════════════════════════════════════════════════════════════ %>
+
+<%
+  # L'utilisateur connecté est-il organisateur de ce match ?
+  is_organizer = current_match_user&.role == "organisateur"
+
+  # L'utilisateur connecté est-il le propriétaire de cette inscription ?
+  is_own_badge = current_match_user&.user_id == match_user.user_id
+
+  # Peut-il basculer le statut ? (organisateur ou joueur lui-même)
+  can_toggle = is_organizer || is_own_badge
+%>
+
+<%# Wrapper avec turbo_frame_tag pour la mise à jour sans rechargement de page %>
+<span id="payment_badge_<%= match_user.id %>">
+
+  <% if match_user.paid? %>
+    <%# Badge vert : joueur a payé %>
+    <span class="match-payment-badge match-payment-badge--paid"
+          title="A payé">
+      <i data-lucide="check-circle" style="width:10px;height:10px;"></i>
+      Payé
+    </span>
+  <% else %>
+    <%# Badge gris : joueur n'a pas encore payé — visible seulement pour organisateur et joueur lui-même %>
+    <% if can_toggle %>
+      <span class="match-payment-badge match-payment-badge--unpaid"
+            title="N'a pas encore payé">
+        <i data-lucide="circle" style="width:10px;height:10px;"></i>
+        Non payé
+      </span>
+    <% end %>
+  <% end %>
+
+  <%# Bouton de bascule — visible pour l'organisateur ou le joueur lui-même %>
+  <% if can_toggle && match.booking_link.present? %>
+    <%= button_to toggle_payment_match_match_user_path(match, match_user),
+        method: :patch,
+        class: "match-payment-toggle-btn",
+        title: match_user.paid? ? "Marquer comme non payé" : "Marquer comme payé",
+        data: { turbo_stream: true } do %>
+      <i data-lucide="<%= match_user.paid? ? 'x' : 'check' %>" style="width:9px;height:9px;"></i>
+    <% end %>
+  <% end %>
+
+</span>

--- a/app/views/matches/_form.html.erb
+++ b/app/views/matches/_form.html.erb
@@ -882,6 +882,25 @@
             </p>
           </div><%# fin prix %>
 
+          <%# ── Lien de réservation du terrain (facultatif) ── %>
+          <div class="mt-3">
+            <label class="form-label d-block" for="match_booking_link">
+              Lien de réservation du terrain
+              <span class="ms-1 text-muted" style="font-size:0.75rem; font-weight:400;">(facultatif)</span>
+            </label>
+
+            <%# Champ URL : les participants approuvés pourront cliquer pour payer directement %>
+            <%= f.url_field :booking_link,
+                class: "form-control form-control-sm",
+                placeholder: "https://...",
+                value: @match.booking_link %>
+
+            <p class="form-text mt-1" style="color: rgba(255, 255, 255, 0.55); font-size: 0.8rem;">
+              <i data-lucide="link" style="width:12px; height:12px; vertical-align:middle;"></i>
+              Les participants inscrits verront ce lien pour réserver et payer le terrain.
+            </p>
+          </div><%# fin booking_link %>
+
         </div><%# fin section 4 %>
 
         <%# Lien Annuler visible uniquement sur mobile (< lg)

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -630,24 +630,37 @@
 
             <%# ── Joueurs approuvés (organisateur inclus) ── %>
             <% approved_users.each do |mu| %>
-              <%# Lien vers le profil du joueur — toute la card est cliquable %>
-              <%= link_to user_profil_path(mu.user),
-                  class: "match-player-item",
-                  style: "text-decoration:none;" do %>
+              <%# Wrapper non-cliquable pour pouvoir inclure le badge de paiement %>
+              <div class="match-player-item-wrapper">
 
-                <%# Avatar du joueur ou initiales colorées si pas de photo %>
-                <%= user_avatar_tag mu.user, css_class: "match-player-avatar" %>
+                <%# Lien vers le profil du joueur %>
+                <%= link_to user_profil_path(mu.user),
+                    class: "match-player-item",
+                    style: "text-decoration:none;" do %>
 
-                <%# Prénom + 1ère lettre du Nom suivi d'un point
-                    Ex : "Marc L." — si pas de profil, on affiche la partie avant @ %>
-                <%
-                  first       = mu.user.profil&.first_name.presence || mu.user.email.split("@").first
-                  last_letter = mu.user.profil&.last_name.presence&.first&.upcase
-                  display     = last_letter ? "#{first} #{last_letter}." : first
-                %>
-                <span class="match-player-name"><%= display %></span>
+                  <%# Avatar du joueur ou initiales colorées si pas de photo %>
+                  <%= user_avatar_tag mu.user, css_class: "match-player-avatar" %>
 
-              <% end %>
+                  <%# Prénom + 1ère lettre du Nom suivi d'un point
+                      Ex : "Marc L." — si pas de profil, on affiche la partie avant @ %>
+                  <%
+                    first       = mu.user.profil&.first_name.presence || mu.user.email.split("@").first
+                    last_letter = mu.user.profil&.last_name.presence&.first&.upcase
+                    display     = last_letter ? "#{first} #{last_letter}." : first
+                  %>
+                  <span class="match-player-name"><%= display %></span>
+
+                <% end %>
+
+                <%# Badge de paiement — affiché uniquement si un lien de réservation est défini %>
+                <% if @match.booking_link.present? %>
+                  <%= render "match_users/payment_badge",
+                      match_user: mu,
+                      match: @match,
+                      current_match_user: @current_match_user %>
+                <% end %>
+
+              </div>
             <% end %>
 
             <%# ── Joueurs en attente — avatar avec badge horloge ── %>
@@ -869,6 +882,59 @@
             <%= link_to new_user_session_path, class: "btn btn-primary w-100 match-join-btn" do %>
               Rejoindre le match
             <% end %>
+          <% end %>
+
+          <%# ── Lien de réservation du terrain — visible pour les participants approuvés et l'organisateur ── %>
+          <% if @match.booking_link.present? && is_participant %>
+            <div class="match-booking-link-block mt-3">
+              <%# Bouton principal : ouvre le lien de paiement dans un nouvel onglet %>
+              <%= link_to @match.booking_link,
+                  target: "_blank",
+                  rel: "noopener noreferrer",
+                  class: "btn match-booking-btn w-100" do %>
+                <i data-lucide="external-link" style="width:14px;height:14px;"></i>
+                Réserver / Payer le terrain
+              <% end %>
+
+              <%# Bouton "J'ai payé" — uniquement pour le joueur lui-même (pas l'organisateur) %>
+              <% if @current_match_user && @current_match_user.role != "organisateur" %>
+                <% if @current_match_user.paid? %>
+                  <div class="match-booking-paid-status mt-2">
+                    <i data-lucide="check-circle" style="width:13px;height:13px;"></i>
+                    Tu as confirmé ton paiement
+                    <%# Possibilité d'annuler si erreur %>
+                    <%= button_to toggle_payment_match_match_user_path(@match, @current_match_user),
+                        method: :patch,
+                        class: "match-booking-undo-btn ms-2",
+                        title: "Annuler",
+                        data: { turbo_stream: true } do %>
+                      Annuler
+                    <% end %>
+                  </div>
+                <% else %>
+                  <%= button_to toggle_payment_match_match_user_path(@match, @current_match_user),
+                      method: :patch,
+                      class: "btn match-booking-confirm-btn w-100 mt-2",
+                      data: { turbo_stream: true } do %>
+                    <i data-lucide="check" style="width:13px;height:13px;"></i>
+                    J'ai payé
+                  <% end %>
+                <% end %>
+              <% end %>
+
+              <%# Récap paiements pour l'organisateur %>
+              <% if @current_match_user&.role == "organisateur" %>
+                <%
+                  approved_only = @match_users.select { |mu| mu.approved? }
+                  paid_count    = approved_only.count(&:paid?)
+                  total_count   = approved_only.count
+                %>
+                <div class="match-booking-organizer-recap mt-2">
+                  <i data-lucide="users" style="width:12px;height:12px;"></i>
+                  <strong><%= paid_count %>/<%= total_count %></strong> joueur<%= total_count > 1 ? "s" : "" %> ont payé
+                </div>
+              <% end %>
+            </div>
           <% end %>
 
           <%# Mode de validation choisi par l'organisateur %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,8 @@ Rails.application.routes.draw do
       member do
         patch :approve
         patch :reject
-        patch :confirm  # Membre d'équipe qui confirme sa propre place (team match)
+        patch :confirm        # Membre d'équipe qui confirme sa propre place (team match)
+        patch :toggle_payment # Bascule le statut de paiement (organisateur ou joueur lui-même)
       end
     end
 

--- a/db/migrate/20260622125930_add_booking_link_to_matches_and_payment_confirmed_to_match_users.rb
+++ b/db/migrate/20260622125930_add_booking_link_to_matches_and_payment_confirmed_to_match_users.rb
@@ -1,0 +1,9 @@
+class AddBookingLinkToMatchesAndPaymentConfirmedToMatchUsers < ActiveRecord::Migration[8.1]
+  def change
+    # Lien de réservation du terrain — facultatif, renseigné par l'organisateur
+    add_column :matches, :booking_link, :string
+
+    # Suivi du paiement par joueur — false par défaut (non payé)
+    add_column :match_users, :payment_confirmed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_125930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -131,6 +131,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
     t.datetime "last_read_at"
     t.bigint "match_id", null: false
     t.text "message"
+    t.boolean "payment_confirmed", default: false, null: false
     t.string "role"
     t.string "status", default: "pending"
     t.datetime "updated_at", null: false
@@ -154,6 +155,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
 
   create_table "matches", force: :cascade do |t|
     t.string "banner_image"
+    t.string "booking_link"
     t.datetime "created_at", null: false
     t.date "date"
     t.string "description"
@@ -161,6 +163,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
     t.string "genre_restriction", default: "tous"
     t.bigint "homme_du_match_id"
     t.string "level"
+    t.integer "max_supporters", default: 0
+    t.float "pin_latitude"
+    t.float "pin_longitude"
     t.string "place"
     t.integer "player_left"
     t.integer "players_present"
@@ -292,6 +297,148 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
     t.index ["user_id"], name: "index_security_logs_on_user_id"
   end
 
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", null: false
+    t.bigint "channel_hash", null: false
+    t.datetime "created_at", null: false
+    t.binary "payload", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "active_job_id"
+    t.text "arguments"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.text "arguments"
+    t.string "class_name"
+    t.string "command", limit: 2048
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "sport_profils", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "level"
@@ -349,8 +496,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
     t.text "description"
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.string "visibility", default: "public", null: false
     t.index ["captain_id"], name: "index_teams_on_captain_id"
     t.index ["name", "captain_id"], name: "index_teams_on_name_and_captain_id", unique: true
+    t.index ["visibility"], name: "index_teams_on_visibility"
   end
 
   create_table "user_achievements", force: :cascade do |t|
@@ -399,13 +548,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
     t.string "city"
     t.datetime "created_at", null: false
     t.boolean "from_nominatim", default: false, null: false
+    t.boolean "from_overpass", default: false, null: false
     t.float "latitude"
     t.float "longitude"
     t.string "name"
+    t.bigint "osm_id"
     t.string "postal_code"
     t.string "sport_type"
     t.datetime "updated_at", null: false
     t.index ["city"], name: "index_venues_on_city"
+    t.index ["osm_id"], name: "index_venues_on_osm_id"
     t.index ["sport_type"], name: "index_venues_on_sport_type"
   end
 
@@ -446,6 +598,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_100000) do
   add_foreign_key "profils", "users"
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "security_logs", "users", on_delete: :nullify
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "sport_profils", "profils"
   add_foreign_key "sport_profils", "sports"
   add_foreign_key "team_invitations", "teams"


### PR DESCRIPTION
- Nouveau champ booking_link (URL) facultatif sur le match
- Nouveau champ payment_confirmed (booléen) sur match_user
- Bouton "Réserver / Payer le terrain" visible uniquement pour les participants approuvés
- Bouton "J'ai payé" pour que chaque joueur confirme son paiement
- Récap paiements (X/Y joueurs) pour l'organisateur
- Badge Payé/Non payé sur chaque avatar joueur (si lien défini)
- L'organisateur peut aussi basculer le statut de paiement de chaque joueur