### PR TITLE
Fix page tournois bientot : bouton vert + toujours en sombre

### DIFF
--- a/app/assets/stylesheets/pages/_tournament_coming_soon.scss
+++ b/app/assets/stylesheets/pages/_tournament_coming_soon.scss
@@ -1,6 +1,8 @@
 // ── Page d'attente « Tournois — Bientôt disponible » ─────────────────────────
 // Affichée depuis le header tant que la feature tournoi n'est pas lancée.
-// Theme-aware : utilise les variables var(--theme-*) définies dans config/_colors.scss.
+// TOUJOURS en sombre, quel que soit le thème du site : on fige donc les couleurs
+// sur les tokens $dark-* plutôt que sur les var(--theme-*) (qui viraient au blanc
+// en mode clair et rendaient la carte illisible sur fond clair).
 
 .tournament-soon {
   min-height: calc(100vh - 80px); // 80px ≈ hauteur du header
@@ -9,6 +11,8 @@
   justify-content: center;
   padding: 2rem 1.25rem;
   text-align: center;
+  // Fond sombre plein cadre : couvre le fond clair de la page en mode clair.
+  background-color: $dark-bg;
 }
 
 // Carte centrale
@@ -19,8 +23,8 @@
   gap: 1.5rem;
   max-width: 520px;
   padding: 3rem 2.25rem;
-  background-color: var(--theme-bg-card);
-  border: 1px solid var(--theme-nav-border);
+  background-color: $dark-card-bg;
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 1.25rem;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
 }
@@ -57,11 +61,11 @@
 
 .tournament-soon__title {
   margin: 0;
-  color: var(--theme-text-primary);
+  color: $dark-text;
 }
 
 .tournament-soon__text {
   margin: 0;
-  color: var(--theme-text-muted);
+  color: $dark-muted;
   line-height: 1.6;
 }

--- a/app/views/tournaments/coming_soon.html.erb
+++ b/app/views/tournaments/coming_soon.html.erb
@@ -21,6 +21,6 @@
       ça se prépare en coulisses !
     </p>
 
-    <%= link_to "Retour à l'accueil", root_path, class: "btn btn-cta-primary" %>
+    <%= link_to "Retour à l'accueil", root_path, class: "btn btn-primary btn-cta-primary" %>
   </div>
 </section>


### PR DESCRIPTION
## Contexte

Deux problèmes visuels sur la page d'attente `/tournois/bientot` (affichée depuis le lien « Tournoi » du header tant que la feature n'est pas lancée).

## Changements

- **Bouton « Retour à l'accueil »** — s'affichait en texte gris au lieu du bouton vert. Cause : `.btn-cta-primary` ne fournit pas la couleur (elle vient de Bootstrap via `.btn-primary`, cf. `components/_buttons.scss`) ; il manquait `btn-primary` sur le lien. Corrigé en `btn btn-primary btn-cta-primary` (comme partout ailleurs).
- **Page toujours en sombre** — la page utilisait les `var(--theme-*)`, donc en mode clair la carte devenait blanche sur fond clair (illisible). Couleurs figées sur les tokens `$dark-*` pour garder le rendu sombre quel que soit le thème du site.

## Vérification

Serveur local : `/tournois/bientot` → HTTP 200, aucune erreur SCSS. CSS compilé vérifié : `.tournament-soon` `#111111`, `.tournament-soon__card` `#1a1c1a`, titre `#f0f0f0`, texte `rgba(255,255,255,0.55)` — indépendants du thème.

🤖 Generated with [Claude Code](https://claude.com/claude-code)