### PR TITLE
Slack : inscription à un match depuis le bouton « S'inscrire »

### DIFF
--- a/app/controllers/concerns/slack_request_verification.rb
+++ b/app/controllers/concerns/slack_request_verification.rb
@@ -1,0 +1,43 @@
+# Vérifie l'authenticité des requêtes ENTRANTES de Slack (interactivity, slash
+# commands, events). C'est LA protection de ces endpoints : ils sont publics (pas
+# de session, pas de CSRF token), donc on s'assure que la requête vient bien de
+# Slack via la signature HMAC signée avec le Signing Secret de l'app.
+#
+# Algorithme officiel Slack :
+#   base      = "v0:{timestamp}:{corps brut exact de la requête}"
+#   signature = "v0=" + HMAC_SHA256(signing_secret, base)  (en hexadécimal)
+# puis comparaison en temps constant avec l'en-tête X-Slack-Signature.
+#
+# Deux pièges couverts :
+#   - le corps doit être le RAW body exact (request.raw_post), pas les params reparsés ;
+#   - anti-replay : on rejette au-delà de 5 min d'écart (une signature interceptée
+#     ne peut pas être rejouée indéfiniment).
+module SlackRequestVerification
+  extend ActiveSupport::Concern
+
+  # Écart maximal toléré entre l'horodatage de la requête et maintenant (secondes).
+  MAX_TIMESTAMP_SKEW = 5 * 60
+
+  private
+
+  def verify_slack_signature!
+    secret = Slack.signing_secret
+    # Sans secret configuré, on ne PEUT pas vérifier → on refuse (fail-closed).
+    return head :unauthorized if secret.blank?
+
+    timestamp = request.headers["X-Slack-Request-Timestamp"].to_s
+    signature = request.headers["X-Slack-Signature"].to_s
+    return head :unauthorized if timestamp.blank? || signature.blank?
+
+    # Anti-replay : rejette les requêtes trop anciennes ou aux horodatages aberrants.
+    return head :unauthorized if (Time.now.to_i - timestamp.to_i).abs > MAX_TIMESTAMP_SKEW
+
+    base     = "v0:#{timestamp}:#{request.raw_post}"
+    expected = "v0=" + OpenSSL::HMAC.hexdigest("SHA256", secret, base)
+
+    # Comparaison en temps constant (évite les attaques temporelles).
+    return if ActiveSupport::SecurityUtils.secure_compare(expected, signature)
+
+    head :unauthorized
+  end
+end

--- a/app/controllers/slack/base_controller.rb
+++ b/app/controllers/slack/base_controller.rb
@@ -1,0 +1,17 @@
+# Contrôleur de base pour les endpoints ENTRANTS de Slack (interactivity, commands,
+# events). Volontairement PAS un ApplicationController :
+#   - pas de Devise (Slack n'a pas de session Teams-up ; l'identité est résolue via
+#     SlackIdentity à partir du team_id/user_id signés) ;
+#   - pas de Pundit (le `after_action :verify_authorized` d'ApplicationController
+#     lèverait sur ces endpoints sans `authorize`) ;
+#   - pas de protection CSRF par token (Slack ne peut pas en fournir) → on la
+#     désactive et on la remplace par la vérification de signature HMAC.
+module Slack
+  class BaseController < ActionController::Base
+    # Slack poste sans token CSRF → on désactive la protection par formulaire…
+    skip_forgery_protection
+    # …et on la remplace par la vérification de la signature Slack sur chaque requête.
+    include SlackRequestVerification
+    before_action :verify_slack_signature!
+  end
+end

--- a/app/controllers/slack/interactivity_controller.rb
+++ b/app/controllers/slack/interactivity_controller.rb
@@ -1,0 +1,42 @@
+# Reçoit les interactions Slack (clics sur les boutons Block Kit).
+# Aujourd'hui : le bouton « S'inscrire » (action_id "match_join") posté par
+# Slack::BlockKitBuilder#match_created_blocks.
+#
+# Slack envoie un POST form-urlencoded avec un champ `payload` = JSON, et attend
+# une réponse HTTP en MOINS DE 3 SECONDES. On se contente donc d'ACK immédiatement
+# (head :ok) et on délègue le vrai travail (résolution d'identité + inscription +
+# message de confirmation éphémère) à SlackEnrollJob, qui répondra via `response_url`.
+#
+# La signature est vérifiée en amont par Slack::BaseController.
+module Slack
+  class InteractivityController < Slack::BaseController
+    def create
+      payload = parse_payload
+      return head :ok unless payload
+
+      # On ne traite que les clics de bouton pour l'instant.
+      return head :ok unless payload["type"] == "block_actions"
+
+      action = Array(payload["actions"]).find { |a| a["action_id"] == "match_join" }
+      return head :ok unless action
+
+      SlackEnrollJob.perform_later(
+        match_id:      action["value"],
+        team_id:       payload.dig("team", "id"),
+        slack_user_id: payload.dig("user", "id"),
+        response_url:  payload["response_url"]
+      )
+
+      head :ok
+    end
+
+    private
+
+    # Le payload interactif arrive dans le champ de formulaire `payload` (JSON).
+    def parse_payload
+      JSON.parse(params[:payload].to_s)
+    rescue JSON::ParserError
+      nil
+    end
+  end
+end

--- a/app/jobs/slack_enroll_job.rb
+++ b/app/jobs/slack_enroll_job.rb
@@ -1,0 +1,54 @@
+# Traite en arrière-plan un clic « S'inscrire » venu de Slack (bouton Block Kit).
+# Découplé du controller pour tenir la fenêtre de 3 s imposée par Slack : l'endpoint
+# ACK immédiatement, ce job fait le vrai travail puis répond via `response_url`.
+#
+# Étapes :
+#   1. résoudre l'identité Slack (team_id + user_id) → un compte Teams-up lié ;
+#      si non lié → message éphémère invitant à lier son compte (avec le lien) ;
+#   2. sinon, inscrire via MatchEnrollmentService (même logique que le web) ;
+#   3. renvoyer un message éphémère de confirmation adapté au résultat.
+class SlackEnrollJob < ApplicationJob
+  queue_as :default
+
+  # L'inscription ne dépend d'aucun objet susceptible de disparaître entre l'enqueue
+  # et l'exécution : on gère explicitement le match absent (ci-dessous), pas via discard.
+
+  def perform(match_id:, team_id:, slack_user_id:, response_url:)
+    return if response_url.blank?
+
+    identity = SlackIdentity.for_slack(team_id: team_id, user_id: slack_user_id)
+    return respond(response_url, link_account_message) unless identity
+
+    match = Match.find_by(id: match_id)
+    return respond(response_url, "Ce match n'existe plus. 🙁") unless match
+
+    result = MatchEnrollmentService.new(match: match, user: identity.user).call
+    respond(response_url, message_for(result.status, match))
+  end
+
+  private
+
+  # Poste un message éphémère (visible du seul cliqueur) via la response_url.
+  def respond(response_url, text)
+    Slack::ApiClient.post_response_url(response_url, response_type: "ephemeral", text: text)
+  end
+
+  # Invitation à lier son compte (URL absolue : le job n'a pas de `request`).
+  def link_account_message
+    url = Rails.application.routes.url_helpers.slack_connect_url
+    "Pour t'inscrire depuis Slack, lie d'abord ton compte Teams-up : #{url}"
+  end
+
+  # Message de confirmation adapté au résultat de l'inscription.
+  def message_for(status, match)
+    title = match.title
+    case status
+    when :approved            then "✅ Tu es inscrit au match « #{title} » !"
+    when :waiting             then "⏳ Le match « #{title} » est complet — tu es sur la liste d'attente."
+    when :pending             then "📨 Ta demande pour « #{title} » a été envoyée à l'organisateur."
+    when :already_registered  then "Tu es déjà inscrit au match « #{title} »."
+    when :gender_restricted   then "Le match « #{title} » est réservé aux joueuses."
+    else                           "Impossible de t'inscrire pour le moment. Réessaie plus tard."
+    end
+  end
+end

--- a/app/services/slack/api_client.rb
+++ b/app/services/slack/api_client.rb
@@ -42,6 +42,23 @@ module Slack
       execute(uri, request)
     end
 
+    # POST JSON vers une `response_url` Slack (fournie dans un payload interactif).
+    # Ces URLs sont à usage unique et DÉJÀ authentifiées par un jeton intégré à l'URL :
+    # ni Bearer, ni vérification de `ok` (Slack répond par un simple 200). On renvoie
+    # la réponse brute Net::HTTP sans la parser.
+    def self.post_response_url(url, payload)
+      uri = URI(url)
+      request = Net::HTTP::Post.new(uri)
+      request["Content-Type"] = "application/json; charset=utf-8"
+      request.body = payload.to_json
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+      http.request(request)
+    end
+
     # Exécute la requête, parse le JSON et lève Error si `ok` est faux.
     def self.execute(uri, request)
       http = Net::HTTP.new(uri.host, uri.port)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,8 @@ Rails.application.routes.draw do
     get "connect",         to: "connections#connect"
     get "connect/callback", to: "connections#callback"
     delete "disconnect/:id", to: "connections#destroy", as: :disconnect
+    # Interactions Block Kit (clic « S'inscrire ») — signature HMAC vérifiée, pas de CSRF.
+    post "interactivity",  to: "interactivity#create"
   end
 
   # Profil public d'un autre utilisateur

--- a/test/integration/slack_interactivity_test.rb
+++ b/test/integration/slack_interactivity_test.rb
@@ -1,0 +1,142 @@
+# Tests de l'inscription depuis Slack (PR 6) :
+#   - vérification de signature HMAC de l'endpoint /slack/interactivity ;
+#   - enqueue de SlackEnrollJob sur un clic « S'inscrire » valide ;
+#   - logique du job (compte non lié → invitation à lier ; compte lié → inscription).
+require "test_helper"
+require "webmock/minitest"
+
+class SlackInteractivityTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  SIGNING_SECRET = "test_signing_secret"
+  RESPONSE_URL   = "https://hooks.slack.com/actions/T_TEST/123/abc"
+
+  setup do
+    # L'endpoint refuse tout si le secret n'est pas configuré → on en pose un de test.
+    @previous_secret = ENV["SLACK_SIGNING_SECRET"]
+    ENV["SLACK_SIGNING_SECRET"] = SIGNING_SECRET
+
+    @organizer = create_test_user(email: "orga-si@test.fr", first_name: "Orga", last_name: "T")
+    @joiner    = create_test_user(email: "joiner-si@test.fr", first_name: "Joe", last_name: "T")
+    @sport     = Sport.create!(name: "Foot SI", slug: "foot-si-#{SecureRandom.hex(3)}", icon: "⚽")
+    @match = Match.create!(
+      title: "Match SI", date: Date.tomorrow, time: Time.current.change(hour: 18, min: 0),
+      players_needed: 4, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @organizer, sport: @sport
+    )
+    @match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+
+    @workspace = SlackWorkspace.create!(team_id: "T_TEST", team_name: "Acme", bot_token: "xoxb-test")
+  end
+
+  teardown do
+    ENV["SLACK_SIGNING_SECRET"] = @previous_secret
+    SlackIdentity.delete_all
+    SlackWorkspace.delete_all
+    teardown_db
+  end
+
+  # Relie @joiner au workspace de test.
+  def link_joiner!
+    SlackIdentity.create!(user: @joiner, slack_workspace: @workspace,
+                          slack_user_id: "U_JOINER", slack_team_id: "T_TEST")
+  end
+
+  # Payload block_actions "match_join" tel que Slack l'envoie.
+  def join_payload(match_id: @match.id, user_id: "U_JOINER", team_id: "T_TEST")
+    {
+      "type" => "block_actions",
+      "team" => { "id" => team_id },
+      "user" => { "id" => user_id },
+      "response_url" => RESPONSE_URL,
+      "actions" => [{ "action_id" => "match_join", "value" => match_id.to_s }]
+    }
+  end
+
+  # POST signé sur /slack/interactivity (corps form-urlencoded exact + signature v0).
+  def signed_post(payload, secret: SIGNING_SECRET, timestamp: Time.now.to_i, signature: nil)
+    body = "payload=#{CGI.escape(payload.to_json)}"
+    signature ||= "v0=" + OpenSSL::HMAC.hexdigest("SHA256", secret.to_s, "v0:#{timestamp}:#{body}")
+    post slack_interactivity_path, params: body,
+         headers: {
+           "CONTENT_TYPE"              => "application/x-www-form-urlencoded",
+           "X-Slack-Request-Timestamp" => timestamp.to_s,
+           "X-Slack-Signature"         => signature
+         }
+  end
+
+  # ── Signature ────────────────────────────────────────────────────────────────
+  test "signature valide + match_join → 200 et SlackEnrollJob enqueue" do
+    assert_enqueued_with(job: SlackEnrollJob) do
+      signed_post(join_payload)
+    end
+    assert_response :ok
+  end
+
+  test "signature invalide → 401 et aucun job" do
+    assert_no_enqueued_jobs(only: SlackEnrollJob) do
+      signed_post(join_payload, signature: "v0=deadbeef")
+    end
+    assert_response :unauthorized
+  end
+
+  test "horodatage expiré (> 5 min) → 401 (anti-replay)" do
+    assert_no_enqueued_jobs(only: SlackEnrollJob) do
+      signed_post(join_payload, timestamp: 10.minutes.ago.to_i)
+    end
+    assert_response :unauthorized
+  end
+
+  test "sans SLACK_SIGNING_SECRET configuré → 401 (fail-closed)" do
+    ENV["SLACK_SIGNING_SECRET"] = nil
+    assert_no_enqueued_jobs(only: SlackEnrollJob) do
+      # On signe avec un secret quelconque : peu importe, le serveur refuse d'emblée.
+      signed_post(join_payload, secret: "whatever")
+    end
+    assert_response :unauthorized
+  end
+
+  test "payload non block_actions → 200 sans job" do
+    assert_no_enqueued_jobs(only: SlackEnrollJob) do
+      signed_post({ "type" => "shortcut" })
+    end
+    assert_response :ok
+  end
+
+  # ── Job : compte lié → inscription réelle ──────────────────────────────────────
+  test "SlackEnrollJob avec compte lié inscrit le joueur et répond en éphémère" do
+    link_joiner!
+    stub = stub_request(:post, RESPONSE_URL).to_return(status: 200, body: "ok")
+
+    assert_difference -> { @match.match_users.where(user: @joiner).count }, 1 do
+      SlackEnrollJob.perform_now(match_id: @match.id, team_id: "T_TEST",
+                                 slack_user_id: "U_JOINER", response_url: RESPONSE_URL)
+    end
+    assert_equal "approved", @match.match_users.find_by(user: @joiner).status
+    assert_requested(:post, RESPONSE_URL) { |req| JSON.parse(req.body)["text"].include?("inscrit") }
+  end
+
+  # ── Job : compte NON lié → invitation à lier, aucune inscription ───────────────
+  test "SlackEnrollJob sans compte lié invite à lier et n'inscrit personne" do
+    stub = stub_request(:post, RESPONSE_URL).to_return(status: 200, body: "ok")
+
+    assert_no_difference "MatchUser.count" do
+      SlackEnrollJob.perform_now(match_id: @match.id, team_id: "T_TEST",
+                                 slack_user_id: "U_INCONNU", response_url: RESPONSE_URL)
+    end
+    assert_requested(:post, RESPONSE_URL) { |req| JSON.parse(req.body)["text"].include?("lie") }
+  end
+
+  # ── Job : match introuvable → message dédié, aucune inscription ────────────────
+  test "SlackEnrollJob sur un match supprimé répond sans planter" do
+    link_joiner!
+    stub = stub_request(:post, RESPONSE_URL).to_return(status: 200, body: "ok")
+
+    assert_no_difference "MatchUser.count" do
+      SlackEnrollJob.perform_now(match_id: 0, team_id: "T_TEST",
+                                 slack_user_id: "U_JOINER", response_url: RESPONSE_URL)
+    end
+    assert_requested(:post, RESPONSE_URL) { |req| JSON.parse(req.body)["text"].include?("n'existe plus") }
+  end
+end


### PR DESCRIPTION
## Objectif
Permettre à un membre d'un espace Slack de **s'inscrire à un match** en cliquant sur le bouton « S'inscrire » du message Block Kit (posté par PR 3/4). Réutilise `MatchEnrollmentService` (PR 5) → même logique que le web.

## Sécurité (endpoint public)
- **`SlackRequestVerification`** (concern) : vérif de la signature HMAC officielle `v0={hex}` sur `v0:{timestamp}:{raw_body}`, comparaison en **temps constant**, **anti-replay** (rejet > 5 min), **fail-closed** si `SLACK_SIGNING_SECRET` absent.
- **`Slack::BaseController < ActionController::Base`** : pas de Devise, pas de Pundit (évite `verify_authorized`), CSRF token désactivé — la signature remplace le CSRF.

## Flux
1. `Slack::InteractivityController#create` : **ACK en < 3 s** (contrainte Slack), délègue à un job.
2. `SlackEnrollJob` : résout `SlackIdentity.for_slack(team, user)`.
   - **non lié** → message éphémère invitant à lier son compte (avec lien `/slack/connect`), aucune inscription.
   - **lié** → `MatchEnrollmentService` puis confirmation éphémère adaptée (inscrit / liste d'attente / demande envoyée / déjà inscrit / réservé aux joueuses).
   - **match supprimé** → message dédié, pas de crash.
3. `ApiClient#post_response_url` : POST JSON vers la `response_url` (pré-authentifiée, sans Bearer ni vérif `ok`).

## Tests (8)
Signature valide → 200 + job enqueue ; signature invalide / horodatage expiré / secret absent → 401 ; payload non `block_actions` → 200 sans job ; job avec compte lié (inscription réelle + éphémère), sans compte lié (invitation), match absent.

## Prérequis Slack (hors code)
Renseigner l'**Interactivity Request URL** de l'app Slack : `https://<host>/slack/interactivity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)