### PR TITLE
Fix design modale de partage Slack (contraste + espacement)

### DIFF
--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1435,10 +1435,10 @@
           <div class="pending-modal-divider" style="margin-top:20px;"></div>
 
           <%= form_with url: share_on_slack_match_path(@match), method: :post do %>
-            <div style="padding: 16px 0 4px; text-align:left;">
+            <div style="padding: 16px 0 8px; text-align:left;">
               <%= render "shared/slack_share_field", workspaces: @slack_destinations, standalone: true %>
             </div>
-            <div class="d-flex gap-3" style="padding: 4px 0;">
+            <div class="d-flex gap-3" style="margin-top: 20px;">
               <button type="submit"
                       class="btn btn-sm flex-fill"
                       style="background:rgba(30,221,136,0.12); color:#1EDD88; border:1px solid rgba(30,221,136,0.35);">

--- a/app/views/shared/_slack_share_field.html.erb
+++ b/app/views/shared/_slack_share_field.html.erb
@@ -40,7 +40,9 @@
       <div data-slack-share-target="wrapper" style="<%= "display:none;" unless standalone %>">
         <% if workspaces.size > 1 %>
           <div class="mb-2">
-            <%= label_tag :slack_workspace_id, "Espace Slack", class: "form-label small text-muted" %>
+            <%# Couleur theme-aware (pas le .text-muted fixe de Bootstrap, illisible sur fond sombre) %>
+            <%= label_tag :slack_workspace_id, "Espace Slack",
+                  class: "form-label small", style: "color: var(--theme-text-muted);" %>
             <%= select_tag :slack_workspace_id,
                   options_for_select(workspaces.map { |w| [w[:name], w[:id]] }),
                   class: "form-select",
@@ -52,7 +54,8 @@
                 data: { slack_share_target: "workspace" } %>
         <% end %>
 
-        <%= label_tag :slack_channel_id, "Destination (channel ou message direct)", class: "form-label small text-muted" %>
+        <%= label_tag :slack_channel_id, "Destination (channel ou message direct)",
+              class: "form-label small", style: "color: var(--theme-text-muted);" %>
         <%= select_tag :slack_channel_id, "",
               include_blank: "Ma destination par défaut",
               class: "form-select",


### PR DESCRIPTION
## Problème
Sur la modale « Partager ce match sur Slack », le label **Destination** (et Espace Slack) était quasi illisible : il utilisait la classe `.text-muted` **de Bootstrap** (gris fixe `#6c757d`), qui ne s'adapte pas au thème alors que la modale (`.pending-modal-content`) est theme-aware. Sur fond sombre, le label restait terne/olive.

## Correctif
- Labels du partial `_slack_share_field` → `color: var(--theme-text-muted)` (lisible en thème clair **et** sombre, comme le sous-titre de la modale).
- Espacement : plus d'air entre le select de destination et les boutons Partager/Annuler.

Aucune régression logique — 7 tests d'intégration Slack verts (le partial est rendu via `GET /matches/new`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)