### PR TITLE
Durcissement de l'intégration Slack

### DIFF
--- a/app/controllers/slack/events_controller.rb
+++ b/app/controllers/slack/events_controller.rb
@@ -1,0 +1,24 @@
+# Reçoit les événements de l'API Events de Slack (POST JSON).
+#
+# En v1, Teams-up ne s'abonne à AUCUN event : ce contrôleur existe uniquement pour
+# répondre au handshake `url_verification` que Slack envoie lorsqu'on renseigne la
+# « Request URL » de l'Events API dans la config de l'app. Slack attend qu'on lui
+# renvoie tel quel le `challenge` reçu (< 3 s) pour valider l'URL.
+#
+# Tout autre type d'event est simplement acquitté (head :ok) sans traitement.
+#
+# La signature est vérifiée en amont par Slack::BaseController (le challenge est
+# lui aussi signé → il passe la vérif HMAC sans cas particulier).
+module Slack
+  class EventsController < Slack::BaseController
+    def create
+      if params[:type] == "url_verification"
+        # Handshake de configuration : on renvoie le challenge en texte brut.
+        render plain: params[:challenge]
+      else
+        # v1 : aucun event écouté → simple accusé de réception.
+        head :ok
+      end
+    end
+  end
+end

--- a/app/views/profils/show_simple.html.erb
+++ b/app/views/profils/show_simple.html.erb
@@ -72,6 +72,37 @@
           </div>
         <% end %>
 
+        <%# ── Intégration Slack — visible uniquement sur son propre profil ── %>
+        <%# Point d'entrée clair vers la page de gestion des intégrations : afficher/partager
+            ses matchs dans Slack, créer un match via /match. L'état (lié ou non) est reflété. %>
+        <% if user_signed_in? && current_user == @profil_user %>
+          <div class="match-block" style="margin-top:1rem; padding:1rem 1.25rem;">
+            <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
+              <div>
+                <div style="display:flex; align-items:center; gap:0.4rem; font-size:0.78rem; font-weight:700;
+                            text-transform:uppercase; letter-spacing:0.08em; color:#1EDD88; margin-bottom:0.25rem;">
+                  <%= render "shared/slack_logo", size: 15 %>
+                  Slack
+                </div>
+                <p style="font-size:0.75rem; color:var(--theme-text-muted); margin:0;">
+                  <% if current_user.slack_linked? %>
+                    Compte connecté — partage tes matchs et crée-les avec <code>/match</code>.
+                  <% else %>
+                    Connecte Slack pour partager tes matchs et les créer depuis <code>/match</code>.
+                  <% end %>
+                </p>
+              </div>
+              <%= link_to profil_integrations_path,
+                          class: "btn btn-sm #{current_user.slack_linked? ? 'btn-outline-light' : 'btn-cta-primary'}",
+                          style: "white-space:nowrap; flex-shrink:0;" do %>
+                <i data-lucide="<%= current_user.slack_linked? ? 'settings' : 'plug' %>"
+                   style="width:15px; height:15px; vertical-align:-3px;"></i>
+                <%= current_user.slack_linked? ? "Gérer" : "Connecter Slack" %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
       </div>
       <%# / col-lg-4 %>
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -8,5 +8,8 @@ Rails.application.config.filter_parameters += [
   # Code d'autorisation OAuth renvoyé par Google dans l'URL de callback (peut être échangé contre un access_token)
   :code,
   # Tokens hCaptcha/reCaptcha soumis dans les formulaires auth — noms exacts utilisés par les widgets
-  "h-captcha-response", "g-recaptcha-response"
+  "h-captcha-response", "g-recaptcha-response",
+  # Payload brut des interactions Slack (form param `payload` = JSON) — contient des
+  # données utilisateur ; on ne le laisse pas apparaître en clair dans les logs.
+  :payload
 ]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -133,6 +133,21 @@ class Rack::Attack
 
 
   # -----------------------------------------------------------------------
+  # THROTTLE 8 : Endpoints Slack entrants (interactivity / commands / events)
+  #
+  # But : simple filet anti-flood sur les endpoints publics que Slack appelle.
+  # La VRAIE protection de ces routes est la signature HMAC vérifiée dans
+  # Slack::BaseController (SlackRequestVerification) — pas ce throttle.
+  # On plafonne donc TRÈS largement (60 req/min/IP) : Slack émet depuis un petit
+  # pool d'IP partagées, un seuil bas bloquerait du trafic légitime. Ces clients
+  # sont des machines → la réponse 429 par défaut suffit (pas de cookie/flash UI).
+  # -----------------------------------------------------------------------
+  throttle("slack/ip", limit: 60, period: 1.minute) do |req|
+    req.ip if req.path.start_with?("/slack/interactivity", "/slack/commands", "/slack/events")
+  end
+
+
+  # -----------------------------------------------------------------------
   # Notification Rack::Attack → SecurityLog
   #
   # Quand rack-attack bloque une requête (throttle déclenché), il publie

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,8 @@ Rails.application.routes.draw do
     post "interactivity",  to: "interactivity#create"
     # Slash commands (/match) — ouvre la modale de création de match.
     post "commands",       to: "commands#create"
+    # Events API — répond au handshake url_verification (aucun event écouté en v1).
+    post "events",         to: "events#create"
   end
 
   # Profil public d'un autre utilisateur

--- a/test/integration/slack_events_test.rb
+++ b/test/integration/slack_events_test.rb
@@ -1,0 +1,60 @@
+# Tests de l'endpoint Events API de Slack (PR 8) :
+#   - handshake `url_verification` signé → renvoie le challenge en texte brut ;
+#   - event quelconque signé → simple accusé de réception (aucun effet) ;
+#   - signature absente/invalide → 401 (garde de Slack::BaseController).
+#
+# L'Events API poste du JSON (Content-Type application/json) ; la signature HMAC
+# porte sur le body brut, indépendamment du content-type.
+require "test_helper"
+
+class SlackEventsTest < ActionDispatch::IntegrationTest
+  SIGNING_SECRET = "test_signing_secret"
+
+  setup do
+    @previous_secret = ENV["SLACK_SIGNING_SECRET"]
+    ENV["SLACK_SIGNING_SECRET"] = SIGNING_SECRET
+  end
+
+  teardown do
+    ENV["SLACK_SIGNING_SECRET"] = @previous_secret
+    teardown_db
+  end
+
+  # POST JSON signé sur un endpoint Slack. `body` est la chaîne JSON brute.
+  def signed_post_json(path, body, timestamp: Time.now.to_i, signature: nil)
+    signature ||= "v0=" + OpenSSL::HMAC.hexdigest("SHA256", SIGNING_SECRET, "v0:#{timestamp}:#{body}")
+    post path, params: body,
+         headers: {
+           "CONTENT_TYPE"              => "application/json",
+           "X-Slack-Request-Timestamp" => timestamp.to_s,
+           "X-Slack-Signature"         => signature
+         }
+  end
+
+  test "url_verification signé → renvoie le challenge en texte brut" do
+    challenge = "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P"
+    body = { type: "url_verification", token: "tok", challenge: challenge }.to_json
+
+    signed_post_json "/slack/events", body
+
+    assert_response :ok
+    assert_equal challenge, @response.body
+  end
+
+  test "event quelconque signé → 200 sans effet" do
+    body = { type: "event_callback", event: { type: "message", text: "coucou" } }.to_json
+
+    signed_post_json "/slack/events", body
+
+    assert_response :ok
+    assert_empty @response.body
+  end
+
+  test "signature invalide → 401" do
+    body = { type: "url_verification", challenge: "x" }.to_json
+
+    signed_post_json "/slack/events", body, signature: "v0=deadbeef"
+
+    assert_response :unauthorized
+  end
+end


### PR DESCRIPTION
## Contexte

Dernier lot du plan d'intégration Slack (**PR 8 — Durcissement**). Sécurise et fiabilise les endpoints Slack entrants exposés publiquement, et complète l'observabilité.

> ⚠️ **PR empilée sur PR 7** (`slack-slash-command`, slash `/match`). Base à repointer sur `master` une fois PR 7 (#373) mergée — le diff se réduira alors aux seuls changements ci-dessous.

## Changements

- **Rack::Attack** — throttle permissif `slack/ip` (60/min) sur `/slack/{interactivity,commands,events}`. Simple filet anti-flood : la vraie protection reste la **signature HMAC** ; seuil large exprès pour ne pas bloquer les IP partagées de Slack.
- **`Slack::EventsController`** — répond au handshake `url_verification` (renvoie le `challenge`), ACK simple pour tout autre event (aucun event écouté en v1). Route `post /slack/events`.
- **Logs** — ajout de `:payload` au filtrage des paramètres (le body brut interactif Slack). `:token`/`:secret` couvraient déjà bot_token / signing secret ; la gestion `not_in_channel`/token révoqué est déjà assurée par `SlackNotifyJob` + `Slack::ApiClient`.
- **Profil** — lien **Slack** clair dans `profils/show_simple` → `/profil/integrations`, avec état lié/non-lié et logo Slack officiel.

## Tests

`test/integration/slack_events_test.rb` (challenge signé, event ACK, signature invalide → 401). **25 tests Slack verts** au total. Rendu de `/profil` vérifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)