### PR TITLE
Pagination (matchs & équipes) + création de match : Tout niveau & total joueurs

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,4 +1,8 @@
 class MatchesController < ApplicationController
+  # Pagination serveur de la liste des matchs (évite de charger tous les matchs
+  # + leurs avatars préchargés d'un coup — indispensable à la montée en charge).
+  include Pagy::Backend
+
   # Permet aux visiteurs non connectés de voir la liste et le détail d'un match.
   # Les autres actions (créer, rejoindre, etc.) restent protégées par authenticate_user!
   skip_before_action :authenticate_user!, only: %i[index show]
@@ -51,6 +55,12 @@ class MatchesController < ApplicationController
         apply_filters
       end
     end
+
+    # Pagination : 12 matchs par page (3 colonnes × 4 lignes sur desktop).
+    # Appliquée en dernier, après tous les filtres, pour ne charger et ne
+    # précharger (avatars, sport…) que les matchs réellement affichés.
+    # Pagy conserve automatiquement les paramètres de filtre dans les liens.
+    @pagy, @matches = pagy(@matches, items: 12)
 
     # Meta tags pour la liste des matchs — description adaptée au sport actif si filtré
     sport_name = current_sport&.name

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,4 +1,7 @@
 class TeamsController < ApplicationController
+  # Pagination serveur de la section « explorer » (toutes les autres équipes).
+  include Pagy::Backend
+
   before_action :set_team, only: %i[show edit update destroy transfer_captain leave join]
 
   # GET /teams — mes équipes (mises en avant) + toutes les autres (à rejoindre)
@@ -10,9 +13,14 @@ class TeamsController < ApplicationController
 
     # Toutes les AUTRES équipes — section "exploration / rejoindre".
     # On exclut celles déjà dans @my_teams via une sous-requête sur leurs ids.
-    @other_teams = Team.where.not(id: @my_teams.select(:id))
-                       .preload(:captain, :team_members)
-                       .order(created_at: :desc)
+    # Section « explorer » paginée (9 équipes/page) — @my_teams reste entier
+    # (un user a rarement beaucoup d'équipes à lui).
+    @pagy, @other_teams = pagy(
+      Team.where.not(id: @my_teams.select(:id))
+          .preload(:captain, :team_members)
+          .order(created_at: :desc),
+      items: 9
+    )
 
     # Ids des équipes où l'user a déjà une demande en attente → bouton "Demande envoyée"
     @requested_team_ids = current_user.team_invitations_received.requested.pluck(:team_id)

--- a/app/javascript/controllers/match_form_controller.js
+++ b/app/javascript/controllers/match_form_controller.js
@@ -49,6 +49,7 @@ export default class extends Controller {
     // ── Champs Libre : saisie directe ──────────────────────
     "playersPresentInput",    // Input number : joueurs présents (players_present soumis)
     "playersLibreInput",      // Input number visible : joueurs manquants (synchronise playersInput)
+    "libreTotal",             // Span : total joueurs attendus en mode Libre (présents + recherchés)
 
     // ── Éléments du récapitulatif (destinations) ──────────
     "recapTitle",        // Zone affichant le titre dans la sidebar
@@ -283,6 +284,8 @@ export default class extends Controller {
       // Met à jour le récap
       this.recapPresentTarget.textContent  = presentVal
       this.recapPlayersTarget.textContent  = libreVal
+      // Affiche le total attendu (présents + recherchés)
+      this._updateLibreTotal()
 
     } else {
       // ── Mode standard : 1 compteur avec max défini par le format ──
@@ -444,6 +447,7 @@ export default class extends Controller {
     const val = Math.max(1, parseInt(this.playersPresentInputTarget.value) || 1)
     this.playersPresentInputTarget.value = val
     this.recapPresentTarget.textContent  = val
+    this._updateLibreTotal()
   }
 
   // Appelé à chaque frappe dans le champ "Manquants" — met à jour playersInput (hidden) + récap
@@ -452,6 +456,16 @@ export default class extends Controller {
     this.playersLibreInputTarget.value  = val
     this.playersInputTarget.value       = val   // hidden field soumis avec le formulaire
     this.recapPlayersTarget.textContent = val
+    this._updateLibreTotal()
+  }
+
+  // Recalcule le total de joueurs attendus en mode Libre = présents + recherchés.
+  // No-op si la target n'est pas présente (mode standard).
+  _updateLibreTotal() {
+    if (!this.hasLibreTotalTarget) return
+    const present = Math.max(1, parseInt(this.playersPresentInputTarget.value) || 1)
+    const missing = Math.max(1, parseInt(this.playersLibreInputTarget.value) || 1)
+    this.libreTotalTarget.textContent = present + missing
   }
 
   // ── Niveau : génère les boutons de niveau pour le sport sélectionné ──
@@ -460,7 +474,13 @@ export default class extends Controller {
     const container = this.levelButtonsTarget
     container.innerHTML = ""
 
-    levels.forEach((lvl) => {
+    // "Tout niveau" : option ouverte à tous les niveaux, proposée en plus des
+    // niveaux propres au sport. La valeur "Tout niveau" est déjà tolérée par la
+    // validation Rails (match.rb) et stylée via la classe level-tout.
+    const hasTous  = levels.some((l) => l.label === "Tout niveau")
+    const options  = hasTous ? levels : levels.concat([{ label: "Tout niveau" }])
+
+    options.forEach((lvl) => {
       const btn = document.createElement("button")
       btn.type = "button"
       const isActive = lvl.label === savedLevel

--- a/app/views/matches/_form.html.erb
+++ b/app/views/matches/_form.html.erb
@@ -619,6 +619,14 @@
 
             </div><%# fin flex wrapper %>
 
+            <%# Total attendu = présents + recherchés. Mis à jour en direct par Stimulus
+                (changePresent / changeLibre) et initialisé côté serveur en édition. %>
+            <p class="mt-3 mb-0" style="font-size:0.9rem; color:var(--theme-text-primary);">
+              Soit
+              <strong data-match-form-target="libreTotal"><%= (@match.players_present || 1).to_i + (@match.player_left || 1).to_i %></strong>
+              joueur·euse·s au total sur le terrain.
+            </p>
+
           </div><%# fin section Libre %>
 
           <%# ── Boutons de niveau (générés dynamiquement par Stimulus selon le sport) ── %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -383,32 +383,20 @@
     <% else %>
 
       <%#
-        Stimulus "load-more" :
-          data-load-more-step-value="6" → 6 cartes révélées par clic sur le bouton
-          Chaque carte (_match.html.erb) a data-load-more-target="card"
+        id="matches" obligatoire → cible des broadcasts ActionCable.
+        Quand un nouveau match est créé, Turbo l'insère ici automatiquement (prepend).
       %>
-      <div data-controller="load-more" data-load-more-step-value="6">
-
-        <%#
-          id="matches" obligatoire → cible des broadcasts ActionCable.
-          Quand un nouveau match est créé, Turbo l'insère ici automatiquement (prepend).
-        %>
-        <div id="matches" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <%= render @matches %>
-        </div>
-
-        <%# Bouton "Afficher plus" — géré par le Stimulus load-more controller %>
-        <div class="text-center mt-5">
-          <button
-            class="matches-load-more-btn"
-            data-load-more-target="button"
-            data-action="click->load-more#more">
-            Afficher plus de matchs
-            <i data-lucide="chevron-down" style="width:16px;height:16px;margin-left:6px;"></i>
-          </button>
-        </div>
-
+      <div id="matches" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        <%= render @matches %>
       </div>
+
+      <%# Pagination serveur (Pagy) — n'affiche la nav que s'il y a plus d'une page.
+          Les paramètres de filtre sont conservés automatiquement dans les liens. %>
+      <% if @pagy && @pagy.pages > 1 %>
+        <nav class="matches-pagination mt-5 d-flex justify-content-center" aria-label="Pagination des matchs">
+          <%== pagy_bootstrap_nav(@pagy) %>
+        </nav>
+      <% end %>
     <% end %>
 
   </div>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -60,6 +60,13 @@
           </div>
         <% end %>
       </div>
+
+      <%# Pagination serveur (Pagy) — affichée seulement s'il y a plus d'une page. %>
+      <% if @pagy && @pagy.pages > 1 %>
+        <nav class="teams-pagination mt-4 d-flex justify-content-center" aria-label="Pagination des équipes">
+          <%== pagy_bootstrap_nav(@pagy) %>
+        </nav>
+      <% end %>
     <% else %>
       <p style="color:var(--theme-text-muted); font-size:0.9rem;">
         Aucune autre équipe pour le moment.

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,4 +1,8 @@
 # Initializer Pagy — charge les extras nécessaires
 # pagy/extras/bootstrap → fournit pagy_bootstrap_nav() pour les vues
 # pagy/extras/array    → permet de paginer des tableaux Ruby simples
+# pagy/extras/overflow → évite un 500 quand on demande une page inexistante
+#                        (?page=999) : on retombe sur la dernière page valide.
 require "pagy/extras/bootstrap"
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :last_page


### PR DESCRIPTION
Les 2 features poussées après le squash-merge de #338, sur une branche propre depuis master.

## ⚡ Pagination serveur (Pagy)
- **matches#index** : remplace le « Afficher plus » JS (qui chargeait tous les matchs dans le DOM) par de vraies pages numérotées, **12/page**. Seuls les matchs affichés sont chargés + préchargés (avatars…) → clé pour la montée en charge.
- **teams#index** : section « explorer » paginée **9/page** (mes équipes restent entières).
- Overflow géré (`?page=999` retombe sur la dernière page au lieu d'un 500).

## 🏟️ Formulaire de création de match
- Ajoute l'option **« Tout niveau »** dans le choix du niveau (en plus des niveaux propres au sport). Valeur déjà tolérée par la validation et stylée via `level-tout`.
- **Mode Libre** : affiche en direct le **total de joueurs attendus** (présents + recherchés), mis à jour à chaque saisie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)