### PR TITLE
Auto-seed venues custom à chaque déploiement

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,6 +3,7 @@
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
+  ./bin/rails db:seed_custom_venues
 fi
 
 exec "${@}"


### PR DESCRIPTION
## Summary
- Ajoute `./bin/rails db:seed_custom_venues` dans `bin/docker-entrypoint`, exécuté juste après `db:prepare` au démarrage du conteneur en production.
- Évite d'avoir à lancer manuellement la tâche après chaque ajout de venue custom (comme pour le Stade Élisabeth et le réseau Hoops Factory).

## Test plan
- [x] `rails db:seed_custom_venues` testé en local, idempotent (find_or_create_by!)
- [ ] Vérifier après déploiement Railway que les logs montrent bien l'exécution de la tâche au démarrage