### PR TITLE
Fix inscription : ne plus perdre mot de passe + captcha si un sport manque

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,9 +13,15 @@
     <h1 class="h2">Créer un <span class="accent">compte</span></h1>
 
     <%# multipart: true obligatoire pour l'upload de fichier %>
-    <%# data-action="submit->sport-select#validate" : vérifie qu'au moins 1 sport est sélectionné avant soumission %>
+    <%# data-controller + data-action portés par le FORM (et non le div #sport-field) :
+        une action Stimulus ne trouve son controller que sur l'élément lui-même ou un
+        ANCÊTRE, jamais un descendant. Si le controller restait sur #sport-field (enfant
+        du form), le submit->sport-select#validate ne se déclencherait jamais, le formulaire
+        partirait au serveur et l'utilisateur perdrait mot de passe + captcha. %>
     <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name),
-        html: { multipart: true, "data-action": "submit->sport-select#validate" }) do |f| %>
+        html: { multipart: true,
+                "data-controller": "sport-select",
+                "data-action": "submit->sport-select#validate" }) do |f| %>
 
       <%= f.error_notification %>
 
@@ -137,7 +143,9 @@
           <%# ── Bloc sélection des sports ──────────────────────────────────── %>
           <%# L'utilisateur choisit ses sports favoris (au moins 1 requis) %>
           <%# id="sport-field" → cible du scroll automatique en cas d'erreur serveur %>
-          <div id="sport-field" data-controller="sport-select">
+          <%# Le controller sport-select est porté par le <form> (voir plus haut), pas ici :
+              indispensable pour que la validation submit->sport-select#validate se déclenche. %>
+          <div id="sport-field">
             <label class="form-label fw-semibold mb-2">
               Quel(s) sport(s) pratiques-tu ?
               <span class="required-star">*</span>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -10,6 +10,12 @@
 - **Correctif** : ce qui a été changé, et fichier(s) concerné(s)
 -->
 
+## 2026-07-16 — Inscription : mot de passe + captcha perdus quand un sport manque
+- **Symptôme** : à l'inscription classique, un utilisateur remplit mdp + captcha mais oublie le sport ; à la soumission, erreur serveur sur le sport ET perte du mot de passe et du captcha (widget vierge) → l'utilisateur doit tout ressaisir.
+- **Cause racine** : la validation client du sport (`data-action="submit->sport-select#validate"`) était posée sur le `<form>`, mais le `data-controller="sport-select"` était sur le `<div id="sport-field">`, un **descendant** du form. Une action Stimulus ne résout son controller que sur l'élément lui-même ou un **ancêtre**, jamais un descendant → `validate` ne se déclenchait jamais, le form partait au serveur, qui fait `clean_up_passwords` + régénère un hCaptcha vierge (token à usage unique, non restaurable).
+- **Correctif** : déplacer `data-controller="sport-select"` du `<div id="sport-field">` vers le `<form>` (`app/views/devise/registrations/new.html.erb`). L'action `submit->sport-select#validate` trouve alors son controller, bloque la soumission côté client, la page ne recharge pas → mdp + captcha préservés. (La validation du genre marchait déjà car posée en `addEventListener('submit')` directement sur le form.)
+- **Leçon** : en Stimulus, `data-action` et `data-controller` doivent être sur le même élément **ou** le controller sur un ancêtre de l'élément portant l'action — un controller sur un descendant est invisible. Pour un `submit`, mettre le controller sur le `<form>`. Corollaire UX : ce qui est vérifiable côté client (sport, genre) doit l'être, car un aller-retour serveur détruit toujours le mdp (jamais renvoyé en HTML) et le captcha (token usage unique).
+
 ## 2026-07-10 — Abandon (withdrawn) « annulé » à la ronde suivante (Lot 5 tournoi)
 - **Symptôme** : en ronde suisse, un joueur déclaré forfait était **ré-apparié** à la ronde suivante alors qu'il devait être exclu (test `withdraw_player_test` : l'id du retiré réapparaissait dans les matchs de la ronde 2).
 - **Cause racine** : le moteur suisse appelle `recompute_stats_for("swiss", apply_state: true)` à chaque `next_round!`, qui **réécrasait `state`** via `state_for(wins, losses)` → l'état terminal `withdrawn` repassait en `active`/`eliminated`. Or `SwissPairing#create_swiss_round!` apparie `player_scope.active` : le joueur, redevenu `active`, rentrait dans le tirage.


### PR DESCRIPTION
## Problème

À l'inscription classique, un utilisateur qui remplit mot de passe + captcha mais oublie de sélectionner un sport voyait, à la soumission :
- une erreur serveur sur le sport,
- **et la perte de son mot de passe et de son captcha** (widget hCaptcha revenu vierge).

Il devait tout ressaisir. Très frustrant.

## Cause racine

La validation client du sport (`data-action="submit->sport-select#validate"`) était posée sur le `<form>`, mais le `data-controller="sport-select"` était sur le `<div id="sport-field">`, un **descendant** du form.

En Stimulus, une action ne résout son controller que sur l'élément lui-même ou un **ancêtre** — jamais un descendant. La validation ne se déclenchait donc **jamais** : le formulaire partait au serveur, qui fait `clean_up_passwords` et régénère un hCaptcha vierge (token à usage unique, non restaurable).

## Correctif

Déplacer `data-controller="sport-select"` du `<div id="sport-field">` vers le `<form>`. L'action `submit->sport-select#validate` trouve alors son controller, bloque la soumission côté client → la page ne recharge pas, mot de passe + captcha restent intacts. L'utilisateur choisit son sport et reclique, sans rien ressaisir.

La validation du genre fonctionnait déjà (elle utilise un `addEventListener('submit')` posé directement sur le form).

## Vérification

- Page `/users/sign_up` rendue en 200, le `<form>` porte bien `data-controller="sport-select"` et l'action ; le `<div id="sport-field">` ne porte plus le controller.
- Testé en local par l'utilisateur : ✅ le mot de passe et le captcha sont conservés.

Apprentissage consigné dans `tasks/lessons.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)