### PR TITLE
Fix : saut de page à l'ouverture des modales (scrollbar-gutter)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -111,6 +111,23 @@ body {
   }
 }
 
+// ── Réserve la gouttière de scrollbar verticale ─────────────────────────────
+// Empêche le "saut" de la page à l'ouverture d'une modale Bootstrap : quand la
+// modale pose overflow:hidden sur le body, la scrollbar verticale disparaît et,
+// sans réservation, la largeur du contenu s'élargit brusquement (~15px).
+// `scrollbar-gutter: stable` réserve cet espace en PERMANENCE côté navigateur :
+//   - scrollbars classiques (Windows, Firefox, macOS « toujours afficher ») →
+//     gouttière toujours présente, donc aucun reflow quand la scrollbar est masquée ;
+//   - scrollbars overlay (macOS par défaut) → aucune gouttière et aucun saut
+//     (l'overlay ne prend jamais de place dans le layout) : la règle est neutre.
+// C'est ce qui rend correct l'override `body.modal-open { padding-right: 0 }`
+// (voir components/_navbar.scss) : la gouttière compense déjà, il ne faut donc
+// PAS laisser Bootstrap ajouter en plus un padding-right (double compensation).
+// N'affecte ni sticky ni fixed (ne crée aucun clip/containing block).
+html {
+  scrollbar-gutter: stable;
+}
+
 // ── Empêche le scroll horizontal ────────────────────
 // Certains éléments dépassent légèrement du viewport (gradients avec left: -120px,
 // Bootstrap rows avec marges négatives, etc.) et créent une barre de scroll inutile.

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -523,7 +523,10 @@
   &::-webkit-scrollbar-thumb { background: $green; border-radius: 2px; }
 }
 
-// Empêche Bootstrap d'ajouter un padding-right au body quand une modal s'ouvre
+// Empêche Bootstrap d'ajouter un padding-right au body quand une modale s'ouvre.
+// Correct UNIQUEMENT parce que `html { scrollbar-gutter: stable }` (application.scss)
+// réserve déjà la gouttière : le padding Bootstrap ferait alors double compensation
+// et provoquerait un saut. Ne pas retirer l'un sans l'autre.
 body.modal-open {
   padding-right: 0 !important;
 }


### PR DESCRIPTION
## Symptôme
En ouvrant la modale « Partager sur Slack » depuis la page d'un match, la page **saute légèrement** (décalage horizontal du contenu), puis se remet en place à la fermeture. Le bug touche en réalité **toutes les modales Bootstrap** de l'app.

## Cause racine
La règle `body.modal-open { padding-right: 0 !important; }` (ajoutée dans le commit « Avis ») **annule** le `padding-right` compensatoire que Bootstrap ajoute au body à l'ouverture d'une modale. Sans cette compensation ni alternative : la scrollbar verticale disparaît (`overflow:hidden`), la largeur du contenu s'élargit brusquement (~15 px) → le contenu saute.

## Correctif
Réservation permanente de la gouttière de scrollbar au niveau racine :

```scss
html { scrollbar-gutter: stable; }
```

- **Scrollbars overlay (macOS par défaut)** : aucune gouttière visible, aucun saut — la règle est neutre.
- **Scrollbars classiques (Windows, Firefox, macOS « toujours afficher »)** : gouttière réservée en permanence → masquer la scrollbar ne provoque plus aucun reflow.

L'override `body.modal-open { padding-right: 0 }` devient alors **correct** : la gouttière compense déjà, il ne faut donc pas laisser Bootstrap ajouter un padding en plus (sinon double compensation). Commentaires ajoutés aux deux endroits pour lier les deux règles.

`scrollbar-gutter` ne crée aucun clip/containing block → n'affecte ni `position: sticky` (navbar) ni `fixed`.

## Vérification
- `assets:precompile` OK (SCSS valide).
- Fix CSS pur, aucun test auto impacté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)