### PR TITLE
Slack : partage manuel d'un match depuis sa page

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -8,7 +8,7 @@ class MatchesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   # Retrouver le match avant les actions qui en ont besoin
-  before_action :set_match, only: %i[show edit update destroy calendar make_public]
+  before_action :set_match, only: %i[show edit update destroy calendar make_public share_on_slack]
 
   # GET /matches
   # Deux modes :
@@ -117,6 +117,13 @@ class MatchesController < ApplicationController
 
     # Vérifie si l'utilisateur connecté est déjà inscrit à ce match
     @current_match_user = @match.match_users.find_by(user: current_user)
+
+    # Destinations Slack pour la modale de partage — chargées uniquement pour
+    # l'organisateur lié (chaque entrée déclenche des appels API Slack, inutile
+    # pour un simple visiteur).
+    if @current_match_user&.role == "organisateur" && current_user&.slack_linked?
+      @slack_destinations = slack_destinations_for(current_user)
+    end
 
     # Vérifie si current_user est ami avec l'organisateur (pour afficher l'icône ami)
     if user_signed_in?
@@ -352,6 +359,25 @@ class MatchesController < ApplicationController
     authorize @match
     @match.update!(visibility: "public")
     redirect_to @match, notice: "Le match est maintenant ouvert au public !"
+  end
+
+  # POST /matches/:id/share_on_slack
+  # Partage manuel du match dans une destination Slack — réservé à l'organisateur.
+  # Rattrapage si la case « Partager sur Slack » n'a pas été cochée à la création.
+  # Réutilise le même job que #create ; la destination (channel/DM) et le workspace
+  # sont facultatifs → fallback sur la destination par défaut via ChannelResolver.
+  def share_on_slack
+    authorize @match
+
+    unless current_user.slack_linked?
+      return redirect_to @match, alert: "Ton compte n'est lié à aucun espace Slack."
+    end
+
+    SlackNotifyJob.perform_later("Match", @match.id, current_user.id,
+                                 params[:slack_channel_id].presence,
+                                 params[:slack_workspace_id].presence)
+
+    redirect_to @match, notice: "Match partagé sur Slack 🎉"
   end
 
   # GET /matches/:id/calendar

--- a/app/javascript/controllers/slack_share_controller.js
+++ b/app/javascript/controllers/slack_share_controller.js
@@ -19,8 +19,10 @@ export default class extends Controller {
   }
 
   // Affiche/masque le bloc de destination selon l'état de la case.
+  // En mode standalone (modale de partage), il n'y a pas de case → le bloc reste
+  // toujours visible, on ne touche donc pas à son affichage.
   toggle() {
-    if (!this.hasWrapperTarget) return
+    if (!this.hasWrapperTarget || !this.hasCheckboxTarget) return
     this.wrapperTarget.style.display = this.checkboxTarget.checked ? "block" : "none"
   }
 

--- a/app/policies/match_policy.rb
+++ b/app/policies/match_policy.rb
@@ -25,6 +25,11 @@ class MatchPolicy < ApplicationPolicy
     owner?
   end
 
+  # Seul l'organisateur peut partager son match sur Slack
+  def share_on_slack?
+    owner?
+  end
+
   private
 
   # Vérifie que l'utilisateur connecté est le créateur du match

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -289,6 +289,20 @@
               <i data-lucide="edit-2" style="width:14px;height:14px;"></i>
               Modifier
             <% end %>
+
+            <%# Partage Slack — visible seulement si l'organisateur a lié son compte.
+                Ouvre la modale de choix de destination (#slackShareModal). %>
+            <% if current_user&.slack_linked? %>
+              <button type="button"
+                      class="match-banner-action-btn"
+                      data-bs-toggle="modal"
+                      data-bs-target="#slackShareModal"
+                      title="Partager ce match sur Slack">
+                <%= render "shared/slack_logo", size: 14 %>
+                Partager sur Slack
+              </button>
+            <% end %>
+
             <%# Bouton "Supprimer" → ouvre la modal de confirmation au lieu de supprimer directement %>
             <button type="button"
                     class="match-banner-action-btn match-banner-action-btn--danger"
@@ -1390,6 +1404,59 @@
       </div>
     </div>
   </div>
+  <% end %>
+
+  <%# ── Modale de partage Slack — pour l'organisateur ayant lié son compte ──
+      Réutilise le partial + le contrôleur Stimulus du formulaire de création
+      (sélection workspace → destination), en mode standalone (pas de case). %>
+  <% if current_user&.slack_linked? %>
+    <div class="modal fade" id="slackShareModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content pending-modal-content">
+
+          <%# Croix de fermeture %>
+          <button type="button" class="pending-modal-close" data-bs-dismiss="modal" aria-label="Fermer">
+            <i data-lucide="x" style="width:16px;height:16px;"></i>
+          </button>
+
+          <%# Icône + titre %>
+          <div style="display:flex; justify-content:center; padding-top:8px; padding-bottom:16px;">
+            <div class="pending-modal-icon" style="background:var(--theme-hover-bg);">
+              <%= render "shared/slack_logo", size: 22 %>
+            </div>
+          </div>
+          <div class="pending-modal-title" style="font-size:1.05rem; margin-bottom:8px; text-align:center;">
+            Partager ce match sur Slack
+          </div>
+          <div class="pending-modal-subtitle" style="text-align:center;">
+            Choisis l'espace et la destination (channel ou message direct).
+          </div>
+
+          <div class="pending-modal-divider" style="margin-top:20px;"></div>
+
+          <%= form_with url: share_on_slack_match_path(@match), method: :post do %>
+            <div style="padding: 16px 0 4px; text-align:left;">
+              <%= render "shared/slack_share_field", workspaces: @slack_destinations, standalone: true %>
+            </div>
+            <div class="d-flex gap-3" style="padding: 4px 0;">
+              <button type="submit"
+                      class="btn btn-sm flex-fill"
+                      style="background:rgba(30,221,136,0.12); color:#1EDD88; border:1px solid rgba(30,221,136,0.35);">
+                <i data-lucide="send" style="width:14px;height:14px; vertical-align:-2px;"></i>
+                Partager
+              </button>
+              <button type="button"
+                      class="btn btn-sm flex-fill"
+                      style="background:var(--theme-hover-bg); color:var(--theme-text-muted); border:1px solid var(--theme-border);"
+                      data-bs-dismiss="modal">
+                Annuler
+              </button>
+            </div>
+          <% end %>
+
+        </div>
+      </div>
+    </div>
   <% end %>
 
 <% end %>

--- a/app/views/profils/integrations.html.erb
+++ b/app/views/profils/integrations.html.erb
@@ -22,7 +22,7 @@
 
       <%# En-tête : icône + titre de section vert (.match-block-title) %>
       <div class="match-block-title">
-        <i data-lucide="slack" style="width:20px; height:20px;"></i>
+        <%= render "shared/slack_logo", size: 20 %>
         Slack
       </div>
       <p style="font-size:0.85rem; color:var(--theme-text-muted); margin:-0.5rem 0 1.25rem;">

--- a/app/views/shared/_slack_logo.html.erb
+++ b/app/views/shared/_slack_logo.html.erb
@@ -1,0 +1,14 @@
+<%# ── Logo Slack officiel (mark 4 couleurs), en SVG inline ─────────────────────
+  Vectoriel → net à toutes les tailles, autonome (aucun asset à charger), rend
+  aussi bien en thème clair que sombre. Remplace le picto Lucide "slack".
+  Local :  size (optionnel, défaut 16) — largeur = hauteur en px.
+%>
+<% size = local_assigns.fetch(:size, 16) %>
+<svg width="<%= size %>" height="<%= size %>" viewBox="0 0 122.8 122.8"
+     xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+     style="vertical-align:-2px; flex-shrink:0;">
+  <path fill="#E01E5A" d="M25.8 77.6c0 7.1-5.8 12.9-12.9 12.9S0 84.7 0 77.6s5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V77.6z"/>
+  <path fill="#36C5F0" d="M45.2 25.8c-7.1 0-12.9-5.8-12.9-12.9S38.1 0 45.2 0s12.9 5.8 12.9 12.9v12.9H45.2zm0 6.5c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H12.9C5.8 58.1 0 52.3 0 45.2s5.8-12.9 12.9-12.9h32.3z"/>
+  <path fill="#2EB67D" d="M97 45.2c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9-5.8 12.9-12.9 12.9H97V45.2zm-6.5 0c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V12.9C64.7 5.8 70.5 0 77.6 0s12.9 5.8 12.9 12.9v32.3z"/>
+  <path fill="#ECB22E" d="M77.6 97c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9-12.9-5.8-12.9-12.9V97h12.9zm0-6.5c-7.1 0-12.9-5.8-12.9-12.9s5.8-12.9 12.9-12.9h32.3c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H77.6z"/>
+</svg>

--- a/app/views/shared/_slack_share_field.html.erb
+++ b/app/views/shared/_slack_share_field.html.erb
@@ -1,8 +1,11 @@
-<%# ── Champ de partage Slack (formulaires de création match / tournoi) ────────── %>
+<%# ── Champ de partage Slack (formulaires de création + modale de partage) ────── %>
 <%#
   Locals attendus :
     workspaces : tableau [{ id:, name:, destinations: { "Channels" => [[nom,id]...],
                  "Messages directs" => [[nom,id]...] } }] (peut être vide)
+    standalone : (optionnel, défaut false) mode modale de partage manuel — on omet
+                 la case « Partager sur Slack » (le partage est l'intention explicite)
+                 et la destination reste toujours visible.
   N'affiche rien si l'utilisateur n'a pas lié Slack.
 
   Sélection en DEUX temps :
@@ -14,23 +17,27 @@
   Ce ne sont PAS des attributs du modèle → check_box_tag / select_tag ; les params
   post_to_slack / slack_workspace_id / slack_channel_id sont lus dans le controller.
 %>
+<% standalone = local_assigns.fetch(:standalone, false) %>
 <% if current_user.slack_linked? %>
-  <div class="mb-4"
+  <div class="<%= "mb-4" unless standalone %>"
        data-controller="slack-share"
        data-slack-share-data-value="<%= workspaces.to_json %>">
-    <div class="form-check mb-2">
-      <%= check_box_tag :post_to_slack, "1", false,
-            class: "form-check-input",
-            data: { action: "slack-share#toggle", slack_share_target: "checkbox" } %>
-      <%= label_tag :post_to_slack, class: "form-check-label" do %>
-        <i data-lucide="slack" style="width:16px; height:16px; vertical-align:-3px;"></i>
-        Partager sur Slack à la création
-      <% end %>
-    </div>
+    <% unless standalone %>
+      <div class="form-check mb-2">
+        <%= check_box_tag :post_to_slack, "1", false,
+              class: "form-check-input",
+              data: { action: "slack-share#toggle", slack_share_target: "checkbox" } %>
+        <%= label_tag :post_to_slack, class: "form-check-label" do %>
+          <%= render "shared/slack_logo", size: 16 %>
+          Partager sur Slack à la création
+        <% end %>
+      </div>
+    <% end %>
 
     <% if workspaces.present? %>
-      <%# Masqué tant que la case n'est pas cochée (géré par le Stimulus controller). %>
-      <div data-slack-share-target="wrapper" style="display:none;">
+      <%# En mode formulaire : masqué tant que la case n'est pas cochée (Stimulus).
+          En mode standalone (modale) : toujours visible. %>
+      <div data-slack-share-target="wrapper" style="<%= "display:none;" unless standalone %>">
         <% if workspaces.size > 1 %>
           <div class="mb-2">
             <%= label_tag :slack_workspace_id, "Espace Slack", class: "form-label small text-muted" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,9 @@ Rails.application.routes.draw do
       get :calendar
       # Passe un match privé en public (organisateur uniquement)
       patch :make_public
+      # Partage manuel du match sur Slack (organisateur uniquement) — rattrapage
+      # si la case n'a pas été cochée à la création
+      post :share_on_slack
     end
 
     # Routes imbriquées pour gérer les inscriptions à un match

--- a/test/integration/slack_integration_test.rb
+++ b/test/integration/slack_integration_test.rb
@@ -6,6 +6,7 @@ require "webmock/minitest"
 
 class SlackIntegrationTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
 
   setup do
     @user  = create_test_user(email: "owner@example.com", first_name: "Alice", last_name: "Test")
@@ -98,6 +99,29 @@ class SlackIntegrationTest < ActionDispatch::IntegrationTest
     dest = Slack::ChannelLister.destinations(ws)
     assert_equal [["#general", "C1"]], dest["Channels"]
     assert_equal [["Bob", "U9"]], dest["Messages directs"] # le bot est exclu
+  end
+
+  # ── Partage manuel depuis la page match : organisateur lié → job enqueue ───────
+  test "POST share_on_slack par l'organisateur lié enqueue SlackNotifyJob avec la destination" do
+    ws = link_slack!
+    sign_in @user
+    assert_enqueued_with(job: SlackNotifyJob,
+                         args: ["Match", @match.id, @user.id, "C1", ws.id.to_s]) do
+      post share_on_slack_match_path(@match),
+           params: { slack_channel_id: "C1", slack_workspace_id: ws.id }
+    end
+    assert_redirected_to match_path(@match)
+  end
+
+  # ── Partage manuel : un non-organisateur est refusé et rien n'est enqueue ───────
+  test "POST share_on_slack par un non-organisateur est refusé" do
+    link_slack!
+    intruder = create_test_user(email: "intruder@example.com", first_name: "Eve", last_name: "Test")
+    sign_in intruder
+    assert_no_enqueued_jobs(only: SlackNotifyJob) do
+      post share_on_slack_match_path(@match), params: { slack_channel_id: "C1" }
+    end
+    assert_response :redirect # Pundit → redirect_back avec alerte
   end
 
   # ── Envoi : SlackNotifyJob poste avec le bon token et la bonne destination ─────


### PR DESCRIPTION
## Contexte
PR 4 du plan d'intégration Slack. Rattrapage si l'organisateur a oublié de cocher « Partager sur Slack » à la création — et permet de (re)partager un match plus ancien.

## Changements
- **Action `share_on_slack`** (POST, member) réservée à l'organisateur (`MatchPolicy#share_on_slack?` → `owner?`), qui ré-enqueue le `SlackNotifyJob` déjà utilisé par `#create`.
- **Modale de partage** sur la page match : réutilise le partial `shared/_slack_share_field` + le contrôleur Stimulus `slack-share` (sélection en deux temps workspace → channel/DM) en nouveau **mode `standalone`** (sans case à cocher).
- **Logo Slack officiel** (SVG mark 4 couleurs) dans un partial `shared/_slack_logo`, en remplacement du picto Lucide `slack` (page Intégrations, formulaire de création, page match).
- `@slack_destinations` chargé dans `matches#show` **uniquement pour l'organisateur lié** (évite des appels API Slack pour un simple visiteur).

## Tests
`test/integration/slack_integration_test.rb` — **7 runs, 0 failures** (dont 2 nouveaux : enqueue par l'organisateur / refus d'un non-organisateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)