### PR TITLE
Refacto : extraction MatchEnrollmentService (dérisque l'inscription depuis Slack)

### DIFF
--- a/app/controllers/match_users_controller.rb
+++ b/app/controllers/match_users_controller.rb
@@ -6,39 +6,45 @@ class MatchUsersController < ApplicationController
 
   # POST /matches/:match_id/match_users
   # Rejoindre un match (ou rejoindre la file d'attente si le match est complet)
+  #
+  # La logique métier (dup-check, restriction de genre, décision waiting/pending/
+  # approved sous verrou, notifications) vit dans MatchEnrollmentService pour être
+  # réutilisable hors web (Slack). Le controller garde ce qui est spécifique au web :
+  # l'autorisation Pundit, les broadcasts Turbo temps réel, le flash et le redirect.
   def create
-    # On crée l'inscription avec le message optionnel du joueur
-    @match_user = @match.match_users.new(user: current_user, role: "joueur", message: params[:message].presence)
-    authorize @match_user
+    # Pundit a besoin d'un enregistrement pour résoudre la policy (create? => true).
+    authorize @match.match_users.new(user: current_user, role: "joueur")
 
-    # Vérifie si l'utilisateur est déjà inscrit (peu importe le statut)
-    if @match.match_users.exists?(user: current_user)
+    result = MatchEnrollmentService.new(
+      match: @match, user: current_user, message: params[:message].presence
+    ).call
+
+    # @match_user sert aux broadcasts (auto-join) ci-dessous.
+    @match_user = result.match_user
+
+    case result.status
+    when :already_registered
       redirect_to @match, alert: "Tu es déjà inscrit à ce match."
-      return
-    end
-
-    # ── Vérification de la restriction de genre ───────────────────────────────
-    # Si le match est réservé aux femmes ET que l'utilisateur n'est pas une femme,
-    # on bloque l'inscription avec un message explicatif.
-    # current_user.genre != "femme" inclut aussi les utilisateurs sans genre déclaré (nil).
-    if @match.genre_restriction == "feminin" && current_user.genre != "femme"
+    when :gender_restricted
       redirect_to match_path(@match, **match_redirect_options),
                   alert: "Ce match est réservé aux joueuses. Seules les femmes peuvent s'inscrire."
-      return
-    end
-    # ── Fin vérification genre ────────────────────────────────────────────────
-
-    # On récupère l'organisateur une seule fois pour les notifications
-    organizer = @match.organizer_match_user&.user
-
-    # Redirige vers le bon cas selon l'état du match
-    if @match.full?
-      join_waiting_list(organizer)
-    elsif @match.manual_validation?
-      join_with_manual_validation(organizer)
+    when :waiting
+      redirect_to match_path(@match, **match_redirect_options),
+                  notice: "Le match est complet. Tu as été ajouté à la file d'attente !"
+    when :pending
+      # Broadcast temps réel vers l'organisateur (met à jour #pending_modal_inner
+      # et affiche la notification de nouvelle demande, peu importe sa page).
+      broadcast_pending_modal_to_organizer
+      redirect_to match_path(@match, **match_redirect_options), notice: "Ta demande a été envoyée à l'organisateur !"
+    when :approved
+      # Notifie l'organisateur en temps réel s'il est sur la page du match
+      # (injecte et ouvre #autoJoinModal). AVANT le redirect, qui stoppe le client.
+      broadcast_auto_join_to_organizer
+      # flash[:show_calendar_modal] déclenche la modale "Demande acceptée" (show.html.erb)
+      flash[:show_calendar_modal] = true
+      redirect_to match_path(@match, **match_redirect_options), notice: "Tu as rejoint le match !"
     else
-      # Mode automatique : accepté immédiatement
-      join_automatically(organizer)
+      redirect_to match_path(@match, **match_redirect_options), alert: "Impossible de rejoindre le match."
     end
   end
 
@@ -282,7 +288,7 @@ class MatchUsersController < ApplicationController
   end
 
   # Notifie l'organisateur en temps réel qu'un joueur a rejoint automatiquement.
-  # Appelé depuis join_automatically après le save et le decrement.
+  # Appelé depuis #create (cas :approved) après l'inscription automatique.
   def broadcast_auto_join_to_organizer
     orga = organizer_user
     return unless orga
@@ -346,77 +352,5 @@ class MatchUsersController < ApplicationController
   # Retourne les options de redirect pour le match — inclut le token si match privé
   def match_redirect_options
     @match.private? ? { token: @match.private_token } : {}
-  end
-
-  # Cas 1 : Le match est complet → mise en file d'attente
-  def join_waiting_list(organizer)
-    @match_user.status = "waiting"
-    if @match_user.save
-      notify(organizer, "#{current_user.display_name} s'est inscrit en file d'attente pour \"#{@match.title}\"")
-      # Email transactionnel : informe l'organisateur qu'un joueur est en file d'attente
-      UserMailer.match_joined(@match, current_user, status: "waiting").deliver_later
-      redirect_to match_path(@match, **match_redirect_options),
-                  notice: "Le match est complet. Tu as été ajouté à la file d'attente !"
-    else
-      redirect_to match_path(@match, **match_redirect_options), alert: "Impossible de rejoindre la file d'attente."
-    end
-  end
-
-  # Cas 2 : Validation manuelle → en attente de l'organisateur
-  def join_with_manual_validation(organizer)
-    @match_user.status = "pending"
-    @match_user.save
-    notify(organizer, "#{current_user.display_name} veut rejoindre votre match \"#{@match.title}\"")
-    # Email transactionnel : informe l'organisateur d'une nouvelle demande à traiter
-    UserMailer.match_joined(@match, current_user, status: "pending").deliver_later
-
-    # Broadcast en temps réel vers l'organisateur s'il est sur la page du match.
-    # Met à jour le contenu de #pending_modal_inner et ouvre la modal automatiquement.
-    broadcast_pending_modal_to_organizer
-
-    redirect_to match_path(@match, **match_redirect_options), notice: "Ta demande a été envoyée à l'organisateur !"
-  end
-
-  # Cas 3 : Validation automatique → accepté immédiatement
-  def join_automatically(organizer)
-    status_assigned = nil
-
-    # with_lock ouvre une transaction et pose un SELECT FOR UPDATE sur la ligne du match.
-    # Un seul process à la fois évalue le nombre de confirmés puis inscrit — plus de
-    # race condition. player_left est recalculé par le callback de MatchUser au save.
-    @match.with_lock do
-      if @match.confirmed_players_count >= @match.players_needed.to_i
-        # La place a été prise par un autre joueur entre le check initial (create) et maintenant
-        @match_user.status = "waiting"
-        @match_user.save
-        status_assigned = :waiting
-      else
-        @match_user.status = "approved"
-        status_assigned = @match_user.save ? :approved : :error
-      end
-    end
-
-    case status_assigned
-    when :waiting
-      notify(organizer, "#{current_user.display_name} s'est inscrit en file d'attente pour \"#{@match.title}\"")
-      UserMailer.match_joined(@match, current_user, status: "waiting").deliver_later
-      redirect_to match_path(@match, **match_redirect_options),
-                  notice: "Le match est complet. Tu as été ajouté à la file d'attente !"
-    when :approved
-      notify(organizer, "#{current_user.display_name} a rejoint votre match \"#{@match.title}\"")
-      # Email transactionnel : informe l'organisateur qu'un joueur a rejoint automatiquement
-      UserMailer.match_joined(@match, current_user, status: "approved").deliver_later
-
-      # Notifie l'organisateur en temps réel s'il est sur la page du match.
-      # Injecte la modal #autoJoinModal dans son navigateur et l'ouvre automatiquement.
-      # Doit être appelé AVANT redirect_to (le redirect stoppe l'exécution côté client).
-      broadcast_auto_join_to_organizer
-
-      # flash[:show_calendar_modal] déclenche la modale "Demande acceptée" dans show.html.erb
-      flash[:show_calendar_modal] = true
-      redirect_to match_path(@match, **match_redirect_options), notice: "Tu as rejoint le match !"
-    else
-      redirect_to match_path(@match, **match_redirect_options), alert: "Impossible de rejoindre le match."
-    end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@
 class UserMailer < ApplicationMailer
   # ── 1. Un joueur a rejoint ton match ──────────────────────────────────────
   # Destinataire : l'organisateur du match
-  # Déclenché    : join_automatically, join_with_manual_validation, join_waiting_list
+  # Déclenché    : MatchEnrollmentService (cas approved / pending / waiting)
   #
   # @param match        [Match] le match concerné
   # @param joining_user [User]  le joueur qui vient de s'inscrire

--- a/app/services/match_enrollment_service.rb
+++ b/app/services/match_enrollment_service.rb
@@ -1,0 +1,121 @@
+# ── Service MatchEnrollmentService ────────────────────────────────────────────
+# Encapsule TOUTE la logique métier d'inscription d'un joueur à un match, extraite
+# de MatchUsersController#create afin de pouvoir la réutiliser depuis un autre
+# point d'entrée (notamment l'inscription déclenchée depuis Slack — cf. PR 6).
+#
+# Responsabilités du service (métier pur, sans HTTP) :
+#   - refus si déjà inscrit / si restriction de genre non respectée ;
+#   - décision waiting / pending / approved selon l'état du match, avec le même
+#     verrou `with_lock` (SELECT FOR UPDATE) que l'original pour éviter les races ;
+#   - création de la notification in-app à l'organisateur + email transactionnel.
+#
+# Ce qui reste au controller (dépend du contexte web) : `authorize`, les
+# broadcasts Turbo temps réel, le flash et les redirections. Le controller mappe
+# simplement `result.status` vers la bonne réponse.
+#
+# Utilisation :
+#   result = MatchEnrollmentService.new(match: @match, user: current_user,
+#                                       message: params[:message].presence).call
+#   result.status # => :approved | :waiting | :pending
+#                 #    | :already_registered | :gender_restricted | :error
+class MatchEnrollmentService
+  # Les helpers de routes (match_path) ne sont pas disponibles par défaut hors
+  # controller/vue → on les inclut pour construire le lien de la notification.
+  include Rails.application.routes.url_helpers
+
+  # Résultat de la tentative. `match_user` est l'inscription créée (nil pour les
+  # refus en amont : déjà inscrit / genre).
+  Result = Struct.new(:status, :match_user, keyword_init: true)
+
+  def initialize(match:, user:, message: nil)
+    @match   = match
+    @user    = user
+    @message = message
+  end
+
+  def call
+    # Déjà inscrit (peu importe le statut) → refus.
+    return Result.new(status: :already_registered) if @match.match_users.exists?(user: @user)
+
+    # Match réservé aux joueuses : un non-femme (genre nil inclus) est bloqué.
+    return Result.new(status: :gender_restricted) if gender_blocked?
+
+    @match_user = @match.match_users.new(user: @user, role: "joueur", message: @message)
+    @organizer  = @match.organizer_match_user&.user
+
+    if @match.full?
+      enroll_waiting_list
+    elsif @match.manual_validation?
+      enroll_manual
+    else
+      enroll_automatic
+    end
+  end
+
+  private
+
+  def gender_blocked?
+    @match.genre_restriction == "feminin" && @user.genre != "femme"
+  end
+
+  # Cas 1 : match complet → file d'attente.
+  def enroll_waiting_list
+    @match_user.status = "waiting"
+    return Result.new(status: :error, match_user: @match_user) unless @match_user.save
+
+    notify(@organizer, "#{@user.display_name} s'est inscrit en file d'attente pour \"#{@match.title}\"")
+    UserMailer.match_joined(@match, @user, status: "waiting").deliver_later
+    Result.new(status: :waiting, match_user: @match_user)
+  end
+
+  # Cas 2 : validation manuelle → en attente de l'organisateur.
+  # (Comme dans l'original, on ne traite pas l'échec de save ici.)
+  def enroll_manual
+    @match_user.status = "pending"
+    @match_user.save
+    notify(@organizer, "#{@user.display_name} veut rejoindre votre match \"#{@match.title}\"")
+    UserMailer.match_joined(@match, @user, status: "pending").deliver_later
+    Result.new(status: :pending, match_user: @match_user)
+  end
+
+  # Cas 3 : validation automatique → accepté immédiatement, sauf si la dernière
+  # place vient d'être prise (recheck sous verrou).
+  def enroll_automatic
+    status_assigned = nil
+
+    # with_lock : SELECT FOR UPDATE sur la ligne du match — un seul process évalue
+    # le nombre de confirmés puis inscrit, éliminant la race condition. player_left
+    # est recalculé par le callback de MatchUser au save.
+    @match.with_lock do
+      if @match.confirmed_players_count >= @match.players_needed.to_i
+        # Place prise entre le check initial et maintenant → file d'attente.
+        @match_user.status = "waiting"
+        @match_user.save
+        status_assigned = :waiting
+      else
+        @match_user.status = "approved"
+        status_assigned = @match_user.save ? :approved : :error
+      end
+    end
+
+    case status_assigned
+    when :waiting
+      notify(@organizer, "#{@user.display_name} s'est inscrit en file d'attente pour \"#{@match.title}\"")
+      UserMailer.match_joined(@match, @user, status: "waiting").deliver_later
+      Result.new(status: :waiting, match_user: @match_user)
+    when :approved
+      notify(@organizer, "#{@user.display_name} a rejoint votre match \"#{@match.title}\"")
+      UserMailer.match_joined(@match, @user, status: "approved").deliver_later
+      Result.new(status: :approved, match_user: @match_user)
+    else
+      Result.new(status: :error, match_user: @match_user)
+    end
+  end
+
+  # Notification in-app à un utilisateur (rien si nil, ex. organisateur introuvable).
+  def notify(user, message)
+    return unless user
+
+    Notification.create(user: user, message: message, link: match_path(@match))
+  end
+end

--- a/app/views/match_users/_auto_join_notification.html.erb
+++ b/app/views/match_users/_auto_join_notification.html.erb
@@ -1,6 +1,6 @@
 <%# Modal de notification "un joueur a rejoint automatiquement" pour l'organisateur.
     Injectée dans #global_notification_container en temps réel via Turbo Stream
-    (broadcast depuis MatchUsersController#join_automatically).
+    (broadcast depuis MatchUsersController#create, cas :approved).
     Variables attendues : joining_user (User), match, match_user (MatchUser) %>
 
 <%# data-auto-open / data-redirect-url : ouverture et redirection gérées par application.html.erb %>

--- a/app/views/match_users/_new_request_notification.html.erb
+++ b/app/views/match_users/_new_request_notification.html.erb
@@ -1,6 +1,6 @@
 <%# Modal de notification "nouvelle demande manuelle" pour l'organisateur.
     Injectée dans #global_notification_container en temps réel via Turbo Stream
-    (broadcast depuis MatchUsersController#join_with_manual_validation).
+    (broadcast depuis MatchUsersController#create, cas :pending).
     Affiche directement la liste des joueurs en attente avec boutons accepter/refuser.
     Variables attendues : match (Match), pending_users (collection MatchUser avec user:profil) %>
 

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1564,7 +1564,7 @@
 
 <%# ══════════════════════════════════════════════════
     MODAL "DEMANDE ACCEPTÉE" — affiché automatiquement après avoir rejoint
-    Déclenché par flash[:show_calendar_modal] (posé par join_automatically)
+    Déclenché par flash[:show_calendar_modal] (posé dans MatchUsersController#create, cas :approved)
     Contient un bouton pour ajouter le match à un calendrier externe
     ══════════════════════════════════════════════════ %>
 <% if flash[:show_calendar_modal] && @match.date.present? && @match.time.present? %>

--- a/test/services/match_enrollment_service_test.rb
+++ b/test/services/match_enrollment_service_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+# Tests unitaires de MatchEnrollmentService : la logique métier d'inscription
+# extraite de MatchUsersController#create. Couvre tous les cas de retour.
+class MatchEnrollmentServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @organizer = create_test_user(email: "orga-mes@test.fr", first_name: "Orga", last_name: "T")
+    @player    = create_test_user(email: "player-mes@test.fr", first_name: "Joueur", last_name: "T")
+    @sport     = Sport.create!(name: "Foot MES", slug: "foot-mes-#{SecureRandom.hex(3)}", icon: "⚽")
+  end
+
+  teardown { teardown_db }
+
+  # Fabrique un match avec son organisateur inscrit.
+  def build_match(validation_mode: "automatic", players_needed: 4, genre_restriction: "tous")
+    match = Match.create!(
+      title: "M-#{SecureRandom.hex(3)}", date: Date.tomorrow,
+      time: Time.current.change(hour: 18, min: 0),
+      players_needed: players_needed, level: "Débutant", visibility: "public",
+      validation_mode: validation_mode, genre_restriction: genre_restriction,
+      user: @organizer, sport: @sport
+    )
+    match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+    match
+  end
+
+  def enroll(match, user, message: nil)
+    MatchEnrollmentService.new(match: match, user: user, message: message).call
+  end
+
+  # ── Mode automatique, place disponible → approved ──────────────────────────
+  test "mode automatique avec place → approved et inscription créée" do
+    match = build_match
+    result = enroll(match, @player)
+
+    assert_equal :approved, result.status
+    assert_equal "approved", match.match_users.find_by(user: @player).status
+  end
+
+  # ── Mode manuel → pending ──────────────────────────────────────────────────
+  test "mode manuel → pending" do
+    match = build_match(validation_mode: "manual")
+    result = enroll(match, @player)
+
+    assert_equal :pending, result.status
+    assert_equal "pending", match.match_users.find_by(user: @player).status
+  end
+
+  # ── Match complet → waiting ────────────────────────────────────────────────
+  test "match complet → waiting" do
+    match = build_match(players_needed: 1) # place unique
+    match.match_users.create!(user: create_test_user(email: "occ@test.fr"), role: "joueur", status: "approved")
+
+    result = enroll(match, @player)
+    assert_equal :waiting, result.status
+    assert_equal "waiting", match.match_users.find_by(user: @player).status
+  end
+
+  # ── Déjà inscrit → refus, aucune création ──────────────────────────────────
+  test "déjà inscrit → already_registered sans nouvelle inscription" do
+    match = build_match
+    match.match_users.create!(user: @player, role: "joueur", status: "approved")
+
+    assert_no_difference "MatchUser.count" do
+      assert_equal :already_registered, enroll(match, @player).status
+    end
+  end
+
+  # ── Restriction de genre : un non-femme est refusé ─────────────────────────
+  test "match féminin + user non-femme → gender_restricted sans inscription" do
+    match = build_match(genre_restriction: "feminin")
+
+    assert_no_difference "MatchUser.count" do
+      assert_equal :gender_restricted, enroll(match, @player).status
+    end
+  end
+
+  # ── Restriction de genre : une femme est acceptée ──────────────────────────
+  test "match féminin + user femme → approved" do
+    @player.update_column(:genre, "femme")
+    match = build_match(genre_restriction: "feminin")
+
+    assert_equal :approved, enroll(match, @player).status
+  end
+
+  # ── L'organisateur reçoit une notification in-app + un email ───────────────
+  test "l'inscription notifie l'organisateur (in-app + email)" do
+    match = build_match
+    assert_difference -> { Notification.where(user: @organizer).count }, 1 do
+      assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+        enroll(match, @player)
+      end
+    end
+  end
+
+  # ── Le message optionnel du joueur est bien persisté ───────────────────────
+  test "le message du joueur est enregistré sur l'inscription" do
+    match = build_match(validation_mode: "manual")
+    enroll(match, @player, message: "Salut, je peux jouer gardien")
+
+    assert_equal "Salut, je peux jouer gardien", match.match_users.find_by(user: @player).message
+  end
+end


### PR DESCRIPTION
## Objectif
Extraire la logique métier d'inscription à un match de `MatchUsersController#create` vers un service `MatchEnrollmentService`, **à ISO-comportement**. Refacto préparatoire à l'inscription depuis Slack (PR 6), qui réutilisera ce service hors contexte web.

## Ce que le service encapsule
- dup-check (déjà inscrit)
- restriction de genre (match féminin)
- décision **waiting / pending / approved** avec le même verrou `with_lock` (SELECT FOR UPDATE) que l'original
- notification in-app à l'organisateur + email transactionnel

Retourne un `Result` avec `status ∈ {approved, waiting, pending, already_registered, gender_restricted, error}`.

## Ce qui reste au controller (spécifique web)
`authorize` (Pundit), broadcasts Turbo temps réel (auto-join / pending modal), `flash` et `redirect`. Le controller mappe simplement `result.status`.

## Note (consolidation mineure, chemin non atteignable)
Les deux messages d'erreur distincts de l'original en cas d'échec de `save` ("Impossible de rejoindre la file d'attente." vs "...le match.") sont unifiés en un seul (`:error` → "Impossible de rejoindre le match."). Ce chemin requiert l'échec d'un `save` sur un enregistrement valide → inatteignable en pratique.

## Tests
- ✅ 26 tests de non-régression (`match_users_controller_test` + `match_user_policy_test`) — inchangés, toujours verts
- ✅ 8 nouveaux tests unitaires `MatchEnrollmentService` (tous les cas de retour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)