### PR TITLE
Slack : ciblage workspace à l'install + style page Intégrations

### DIFF
--- a/app/controllers/slack/oauth_controller.rb
+++ b/app/controllers/slack/oauth_controller.rb
@@ -44,6 +44,9 @@ module Slack
     private
 
     # Construit l'URL d'autorisation OAuth du bot avec les scopes et le state signé.
+    # `team` (optionnel) force le workspace ciblé : sans lui, Slack sélectionne
+    # d'office le workspace "le plus actif" de la session, qui n'est pas forcément
+    # celui qu'on veut installer. On le passe via /slack/install?team=T0123ABC.
     def authorize_url
       query = {
         client_id: Slack.client_id,
@@ -51,6 +54,7 @@ module Slack
         redirect_uri: slack_oauth_callback_url,
         state: signed_state
       }
+      query[:team] = params[:team] if params[:team].present?
       "#{Slack::OAUTH_AUTHORIZE_URL}?#{query.to_query}"
     end
 

--- a/app/views/profils/integrations.html.erb
+++ b/app/views/profils/integrations.html.erb
@@ -16,69 +16,73 @@
     </div>
 
     <%# ── Carte Slack ─────────────────────────────────────────────────────── %>
-    <div class="card border-0 shadow-sm" style="border-radius:1rem; overflow:hidden;">
-      <div class="card-body p-4">
+    <%# .match-block : carte sombre theme-aware (fond, bordure, texte clair) réutilisée
+        depuis la page profil — cohérente en mode sombre ET clair. %>
+    <div class="match-block">
 
-        <div class="d-flex align-items-center gap-3 mb-3">
-          <i data-lucide="slack" style="width:28px; height:28px;"></i>
-          <div>
-            <h2 class="h6 mb-0 fw-bold">Slack</h2>
-            <small class="text-muted">Partage tes matchs et inscris-toi depuis Slack</small>
-          </div>
-        </div>
-
-        <% unless @slack_configured %>
-          <%# Garde-fou en local : sans les secrets SLACK_*, les flux OAuth ne marchent pas. %>
-          <div class="alert alert-warning small mb-3" role="alert">
-            <i data-lucide="alert-triangle" style="width:16px; height:16px; vertical-align:-3px;"></i>
-            L'intégration Slack n'est pas encore configurée sur cette instance
-            (variables <code>SLACK_*</code> manquantes).
-          </div>
-        <% end %>
-
-        <% if @slack_identities.any? %>
-          <%# ── Identités déjà liées ────────────────────────────────────── %>
-          <ul class="list-group list-group-flush mb-3">
-            <% @slack_identities.each do |identity| %>
-              <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-                <span>
-                  <i data-lucide="check-circle" class="text-success" style="width:16px; height:16px; vertical-align:-3px;"></i>
-                  Lié à l'espace
-                  <strong><%= identity.slack_workspace.team_name.presence || identity.slack_team_id %></strong>
-                </span>
-                <%= button_to slack_disconnect_path(identity),
-                              method: :delete,
-                              class: "btn btn-sm btn-outline-danger",
-                              data: { turbo_confirm: "Délier ce compte Slack ?" } do %>
-                  Délier
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-muted small mb-3">Ton compte n'est lié à aucun espace Slack.</p>
-        <% end %>
-
-        <%# ── Actions ─────────────────────────────────────────────────────── %>
-        <div class="d-flex flex-wrap gap-2">
-          <%= link_to slack_connect_path, class: "btn btn-cta-primary #{'disabled' unless @slack_configured}" do %>
-            <i data-lucide="link" style="width:16px; height:16px; vertical-align:-3px;"></i>
-            Se connecter avec Slack
-          <% end %>
-
-          <%= link_to slack_install_path, class: "btn btn-outline-secondary #{'disabled' unless @slack_configured}" do %>
-            <i data-lucide="download" style="width:16px; height:16px; vertical-align:-3px;"></i>
-            Installer sur un espace Slack
-          <% end %>
-        </div>
-
-        <p class="text-muted mt-3 mb-0" style="font-size:0.78rem;">
-          « Installer » ajoute le bot Teams-up à ton espace Slack (réservé aux admins Slack).
-          « Se connecter » relie ensuite ton identité Slack à ce compte pour pouvoir t'inscrire
-          aux matchs directement depuis Slack.
-        </p>
-
+      <%# En-tête : icône + titre de section vert (.match-block-title) %>
+      <div class="match-block-title">
+        <i data-lucide="slack" style="width:20px; height:20px;"></i>
+        Slack
       </div>
+      <p style="font-size:0.85rem; color:var(--theme-text-muted); margin:-0.5rem 0 1.25rem;">
+        Partage tes matchs et inscris-toi depuis Slack
+      </p>
+
+      <% unless @slack_configured %>
+        <%# Garde-fou : sans les secrets SLACK_*, les flux OAuth ne marchent pas. %>
+        <div class="alert alert-warning small mb-3" role="alert">
+          <i data-lucide="alert-triangle" style="width:16px; height:16px; vertical-align:-3px;"></i>
+          L'intégration Slack n'est pas encore configurée sur cette instance
+          (variables <code>SLACK_*</code> manquantes).
+        </div>
+      <% end %>
+
+      <% if @slack_identities.any? %>
+        <%# ── Identités déjà liées ──────────────────────────────────────── %>
+        <div class="mb-3">
+          <% @slack_identities.each do |identity| %>
+            <div class="d-flex justify-content-between align-items-center py-2"
+                 style="border-bottom:1px solid var(--theme-border);">
+              <span style="color:var(--theme-text-primary);">
+                <i data-lucide="check-circle" style="width:16px; height:16px; vertical-align:-3px; color:#1EDD88;"></i>
+                Lié à l'espace
+                <strong><%= identity.slack_workspace.team_name.presence || identity.slack_team_id %></strong>
+              </span>
+              <%= button_to slack_disconnect_path(identity),
+                            method: :delete,
+                            class: "btn btn-sm btn-outline-danger",
+                            data: { turbo_confirm: "Délier ce compte Slack ?" } do %>
+                Délier
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p style="color:var(--theme-text-muted); font-size:0.85rem;" class="mb-3">
+          Ton compte n'est lié à aucun espace Slack.
+        </p>
+      <% end %>
+
+      <%# ── Actions ───────────────────────────────────────────────────────── %>
+      <div class="d-flex flex-wrap gap-2">
+        <%= link_to slack_connect_path, class: "btn btn-primary btn-cta-primary #{'disabled' unless @slack_configured}" do %>
+          <i data-lucide="link" class="btn-cta-icon" style="width:16px; height:16px; vertical-align:-3px;"></i>
+          Se connecter avec Slack
+        <% end %>
+
+        <%= link_to slack_install_path, class: "btn btn-cta-secondary #{'disabled' unless @slack_configured}" do %>
+          <i data-lucide="download" class="btn-cta-icon" style="width:16px; height:16px; vertical-align:-3px;"></i>
+          Installer sur un espace Slack
+        <% end %>
+      </div>
+
+      <p class="mt-3 mb-0" style="font-size:0.78rem; color:var(--theme-text-muted);">
+        « Installer » ajoute le bot Teams-up à ton espace Slack (réservé aux admins Slack).
+        « Se connecter » relie ensuite ton identité Slack à ce compte pour pouvoir t'inscrire
+        aux matchs directement depuis Slack.
+      </p>
+
     </div>
 
   </div>


### PR DESCRIPTION
Deux finitions Slack :
1. Paramètre `?team=<team_id>` sur `/slack/install` pour forcer le workspace ciblé (sinon Slack impose le workspace le plus actif de la session).
2. Page `/profil/integrations` harmonisée avec le thème sombre du site (carte `.match-block`, titre vert, boutons `.btn-cta-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)