### PR TITLE
Slack : inscrits sur la carte, désinscription, rappel -15min et annul…

### DIFF
--- a/app/controllers/match_users_controller.rb
+++ b/app/controllers/match_users_controller.rb
@@ -53,23 +53,13 @@ class MatchUsersController < ApplicationController
   def destroy
     authorize @match_user
 
-    # Sauvegarde l'utilisateur et son statut avant destruction
-    # (après @match_user.destroy, ces infos ne sont plus accessibles)
-    leaving_user = @match_user.user
-    was_approved = @match_user.approved?
-
-    # Si le joueur avait une place approuvée, on gère la file d'attente
-    promote_next_in_line if was_approved
-
-    @match_user.destroy
+    # Logique métier (promotion de la file d'attente, destroy, email de départ)
+    # déléguée au service partagé avec la désinscription Slack.
+    result = MatchUnenrollmentService.new(match: @match, user: @match_user.user).call
 
     # Notifie l'organisateur en temps réel si un joueur approuvé a quitté
-    # (pas de notif si pending/waiting/rejected — ces cas ne libèrent pas de place)
-    if was_approved
-      broadcast_player_left_to_organizer(leaving_user)
-      # Email transactionnel : informe l'organisateur du départ et de la place libérée
-      UserMailer.match_player_left(@match, leaving_user).deliver_later
-    end
+    # (pas de broadcast si pending/waiting/rejected — ces cas ne libèrent pas de place)
+    broadcast_player_left_to_organizer(result.leaving_user) if result.was_approved
 
     # Match privé → retour à l'index (le joueur n'a plus accès sans token)
     # Match public → retour à la show du match
@@ -318,35 +308,6 @@ class MatchUsersController < ApplicationController
   # Utilisé par plusieurs méthodes de broadcast pour cibler le canal personnel de l'orga
   def organizer_user
     @match.organizer_match_user&.user
-  end
-
-  # Gère la promotion du prochain joueur en file d'attente quand une place se libère
-  def promote_next_in_line
-    promoted_record = nil
-
-    # with_lock : SELECT FOR UPDATE — évite qu'une promotion concurrente
-    # (ex: deux joueurs quittent simultanément) promouvde deux personnes pour une seule place
-    @match.with_lock do
-      # Cherche le premier joueur en file d'attente (le plus ancien en premier)
-      next_in_line = @match.match_users.where(status: "waiting").order(created_at: :asc).first
-
-      if next_in_line
-        # Promeut automatiquement le joueur : son passage à "approved" déclenche
-        # le recalcul de player_left (la place reste occupée, reprise par le promu).
-        next_in_line.update(status: "approved")
-        promoted_record = next_in_line
-      end
-      # Si personne n'attend, aucune action ici : le départ du joueur (destroy)
-      # déclenche à son tour le recalcul de player_left → la place est rendue.
-    end
-
-    # Notifications en dehors du verrou (non critiques pour la cohérence des données)
-    return unless promoted_record
-
-    message = "🎉 Une place s'est libérée ! Tu as été automatiquement inscrit au match \"#{@match.title}\"."
-    notify(promoted_record.user, message)
-    # Email transactionnel : informe le joueur de sa promotion depuis la file d'attente
-    UserMailer.match_status_changed(promoted_record, accepted: true).deliver_later
   end
 
   # Retourne les options de redirect pour le match — inclut le token si match privé

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -300,47 +300,13 @@ class MatchesController < ApplicationController
   end
 
   # DELETE /matches/:id
-  # Supprime un match et notifie tous les participants en temps réel
+  # Supprime un match et notifie tous les participants (temps réel + email).
+  # Logique déléguée au service partagé avec l'annulation depuis Slack, qui
+  # édite aussi les cartes Slack en « Annulé » avant la suppression.
   def destroy
     authorize @match
 
-    # Récupère tous les participants inscrits (hors organisateur) avant destruction.
-    # On exclut les "rejected" car ils n'ont plus de place et ne sont plus actifs.
-    # IMPORTANT : on broadcast AVANT @match.destroy → le canal ActionCable doit encore exister.
-    participants = @match.match_users
-                         .where.not(role: "organisateur")
-                         .where(status: ["approved", "pending", "waiting"])
-                         .includes(:user)
-
-    # ── Extraction des données AVANT destruction ──────────────────────────────
-    # On sérialise uniquement des scalaires pour éviter le DeserializationError
-    # de SolidQueue lors du deliver_later (GlobalID ne peut pas recharger un
-    # enregistrement détruit).
-    match_title    = @match.title
-    match_date     = @match.date
-    match_time_str = @match.time&.strftime("%Hh%M")
-    venue_name     = @match.venue&.name
-    venue_city     = @match.venue&.city
-    organizer_name = @match.user.display_name
-
-    # Liste des destinataires : participants + organisateur
-    recipient_emails = participants.map { |mu| mu.user.email }
-    recipient_emails << @match.user.email
-
-    # Broadcasts Turbo AVANT destroy → le canal ActionCable doit encore exister
-    participants.each do |mu|
-      broadcast_match_cancelled_to_participant(mu.user)
-    end
-
-    @match.destroy
-
-    # Enqueue des emails asynchrones avec données scalaires uniquement
-    recipient_emails.each do |email|
-      MatchCancelledMailerJob.perform_later(
-        email, match_title, match_date, match_time_str,
-        venue_name, venue_city, organizer_name
-      )
-    end
+    MatchCancellationService.new(match: @match).call
 
     redirect_to matches_path, notice: "Match supprimé."
   end
@@ -416,18 +382,6 @@ class MatchesController < ApplicationController
   end
 
   private
-
-  # Envoie la notification d'annulation du match à un participant spécifique.
-  # Appelé depuis destroy pour chaque participant avant la suppression du match.
-  # La modal s'ouvre automatiquement peu importe la page où se trouve le joueur.
-  def broadcast_match_cancelled_to_participant(participant_user)
-    Turbo::StreamsChannel.broadcast_update_to(
-      "user_#{participant_user.id}_notifications", # canal personnel du joueur
-      target: "global_notification_container", # conteneur dans application.html.erb
-      partial: "matches/match_cancelled_notification",
-      locals: { match: @match }
-    )
-  end
 
   # Applique tous les filtres optionnels sur @matches selon les params reçus
   def apply_filters

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -14,20 +14,42 @@ module Slack
     VIEWS_OPEN_URL = "https://slack.com/api/views.open".freeze
 
     def create
-      return render_ephemeral("Commande inconnue.") unless params[:command] == "/match"
+      case params[:command]
+      when "/match"        then handle_create
+      when "/match-cancel" then handle_cancel
+      else render_ephemeral("Commande inconnue.")
+      end
+    rescue Slack::ApiClient::Error => e
+      # trigger_id expiré, scope manquant… on prévient l'utilisateur sans planter.
+      Rails.logger.warn("[Slack::Commands] appel Slack échoué (#{e.slack_error})")
+      render_ephemeral("Une erreur Slack est survenue. Réessaie.")
+    end
 
+    private
+
+    # `/match` : ouvre la modale de création (views.open, synchrone).
+    def handle_create
       identity = SlackIdentity.for_slack(team_id: params[:team_id], user_id: params[:user_id])
       return render_ephemeral(link_account_message) unless identity
 
       open_modal(identity.slack_workspace)
       head :ok
-    rescue Slack::ApiClient::Error => e
-      # trigger_id expiré, scope manquant… on prévient l'utilisateur sans planter.
-      Rails.logger.warn("[Slack::Commands] views.open a échoué (#{e.slack_error})")
-      render_ephemeral("Impossible d'ouvrir la fenêtre de création. Réessaie.")
     end
 
-    private
+    # `/match-cancel` : réponse éphémère listant les matchs à venir de l'auteur,
+    # chacun avec un bouton « Annuler » (traité par SlackCancelJob). Comme la
+    # réponse est éphémère, elle n'est visible que de lui → bouton privé.
+    def handle_cancel
+      identity = SlackIdentity.for_slack(team_id: params[:team_id], user_id: params[:user_id])
+      return render_ephemeral(link_account_message) unless identity
+
+      matches = Match.where(user: identity.user).upcoming.order(:date, :time)
+      render json: {
+        response_type: "ephemeral",
+        text:          "Tes matchs à venir",
+        blocks:        Slack::BlockKitBuilder.new.cancel_list_blocks(matches)
+      }
+    end
 
     # Ouvre la modale de création dans le workspace de l'utilisateur.
     def open_modal(workspace)
@@ -48,7 +70,7 @@ module Slack
 
     def link_account_message
       url = Rails.application.routes.url_helpers.slack_connect_url
-      "Pour créer un match depuis Slack, lie d'abord ton compte Teams-up : #{url}"
+      "Pour gérer tes matchs depuis Slack, lie d'abord ton compte Teams-up : #{url}"
     end
   end
 end

--- a/app/controllers/slack/interactivity_controller.rb
+++ b/app/controllers/slack/interactivity_controller.rb
@@ -24,12 +24,20 @@ module Slack
 
     private
 
-    # ── block_actions : clic « S'inscrire » ──────────────────────────────────────
+    # ── block_actions : boutons de la carte match ───────────────────────────────
+    # Chaque bouton porte un action_id, mappé vers son job dédié (tous partagent
+    # la même signature : match_id, team_id, slack_user_id, response_url).
+    ACTION_JOBS = {
+      "match_join"   => SlackEnrollJob,
+      "match_leave"  => SlackUnenrollJob,
+      "match_cancel" => SlackCancelJob
+    }.freeze
+
     def handle_block_actions(payload)
-      action = Array(payload["actions"]).find { |a| a["action_id"] == "match_join" }
+      action = Array(payload["actions"]).find { |a| ACTION_JOBS.key?(a["action_id"]) }
       return head :ok unless action
 
-      SlackEnrollJob.perform_later(
+      ACTION_JOBS.fetch(action["action_id"]).perform_later(
         match_id:      action["value"],
         team_id:       payload.dig("team", "id"),
         slack_user_id: payload.dig("user", "id"),

--- a/app/jobs/concerns/slack_ephemeral_responder.rb
+++ b/app/jobs/concerns/slack_ephemeral_responder.rb
@@ -1,0 +1,47 @@
+# Réponses éphémères Slack partagées par les jobs déclenchés depuis un bouton
+# Block Kit d'une carte match (inscription / désinscription). Un job inclut ce
+# module pour répondre au cliqueur via sa `response_url` (message visible de lui
+# seul), et pour l'inviter à lier son compte quand aucune identité Slack n'est
+# rattachée (prérequis pour agir depuis Slack).
+module SlackEphemeralResponder
+  extend ActiveSupport::Concern
+
+  private
+
+  # Poste un message éphémère (visible du seul cliqueur) via la response_url.
+  # `text` reste le repli obligatoire (notif mobile / accessibilité) même quand
+  # on fournit des `blocks` plus riches (ex. le bouton « Lier mon compte »).
+  def respond(response_url, text, blocks: nil)
+    payload = { response_type: "ephemeral", text: text }
+    payload[:blocks] = blocks if blocks
+    Slack::ApiClient.post_response_url(response_url, payload)
+  end
+
+  # Repli texte pour l'invitation à lier son compte.
+  def link_account_text
+    "Pour agir sur les matchs depuis Slack, lie d'abord ton compte Teams-up : #{slack_connect_url}"
+  end
+
+  # Bloc éphémère : explication + bouton « Lier mon compte à Teams-up » (URL
+  # absolue, le job n'a pas de `request`) qui ouvre la page de liaison.
+  def link_account_blocks
+    [
+      { type: "section",
+        text: { type: "mrkdwn",
+                text: "Pour agir sur les matchs depuis Slack, lie d'abord ton compte Teams-up. " \
+                      "Si tu n'as pas encore de compte, tu pourras en créer un." } },
+      { type: "actions",
+        elements: [
+          { type: "button",
+            style: "primary",
+            text: { type: "plain_text", text: "Lier mon compte à Teams-up", emoji: true },
+            url: slack_connect_url }
+        ] }
+    ]
+  end
+
+  # URL absolue de la page de liaison Slack ↔ Teams-up.
+  def slack_connect_url
+    Rails.application.routes.url_helpers.slack_connect_url
+  end
+end

--- a/app/jobs/slack_cancel_job.rb
+++ b/app/jobs/slack_cancel_job.rb
@@ -1,0 +1,37 @@
+# Traite en arrière-plan un clic « Annuler le match » venu de Slack (bouton Block
+# Kit). Comme SlackEnrollJob / SlackUnenrollJob : l'endpoint ACK en < 3 s, ce job
+# fait le travail et répond via `response_url`.
+#
+# Étapes :
+#   1. résoudre l'identité Slack → compte Teams-up lié (sinon : inviter à lier) ;
+#   2. n'autoriser QUE l'organisateur du match (record.user) ;
+#   3. annuler via MatchCancellationService (suppression + emails + édition des
+#      cartes Slack en « Annulé », comme le site) ;
+#   4. répondre en éphémère.
+class SlackCancelJob < ApplicationJob
+  include SlackEphemeralResponder
+
+  queue_as :default
+
+  def perform(match_id:, team_id:, slack_user_id:, response_url:)
+    return if response_url.blank?
+
+    identity = SlackIdentity.for_slack(team_id: team_id, user_id: slack_user_id)
+    unless identity
+      respond(response_url, link_account_text, blocks: link_account_blocks)
+      return
+    end
+
+    match = Match.find_by(id: match_id)
+    return respond(response_url, "Ce match n'existe plus. 🙁") unless match
+
+    # Seul l'organisateur peut annuler.
+    unless match.user_id == identity.user_id
+      return respond(response_url, "Seul l'organisateur du match peut l'annuler.")
+    end
+
+    title = match.title
+    MatchCancellationService.new(match: match).call
+    respond(response_url, "🚫 Match « #{title} » annulé. Les joueurs inscrits sont prévenus.")
+  end
+end

--- a/app/jobs/slack_enroll_job.rb
+++ b/app/jobs/slack_enroll_job.rb
@@ -8,6 +8,8 @@
 #   2. sinon, inscrire via MatchEnrollmentService (même logique que le web) ;
 #   3. renvoyer un message éphémère de confirmation adapté au résultat.
 class SlackEnrollJob < ApplicationJob
+  include SlackEphemeralResponder
+
   queue_as :default
 
   # L'inscription ne dépend d'aucun objet susceptible de disparaître entre l'enqueue
@@ -30,43 +32,6 @@ class SlackEnrollJob < ApplicationJob
   end
 
   private
-
-  # Poste un message éphémère (visible du seul cliqueur) via la response_url.
-  # `text` reste le repli obligatoire (notif mobile / accessibilité) même quand
-  # on fournit des `blocks` plus riches (ici le bouton « Lier mon compte »).
-  def respond(response_url, text, blocks: nil)
-    payload = { response_type: "ephemeral", text: text }
-    payload[:blocks] = blocks if blocks
-    Slack::ApiClient.post_response_url(response_url, payload)
-  end
-
-  # Repli texte pour l'invitation à lier son compte.
-  def link_account_text
-    "Pour t'inscrire depuis Slack, lie d'abord ton compte Teams-up : #{slack_connect_url}"
-  end
-
-  # Bloc éphémère : explication + bouton « Lier mon compte à Teams-up » (URL
-  # absolue, le job n'a pas de `request`) qui ouvre la page de liaison.
-  def link_account_blocks
-    [
-      { type: "section",
-        text: { type: "mrkdwn",
-                text: "Pour t'inscrire depuis Slack, lie d'abord ton compte Teams-up. " \
-                      "Si tu n'as pas encore de compte, tu pourras en créer un." } },
-      { type: "actions",
-        elements: [
-          { type: "button",
-            style: "primary",
-            text: { type: "plain_text", text: "Lier mon compte à Teams-up", emoji: true },
-            url: slack_connect_url }
-        ] }
-    ]
-  end
-
-  # URL absolue de la page de liaison Slack ↔ Teams-up.
-  def slack_connect_url
-    Rails.application.routes.url_helpers.slack_connect_url
-  end
 
   # Message de confirmation adapté au résultat de l'inscription.
   def message_for(status, match)

--- a/app/jobs/slack_match_cancel_job.rb
+++ b/app/jobs/slack_match_cancel_job.rb
@@ -1,0 +1,43 @@
+# Édite les cartes Slack d'un match ANNULÉ en un avis « 🚫 Match annulé ».
+#
+# Reçoit des coordonnées de cartes déjà sérialisées (workspace_id, channel_id,
+# message_ts) parce que le match — et ses slack_match_messages (cascade) — est
+# détruit AVANT l'exécution (cf. MatchCancellationService). On ne peut donc plus
+# recharger la carte depuis la base : tout est passé en arguments scalaires.
+class SlackMatchCancelJob < ApplicationJob
+  queue_as :default
+
+  PERMANENT_SLACK_ERRORS = SlackNotifyJob::PERMANENT_SLACK_ERRORS
+
+  # cards : [{ "workspace_id" =>, "channel_id" =>, "message_ts" => }, ...]
+  def perform(match_title, cards)
+    builder = Slack::BlockKitBuilder.new
+    text    = builder.match_cancelled_text(match_title)
+    blocks  = builder.match_cancelled_blocks(match_title)
+
+    Array(cards).each { |card| update_one(card, text, blocks) }
+  end
+
+  private
+
+  def update_one(card, text, blocks)
+    workspace = SlackWorkspace.find_by(id: card["workspace_id"])
+    return unless workspace
+
+    SlackNotifierService.new(workspace).update_message(
+      channel: card["channel_id"], ts: card["message_ts"], text: text, blocks: blocks
+    )
+  rescue Slack::ApiClient::Error => e
+    # Carte déjà disparue (supprimée à la main) ou erreur définitive → on log
+    # sans réessayer. Erreur transitoire → on relaie pour retry_on.
+    if %w[message_not_found cant_update_message channel_not_found].include?(e.slack_error)
+      nil
+    elsif PERMANENT_SLACK_ERRORS.include?(e.slack_error)
+      Rails.logger.warn("[SlackMatchCancelJob] abandon (#{e.slack_error}) carte #{card["channel_id"]}")
+    else
+      raise
+    end
+  end
+
+  retry_on Slack::ApiClient::Error, wait: :polynomially_longer, attempts: 3
+end

--- a/app/jobs/slack_match_prep_job.rb
+++ b/app/jobs/slack_match_prep_job.rb
@@ -1,0 +1,98 @@
+# Poste un rappel "préparez-vous" dans le(s) channel(s) Slack d'un match, ~15 min
+# avant le coup d'envoi. Planifié comme SlackMatchStatusJob (à build_datetime -
+# 15 min), aux deux mêmes points d'ancrage : au partage sur Slack et à chaque
+# changement d'horaire.
+#
+# Anti-doublon (délicat car les replanifications EMPILENT des jobs sans annuler
+# les anciens) :
+#   1. garde temporelle dans #perform : on n'envoie que si le match est encore à
+#      venir ET imminent → un job caduc (ancien horaire) est ignoré ;
+#   2. flag `slack_prep_sent_at` claim sous verrou → un seul envoi par créneau,
+#      même si deux jobs se déclenchent au même instant (ex. horaire remis à sa
+#      valeur initiale). Le flag est remis à nil quand l'horaire change
+#      (Match#resync_slack_messages), pour autoriser un nouveau rappel.
+class SlackMatchPrepJob < ApplicationJob
+  queue_as :default
+
+  # Match supprimé entre l'enqueue et l'exécution → plus rien à faire.
+  discard_on ActiveRecord::RecordNotFound
+
+  LEAD_TIME = 15.minutes
+  # Retard de queue toléré : au-delà, "dans 15 min" n'a plus de sens, on renonce.
+  MAX_LATENESS = 5.minutes
+
+  PERMANENT_SLACK_ERRORS = SlackNotifyJob::PERMANENT_SLACK_ERRORS
+
+  # Planifie le rappel à build_datetime - 15 min (futur uniquement).
+  def self.schedule(match)
+    start_at = match.build_datetime
+    return if start_at.blank?
+
+    at = start_at - LEAD_TIME
+    return if at <= Time.current
+
+    set(wait_until: at).perform_later(match.id)
+  end
+
+  def perform(match_id)
+    match    = Match.find(match_id)
+    messages = match.slack_match_messages.includes(:slack_workspace)
+    return if messages.empty?
+
+    return unless within_prep_window?(match)
+    return unless claim_send(match)
+
+    text = builder.match_prep_text(match)
+    messages.each { |msg| post_one(msg, match, text) }
+  end
+
+  private
+
+  def builder
+    @builder ||= Slack::BlockKitBuilder.new
+  end
+
+  # Vrai si le match est encore à venir et démarre dans la fenêtre attendue
+  # (~15 min, tolérance de retard de queue). Filtre les jobs devenus caducs
+  # après un décalage d'horaire (leur wait_until reste sur l'ancienne heure).
+  def within_prep_window?(match)
+    start_at = match.build_datetime
+    return false if start_at.blank? || start_at <= Time.current
+
+    start_at <= Time.current + LEAD_TIME + MAX_LATENESS
+  end
+
+  # Réserve l'envoi de façon atomique : renvoie false si un rappel a déjà été
+  # posté pour ce créneau (jobs empilés), true sinon en posant le flag.
+  def claim_send(match)
+    match.with_lock do
+      return false if match.slack_prep_sent_at.present?
+
+      match.update_column(:slack_prep_sent_at, Time.current)
+      true
+    end
+  end
+
+  def post_one(msg, match, text)
+    SlackNotifierService.new(msg.slack_workspace).post_message(
+      channel: msg.channel_id,
+      text:    text,
+      blocks:  builder.match_prep_blocks(match, slack_mentions(match, msg.slack_workspace))
+    )
+  rescue Slack::ApiClient::Error => e
+    # Notif éphémère par nature (utile ~15 min avant) : inutile de retenter plus
+    # tard, on log et on passe. Permanente ou transitoire → même traitement.
+    Rails.logger.warn("[SlackMatchPrepJob] abandon (#{e.slack_error}) match ##{match.id}")
+  end
+
+  # Mentions "<@U…>" des joueurs approuvés (organisateur inclus) ayant lié leur
+  # compte Slack dans CE workspace — pour les pinguer nommément. nil si aucun.
+  def slack_mentions(match, workspace)
+    user_ids = match.match_users.where(status: "approved").pluck(:user_id)
+    return nil if user_ids.empty?
+
+    slack_ids = SlackIdentity.where(slack_workspace: workspace, user_id: user_ids)
+                             .pluck(:slack_user_id)
+    slack_ids.map { |id| "<@#{id}>" }.join(" ").presence
+  end
+end

--- a/app/jobs/slack_notify_job.rb
+++ b/app/jobs/slack_notify_job.rb
@@ -67,6 +67,7 @@ class SlackNotifyJob < ApplicationJob
     )
 
     SlackMatchStatusJob.schedule_transitions(match)
+    SlackMatchPrepJob.schedule(match) # rappel "préparez-vous" à -15 min
   end
 
   # Réessais avec backoff pour les erreurs transitoires relayées ci-dessus.

--- a/app/jobs/slack_unenroll_job.rb
+++ b/app/jobs/slack_unenroll_job.rb
@@ -1,0 +1,47 @@
+# Traite en arrière-plan un clic « Se désinscrire » venu de Slack (bouton Block Kit).
+# Pendant de SlackEnrollJob. Découplé du controller pour tenir la fenêtre de 3 s
+# imposée par Slack : l'endpoint ACK immédiatement, ce job fait le vrai travail
+# puis répond via `response_url`.
+#
+# Étapes :
+#   1. résoudre l'identité Slack (team_id + user_id) → un compte Teams-up lié ;
+#      si non lié → message éphémère invitant à lier son compte ;
+#   2. sinon, désinscrire via MatchUnenrollmentService (même logique que le web :
+#      promotion de la file d'attente, destruction, email à l'organisateur) ;
+#   3. renvoyer un message éphémère de confirmation adapté au résultat.
+#
+# La carte du match se met à jour toute seule : le destroy déclenche le callback
+# MatchUser#refresh_slack_cards qui ré-édite la liste des inscrits.
+class SlackUnenrollJob < ApplicationJob
+  include SlackEphemeralResponder
+
+  queue_as :default
+
+  def perform(match_id:, team_id:, slack_user_id:, response_url:)
+    return if response_url.blank?
+
+    identity = SlackIdentity.for_slack(team_id: team_id, user_id: slack_user_id)
+    unless identity
+      respond(response_url, link_account_text, blocks: link_account_blocks)
+      return
+    end
+
+    match = Match.find_by(id: match_id)
+    return respond(response_url, "Ce match n'existe plus. 🙁") unless match
+
+    result = MatchUnenrollmentService.new(match: match, user: identity.user).call
+    respond(response_url, message_for(result.status, match))
+  end
+
+  private
+
+  # Message de confirmation adapté au résultat de la désinscription.
+  def message_for(status, match)
+    title = match.title
+    case status
+    when :left            then "👋 Tu t'es désinscrit du match « #{title} »."
+    when :not_registered  then "Tu n'étais pas inscrit au match « #{title} »."
+    else                       "Impossible de te désinscrire pour le moment. Réessaie plus tard."
+    end
+  end
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -375,6 +375,11 @@ class Match < ApplicationRecord
 
     SlackMatchStatusJob.perform_later(id)     # rafraîchit le "Quand" affiché maintenant
     SlackMatchStatusJob.schedule_transitions(self) # rebranche les bascules En cours/Terminé
+
+    # Nouvel horaire → on autorise un nouveau rappel "préparez-vous" et on le
+    # replanifie (le flag évite les doublons si un ancien job traîne encore).
+    update_column(:slack_prep_sent_at, nil) if slack_prep_sent_at.present?
+    SlackMatchPrepJob.schedule(self)
   end
 
   def cache_participant_ids

--- a/app/models/match_user.rb
+++ b/app/models/match_user.rb
@@ -42,6 +42,15 @@ class MatchUser < ApplicationRecord
   # idempotent (Turbo remplace la même cible), donc sans effet de bord.
   after_commit :broadcast_match_spots
 
+  # ── Rafraîchissement des cartes Slack ───────────────────────────────────────
+  # La carte Slack d'un match affiche la liste des inscrits (voir
+  # Slack::BlockKitBuilder#enrolled_players_label). Toute inscription qui ENTRE
+  # ou SORT de cette liste (approbation, refus, départ) doit ré-éditer les cartes
+  # suivies pour rester à jour — que l'inscription vienne du web ou de Slack.
+  # SlackMatchStatusJob reconstruit la carte ENTIÈRE (statut + détails + inscrits)
+  # et est idempotent : on le réutilise ici comme rafraîchisseur générique.
+  after_commit :refresh_slack_cards
+
   # Helpers pour vérifier le statut facilement
   def approved?
     status == "approved"
@@ -85,6 +94,37 @@ class MatchUser < ApplicationRecord
   # Ajoute la nouvelle conversation en haut de la sidebar sticky chat de l'utilisateur.
   # Déclenché quand il devient organisateur ou joueur approuvé.
   # Supprime aussi le message "Rejoins un match !" s'il était affiché.
+  # Ré-édite les cartes Slack du match quand la liste des inscrits a pu changer.
+  # On n'enfile le job que si :
+  #   - le match n'est pas en cours de suppression (sinon plus de cartes) ;
+  #   - la liste "approuvés + organisateur" a réellement bougé (départ, ou
+  #     franchissement de la limite "approved") — un pending créé/refusé
+  #     n'apparaît pas sur la carte Slack, donc pas de rafraîchissement inutile ;
+  #   - le match possède au moins une carte Slack suivie (évite un job à vide).
+  def refresh_slack_cards
+    return if destroyed_by_association
+    return unless slack_list_changed?
+    return unless match.slack_match_messages.exists?
+
+    SlackMatchStatusJob.perform_later(match_id)
+  end
+
+  # Statuts qui apparaissent sur la carte Slack (groupes "Inscrits" + "En attente").
+  # rejected/waiting n'y figurent pas → un passage vers/depuis ces statuts ne
+  # concerne la carte que s'il quitte/rejoint l'un des statuts listés.
+  SLACK_LISTED_STATUSES = %w[pending approved].freeze
+
+  # Vrai si l'ensemble affiché sur la carte Slack a pu changer lors de cette
+  # opération : départ d'un joueur (destroy), ou changement de statut dont
+  # l'ancien OU le nouveau figure parmi les statuts listés sur la carte.
+  def slack_list_changed?
+    return true if destroyed?
+    return false unless saved_change_to_status?
+
+    SLACK_LISTED_STATUSES.include?(status) ||
+      SLACK_LISTED_STATUSES.include?(status_before_last_save)
+  end
+
   def broadcast_new_convo_to_sidebar
     # On n'ajoute pas les matchs déjà terminés dans la sidebar
     return if match.past?

--- a/app/services/match_cancellation_service.rb
+++ b/app/services/match_cancellation_service.rb
@@ -1,0 +1,83 @@
+# ── Service MatchCancellationService ──────────────────────────────────────────
+# Encapsule l'annulation d'un match (= suppression, comme l'existant), extraite
+# de MatchesController#destroy pour être réutilisable depuis Slack (bouton
+# « Annuler le match »). Symétrique des autres services métier.
+#
+# Ordre CRITIQUE : tout ce qui a besoin du match ou de ses cartes Slack doit être
+# capturé AVANT le destroy, car `dependent: :destroy` supprime en cascade les
+# slack_match_messages, et SolidQueue ne peut pas recharger un enregistrement
+# détruit (d'où la sérialisation en scalaires pour les emails).
+#
+# Étapes :
+#   1. capture des destinataires + données email (scalaires) + coordonnées des
+#      cartes Slack suivies ;
+#   2. notification temps réel des participants (canal ActionCable encore vivant) ;
+#   3. destroy du match ;
+#   4. emails d'annulation asynchrones + édition des cartes Slack en « Annulé ».
+class MatchCancellationService
+  Result = Struct.new(:status, :title, keyword_init: true)
+
+  def initialize(match:)
+    @match = match
+  end
+
+  def call
+    participants = @match.match_users
+                         .where.not(role: "organisateur")
+                         .where(status: %w[approved pending waiting])
+                         .includes(:user)
+
+    recipient_emails = participants.map { |mu| mu.user.email }
+    recipient_emails << @match.user.email
+
+    email_args  = capture_email_args
+    slack_cards = capture_slack_cards
+    title       = @match.title
+
+    # Broadcasts Turbo AVANT destroy → le canal ActionCable doit encore exister.
+    participants.each { |mu| broadcast_cancellation(mu.user) }
+
+    @match.destroy
+
+    recipient_emails.each { |email| MatchCancelledMailerJob.perform_later(email, *email_args) }
+    SlackMatchCancelJob.perform_later(title, slack_cards) if slack_cards.any?
+
+    Result.new(status: :cancelled, title: title)
+  end
+
+  private
+
+  # Scalaires pour l'email (aucun objet AR : le match sera détruit).
+  # Ordre calqué sur MatchCancelledMailerJob#perform.
+  def capture_email_args
+    [
+      @match.title,
+      @match.date,
+      @match.time&.strftime("%Hh%M"),
+      @match.venue&.name,
+      @match.venue&.city,
+      @match.user.display_name
+    ]
+  end
+
+  # Coordonnées des cartes Slack (hashes sérialisables) captées avant la cascade
+  # destroy, pour pouvoir les éditer en « Annulé » ensuite.
+  def capture_slack_cards
+    @match.slack_match_messages.map do |msg|
+      { "workspace_id" => msg.slack_workspace_id,
+        "channel_id"   => msg.channel_id,
+        "message_ts"   => msg.message_ts }
+    end
+  end
+
+  # Notifie un participant en temps réel (modale « Match annulé »), peu importe
+  # la page où il se trouve. Rendu du partial hors controller via Turbo.
+  def broadcast_cancellation(participant_user)
+    Turbo::StreamsChannel.broadcast_update_to(
+      "user_#{participant_user.id}_notifications",
+      target:  "global_notification_container",
+      partial: "matches/match_cancelled_notification",
+      locals:  { match: @match }
+    )
+  end
+end

--- a/app/services/match_unenrollment_service.rb
+++ b/app/services/match_unenrollment_service.rb
@@ -1,0 +1,83 @@
+# ── Service MatchUnenrollmentService ──────────────────────────────────────────
+# Encapsule la logique métier de DÉSINSCRIPTION d'un joueur, extraite de
+# MatchUsersController#destroy afin de la réutiliser depuis un autre point
+# d'entrée (désinscription déclenchée depuis Slack). C'est le pendant de
+# MatchEnrollmentService.
+#
+# Responsabilités (métier pur, sans HTTP) :
+#   - retrouver l'inscription du joueur (no-op si absent) ;
+#   - si la place était approuvée : promouvoir le 1er de la file d'attente
+#     (sous verrou), puis prévenir l'organisateur du départ par email ;
+#   - détruire l'inscription (le callback MatchUser recalcule les places
+#     et rafraîchit la carte Slack).
+#
+# Ce qui reste au controller web : `authorize`, les broadcasts Turbo temps réel
+# (départ affiché à l'organisateur), le flash et la redirection. Le controller
+# mappe simplement `result.was_approved` vers ses broadcasts.
+#
+# Utilisation :
+#   result = MatchUnenrollmentService.new(match: @match, user: current_user).call
+#   result.status # => :left | :not_registered
+class MatchUnenrollmentService
+  # match_path n'est pas dispo hors controller/vue → on inclut les helpers de
+  # routes pour construire le lien des notifications (promotion depuis la file).
+  include Rails.application.routes.url_helpers
+
+  Result = Struct.new(:status, :leaving_user, :was_approved, keyword_init: true)
+
+  def initialize(match:, user:)
+    @match = match
+    @user  = user
+  end
+
+  def call
+    match_user = @match.match_users.find_by(user: @user)
+    return Result.new(status: :not_registered) unless match_user
+
+    leaving_user = match_user.user
+    was_approved = match_user.approved?
+
+    # Une place approuvée se libère → on promeut d'abord le 1er en file d'attente
+    # (avant le destroy, comme le controller web), puis on prévient l'organisateur.
+    promote_next_in_line if was_approved
+
+    match_user.destroy
+
+    UserMailer.match_player_left(@match, leaving_user).deliver_later if was_approved
+
+    Result.new(status: :left, leaving_user: leaving_user, was_approved: was_approved)
+  end
+
+  private
+
+  # Promeut le prochain joueur en file d'attente quand une place se libère.
+  # with_lock (SELECT FOR UPDATE) : évite que deux départs simultanés promeuvent
+  # deux personnes pour une seule place libérée.
+  def promote_next_in_line
+    promoted_record = nil
+
+    @match.with_lock do
+      next_in_line = @match.match_users.where(status: "waiting").order(created_at: :asc).first
+      if next_in_line
+        # Le passage à "approved" déclenche le recalcul de player_left (la place
+        # reste occupée, reprise par le promu).
+        next_in_line.update(status: "approved")
+        promoted_record = next_in_line
+      end
+      # Si personne n'attend : le destroy de l'inscription rendra la place.
+    end
+
+    return unless promoted_record
+
+    message = "🎉 Une place s'est libérée ! Tu as été automatiquement inscrit au match \"#{@match.title}\"."
+    notify(promoted_record.user, message)
+    UserMailer.match_status_changed(promoted_record, accepted: true).deliver_later
+  end
+
+  # Notification in-app (rien si user nil).
+  def notify(user, message)
+    return unless user
+
+    Notification.create(user: user, message: message, link: match_path(@match))
+  end
+end

--- a/app/services/slack/block_kit_builder.rb
+++ b/app/services/slack/block_kit_builder.rb
@@ -30,6 +30,8 @@ module Slack
         { type: "context",
           elements: [{ type: "mrkdwn", text: status_tag(match) }] },
         { type: "section", fields: fields },
+        # Liste des joueurs déjà inscrits ("Prénom N."), web ET Slack confondus.
+        { type: "section", text: { type: "mrkdwn", text: enrolled_players_label(match) } },
         { type: "actions", elements: action_elements(match) }
       ]
     end
@@ -69,6 +71,88 @@ module Slack
       "Nouveau tournoi : #{tournament.name}"
     end
 
+    # ── Rappel "préparez-vous" (~15 min avant le coup d'envoi) ──────────────────
+    # Nouveau message (pas une ré-édition de la carte) posté dans le(s) même(s)
+    # channel(s) que la carte du match. `mentions` (optionnel) = chaîne "<@U…> <@U…>"
+    # des joueurs dont le compte Slack est lié, pour les notifier nommément.
+    def match_prep_blocks(match, mentions = nil)
+      lines = ["*#{match.title}* démarre dans ~15 min. À vous de jouer ! 💪"]
+      lines << "📍 #{location_label(match)}"
+      lines << mentions if mentions.present?
+
+      [
+        { type: "header",
+          text: { type: "plain_text", text: "⏰ Ça commence bientôt !", emoji: true } },
+        { type: "section", text: { type: "mrkdwn", text: lines.join("\n") } },
+        { type: "actions",
+          elements: [
+            { type: "button",
+              text: { type: "plain_text", text: "Voir sur Teams-up", emoji: true },
+              url: match_url(match) }
+          ] }
+      ]
+    end
+
+    def match_prep_text(match)
+      "Ton match \"#{match.title}\" commence dans un quart d'heure — prépare-toi !"
+    end
+
+    # ── Carte "match annulé" ────────────────────────────────────────────────────
+    # Le match est supprimé lors de l'annulation → la carte devient un simple
+    # avis figé (ni ratio, ni boutons), construit à partir du seul titre capturé
+    # avant destruction.
+    def match_cancelled_blocks(title)
+      [
+        { type: "header",
+          text: { type: "plain_text", text: "🚫 Match annulé", emoji: true } },
+        { type: "section",
+          text: { type: "mrkdwn",
+                  text: "*#{title}*\n_Ce match a été annulé par l'organisateur._" } }
+      ]
+    end
+
+    def match_cancelled_text(title)
+      "Le match \"#{title}\" a été annulé."
+    end
+
+    # ── Liste "annuler un match" (réponse éphémère de /match-cancel) ────────────
+    # Liste des matchs à venir de l'organisateur, chacun avec un bouton
+    # « Annuler » (action_id match_cancel, organisateur vérifié côté
+    # SlackCancelJob). N'étant renvoyée qu'en éphémère, elle n'est visible que de
+    # l'auteur de la commande → le bouton reste privé à l'organisateur.
+    def cancel_list_blocks(matches)
+      if matches.empty?
+        return [{ type: "section",
+                  text: { type: "mrkdwn", text: "Tu n'as aucun match à venir à annuler." } }]
+      end
+
+      blocks = [{ type: "section",
+                  text: { type: "mrkdwn", text: "*Tes matchs à venir* — choisis celui à annuler :" } }]
+
+      matches.each do |match|
+        blocks << {
+          type: "section",
+          text: { type: "mrkdwn",
+                  text: "*#{match.title}*\n#{match_when_label(match)} · #{location_label(match)}" },
+          accessory: {
+            type: "button",
+            style: "danger",
+            text: { type: "plain_text", text: "Annuler", emoji: true },
+            action_id: "match_cancel",
+            value: match.id.to_s,
+            confirm: {
+              title:   { type: "plain_text", text: "Annuler ce match ?" },
+              text:    { type: "mrkdwn", text: "Les joueurs inscrits seront prévenus. Action irréversible." },
+              confirm: { type: "plain_text", text: "Annuler le match" },
+              deny:    { type: "plain_text", text: "Retour" }
+            }
+          }
+        }
+      end
+
+      blocks
+    end
+
     private
 
     # Formate date + heure de façon lisible ("15/07/2026 à 18:30").
@@ -96,7 +180,21 @@ module Slack
         action_id: "match_join",
         value: match.id.to_s
       }
-      [join_button, view_button]
+      # La carte est partagée (pas par-utilisateur) : on affiche les deux boutons.
+      # Un clic incohérent (déjà inscrit / pas inscrit) est géré côté job par un
+      # message éphémère explicite, sans effet de bord.
+      leave_button = {
+        type: "button",
+        style: "danger",
+        text: { type: "plain_text", text: "Se désinscrire", emoji: true },
+        action_id: "match_leave",
+        value: match.id.to_s
+      }
+      # NB : pas de bouton « Annuler » ici. Une carte de channel est partagée
+      # (mêmes blocs pour tous) → impossible de le réserver visuellement à
+      # l'organisateur. L'annulation depuis Slack passe par la slash command
+      # `/match-cancel`, dont la réponse éphémère n'est visible que de son auteur.
+      [join_button, leave_button, view_button]
     end
 
     # Statut du match d'après ses horaires réels :
@@ -152,6 +250,40 @@ module Slack
       total   = present + match.player_left.to_i
 
       "#{present}/#{total} personnes"
+    end
+
+    # Liste des joueurs affichée sur la carte, au format "Prénom N." — MÊME
+    # périmètre que la grille "Joueurs inscrits" du site : deux groupes,
+    # les "Inscrits" (approuvés + organisateur, organisateur en tête) et les
+    # "En attente" (pending). Peu importe le canal : une inscription via Slack
+    # crée un vrai match_user (compte lié obligatoire), donc web et Slack sont
+    # couverts à l'identique. `includes(user: :profil)` évite le N+1 (short_name
+    # lit le profil). Un bloc section Slack est plafonné à 3000 caractères → on
+    # tronque l'ensemble par sécurité si la liste est très longue.
+    def enrolled_players_label(match)
+      players = match.match_users
+                     .where("status IN (:shown) OR role = :organizer",
+                            shown: %w[pending approved], organizer: "organisateur")
+                     .includes(user: :profil)
+
+      approved = players.select { |mu| mu.approved? || mu.role == "organisateur" }
+                        .sort_by { |mu| mu.role == "organisateur" ? 0 : 1 }
+      pending  = players.reject { |mu| mu.approved? || mu.role == "organisateur" }
+
+      sections = [players_section("Inscrits", approved, empty: "Personne pour l'instant")]
+      sections << players_section("En attente", pending) if pending.any?
+
+      text = sections.join("\n\n")
+      text.length > 2900 ? "#{text[0, 2900]}…" : text
+    end
+
+    # Une ligne "*Label (N)*\nPrénom N. · Prénom N.". Si vide et qu'un libellé de
+    # repli est fourni, affiche "*Label*\n_repli_" ; sinon (groupe optionnel) rien.
+    def players_section(label, match_users, empty: nil)
+      names = match_users.map { |mu| mu.user.short_name }
+      return "*#{label}*\n_#{empty}_" if names.empty?
+
+      "*#{label} (#{names.size})*\n#{names.join(' · ')}"
     end
   end
 end

--- a/db/migrate/20260716094810_add_slack_prep_sent_at_to_matches.rb
+++ b/db/migrate/20260716094810_add_slack_prep_sent_at_to_matches.rb
@@ -1,0 +1,5 @@
+class AddSlackPrepSentAtToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :slack_prep_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_16_073744) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_094810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -175,6 +175,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_16_073744) do
     t.integer "players_present"
     t.integer "price_per_player", default: 0
     t.string "private_token"
+    t.datetime "slack_prep_sent_at"
     t.string "slug", null: false
     t.bigint "sport_id"
     t.bigint "team_id"

--- a/test/integration/slack_commands_test.rb
+++ b/test/integration/slack_commands_test.rb
@@ -111,6 +111,42 @@ class SlackCommandsTest < ActionDispatch::IntegrationTest
     assert_not_requested :post, VIEWS_OPEN
   end
 
+  # ── Slash command /match-cancel ────────────────────────────────────────────
+  test "/match-cancel sans compte lié → éphémère invitant à lier" do
+    signed_post slack_commands_path, command_body(command: "/match-cancel")
+    assert_response :ok
+    body = JSON.parse(@response.body)
+    assert_equal "ephemeral", body["response_type"]
+    assert_includes body["text"], "lie"
+  end
+
+  test "/match-cancel lié avec un match à venir → liste éphémère + bouton match_cancel" do
+    link_creator!
+    match = Match.create!(
+      title: "À annuler", date: Date.tomorrow, time: Time.current.change(hour: 18, min: 0),
+      players_needed: 4, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @creator, sport: @sport
+    )
+
+    signed_post slack_commands_path, command_body(command: "/match-cancel")
+    assert_response :ok
+    body = JSON.parse(@response.body)
+    assert_equal "ephemeral", body["response_type"]
+    action_ids = body["blocks"].filter_map { |b| b.dig("accessory", "action_id") }
+    values     = body["blocks"].filter_map { |b| b.dig("accessory", "value") }
+    assert_includes action_ids, "match_cancel"
+    assert_includes values, match.id.to_s
+  end
+
+  test "/match-cancel lié sans match à venir → éphémère 'aucun match'" do
+    link_creator!
+    signed_post slack_commands_path, command_body(command: "/match-cancel")
+    assert_response :ok
+    body = JSON.parse(@response.body)
+    assert_includes body["blocks"].to_s, "aucun match"
+  end
+
   test "signature invalide sur /match → 401" do
     post slack_commands_path, params: command_body,
          headers: {

--- a/test/jobs/slack_cancel_job_test.rb
+++ b/test/jobs/slack_cancel_job_test.rb
@@ -1,0 +1,74 @@
+# Tests de SlackCancelJob : annulation depuis Slack, réservée à l'organisateur.
+require "test_helper"
+require "webmock/minitest"
+
+class SlackCancelJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  RESPONSE_URL = "https://hooks.slack.com/actions/T_CANCEL/1/abc"
+
+  setup do
+    @organizer = create_test_user(email: "orga-scj@test.fr", first_name: "Orga", last_name: "T")
+    @other     = create_test_user(email: "other-scj@test.fr", first_name: "Autre", last_name: "T")
+    @sport     = Sport.create!(name: "Foot SCJ", slug: "foot-scj-#{SecureRandom.hex(3)}", icon: "⚽")
+    @workspace = SlackWorkspace.create!(team_id: "T_CANCEL", team_name: "Acme", bot_token: "xoxb-test")
+
+    @match = Match.create!(
+      title: "SCJ", date: Date.tomorrow, time: Time.current.change(hour: 18, min: 0),
+      players_needed: 4, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @organizer, sport: @sport
+    )
+    @match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+  end
+
+  teardown do
+    SlackIdentity.delete_all
+    SlackWorkspace.delete_all
+    teardown_db
+  end
+
+  def link!(user, slack_user_id)
+    SlackIdentity.create!(user: user, slack_workspace: @workspace,
+                          slack_user_id: slack_user_id, slack_team_id: "T_CANCEL")
+  end
+
+  def run_job(slack_user_id:)
+    SlackCancelJob.perform_now(
+      match_id: @match.id, team_id: "T_CANCEL",
+      slack_user_id: slack_user_id, response_url: RESPONSE_URL
+    )
+  end
+
+  # ── L'organisateur annule → match supprimé ─────────────────────────────────
+  test "organisateur → annule le match" do
+    link!(@organizer, "U_ORGA")
+    stub_request(:post, RESPONSE_URL).to_return(status: 200, body: "ok")
+
+    assert_difference "Match.count", -1 do
+      run_job(slack_user_id: "U_ORGA")
+    end
+  end
+
+  # ── Un non-organisateur ne peut pas annuler ────────────────────────────────
+  test "non-organisateur → refus, match conservé" do
+    link!(@other, "U_OTHER")
+    stub = stub_request(:post, RESPONSE_URL)
+             .with(body: /Seul l'organisateur/)
+             .to_return(status: 200, body: "ok")
+
+    assert_no_difference "Match.count" do
+      run_job(slack_user_id: "U_OTHER")
+    end
+    assert_requested stub
+  end
+
+  # ── Compte Slack non lié → invitation à lier, match conservé ───────────────
+  test "compte non lié → invitation à lier son compte" do
+    stub_request(:post, RESPONSE_URL).to_return(status: 200, body: "ok")
+
+    assert_no_difference "Match.count" do
+      run_job(slack_user_id: "U_UNKNOWN")
+    end
+  end
+end

--- a/test/jobs/slack_match_prep_job_test.rb
+++ b/test/jobs/slack_match_prep_job_test.rb
@@ -1,0 +1,99 @@
+# Tests de SlackMatchPrepJob : le rappel "préparez-vous" ~15 min avant le match.
+# Couvre la garde temporelle (fenêtre de rappel), l'envoi unique par créneau
+# (flag slack_prep_sent_at) et le ciblage du bon channel.
+#
+# On fige l'heure avec travel_to autour de build_datetime plutôt que de bricoler
+# les colonnes date/time (dont la lecture dépend du fuseau).
+require "test_helper"
+require "webmock/minitest"
+
+class SlackMatchPrepJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
+
+  POST_URL = "https://slack.com/api/chat.postMessage"
+
+  setup do
+    @organizer = create_test_user(email: "orga-prep@test.fr", first_name: "Orga", last_name: "T")
+    @sport     = Sport.create!(name: "Foot PREP", slug: "foot-prep-#{SecureRandom.hex(3)}", icon: "⚽")
+    @workspace = SlackWorkspace.create!(team_id: "T_PREP", team_name: "Acme", bot_token: "xoxb-test")
+
+    @match = Match.create!(
+      title: "Prep", date: Date.tomorrow, time: Time.current.change(hour: 18, min: 0),
+      players_needed: 4, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @organizer, sport: @sport
+    )
+    @match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+    SlackMatchMessage.create!(match: @match, slack_workspace: @workspace,
+                              channel_id: "C_PREP", message_ts: "111.222")
+    @kickoff = @match.build_datetime
+  end
+
+  teardown do
+    SlackMatchMessage.delete_all
+    SlackWorkspace.delete_all
+    teardown_db
+  end
+
+  def stub_post
+    stub_request(:post, POST_URL).to_return(
+      status: 200, body: { ok: true, channel: "C_PREP", ts: "999.888" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
+  # ── Match imminent (~15 min avant) → un message posté dans le bon channel ──
+  test "match imminent → poste le rappel" do
+    stub = stub_post
+    travel_to(@kickoff - 15.minutes) do
+      SlackMatchPrepJob.perform_now(@match.id)
+    end
+
+    assert_requested stub, times: 1
+    assert_not_nil @match.reload.slack_prep_sent_at
+  end
+
+  # ── Match trop lointain (hors fenêtre) → aucun envoi ───────────────────────
+  test "match hors fenêtre → n'envoie rien" do
+    stub = stub_post
+    travel_to(@kickoff - 2.hours) do
+      SlackMatchPrepJob.perform_now(@match.id)
+    end
+
+    assert_not_requested stub
+    assert_nil @match.reload.slack_prep_sent_at
+  end
+
+  # ── Match déjà commencé → aucun envoi ──────────────────────────────────────
+  test "match déjà commencé → n'envoie rien" do
+    stub = stub_post
+    travel_to(@kickoff + 5.minutes) do
+      SlackMatchPrepJob.perform_now(@match.id)
+    end
+
+    assert_not_requested stub
+  end
+
+  # ── Deux jobs empilés sur le même créneau → un seul envoi ──────────────────
+  test "double exécution → un seul rappel (flag)" do
+    stub = stub_post
+    travel_to(@kickoff - 15.minutes) do
+      SlackMatchPrepJob.perform_now(@match.id)
+      SlackMatchPrepJob.perform_now(@match.id)
+    end
+
+    assert_requested stub, times: 1
+  end
+
+  # ── Aucune carte Slack suivie → aucun envoi ────────────────────────────────
+  test "match sans carte Slack → n'envoie rien" do
+    @match.slack_match_messages.delete_all
+    stub = stub_post
+    travel_to(@kickoff - 15.minutes) do
+      SlackMatchPrepJob.perform_now(@match.id)
+    end
+
+    assert_not_requested stub
+  end
+end

--- a/test/services/match_cancellation_service_test.rb
+++ b/test/services/match_cancellation_service_test.rb
@@ -1,0 +1,72 @@
+# Tests de MatchCancellationService : annulation = suppression, avec emails aux
+# participants + organisateur et édition des cartes Slack en « Annulé ».
+require "test_helper"
+
+class MatchCancellationServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @organizer = create_test_user(email: "orga-mcs@test.fr", first_name: "Orga", last_name: "T")
+    @player    = create_test_user(email: "player-mcs@test.fr", first_name: "Joueur", last_name: "T")
+    @sport     = Sport.create!(name: "Foot MCS", slug: "foot-mcs-#{SecureRandom.hex(3)}", icon: "⚽")
+  end
+
+  teardown do
+    SlackMatchMessage.delete_all
+    SlackWorkspace.delete_all
+    teardown_db
+  end
+
+  def build_match
+    match = Match.create!(
+      title: "M-#{SecureRandom.hex(3)}", date: Date.tomorrow,
+      time: Time.current.change(hour: 18, min: 0),
+      players_needed: 4, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @organizer, sport: @sport
+    )
+    match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+    match.match_users.create!(user: @player, role: "joueur", status: "approved")
+    match
+  end
+
+  # ── Annulation → match supprimé ────────────────────────────────────────────
+  test "annulation supprime le match" do
+    match = build_match
+
+    assert_difference "Match.count", -1 do
+      result = MatchCancellationService.new(match: match).call
+      assert_equal :cancelled, result.status
+    end
+  end
+
+  # ── Emails d'annulation à chaque destinataire (participant + organisateur) ──
+  test "annulation enfile un email par destinataire" do
+    match = build_match
+
+    assert_enqueued_jobs 2, only: MatchCancelledMailerJob do
+      MatchCancellationService.new(match: match).call
+    end
+  end
+
+  # ── Carte Slack suivie → job d'édition « Annulé » enfilé ───────────────────
+  test "annulation enfile l'édition des cartes Slack quand il y en a" do
+    match     = build_match
+    workspace = SlackWorkspace.create!(team_id: "T_MCS", team_name: "Acme", bot_token: "xoxb-test")
+    SlackMatchMessage.create!(match: match, slack_workspace: workspace,
+                              channel_id: "C_MCS", message_ts: "1.2")
+
+    assert_enqueued_with(job: SlackMatchCancelJob) do
+      MatchCancellationService.new(match: match).call
+    end
+  end
+
+  # ── Aucune carte Slack → pas de job d'édition ──────────────────────────────
+  test "annulation sans carte Slack n'enfile pas SlackMatchCancelJob" do
+    match = build_match
+
+    assert_no_enqueued_jobs only: SlackMatchCancelJob do
+      MatchCancellationService.new(match: match).call
+    end
+  end
+end

--- a/test/services/match_unenrollment_service_test.rb
+++ b/test/services/match_unenrollment_service_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+# Tests unitaires de MatchUnenrollmentService : la logique métier de
+# désinscription extraite de MatchUsersController#destroy (et réutilisée par la
+# désinscription Slack). Couvre les cas de retour et la promotion de la file.
+class MatchUnenrollmentServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @organizer = create_test_user(email: "orga-mus@test.fr", first_name: "Orga", last_name: "T")
+    @player    = create_test_user(email: "player-mus@test.fr", first_name: "Joueur", last_name: "T")
+    @sport     = Sport.create!(name: "Foot MUS", slug: "foot-mus-#{SecureRandom.hex(3)}", icon: "⚽")
+  end
+
+  teardown { teardown_db }
+
+  # Fabrique un match avec son organisateur inscrit.
+  def build_match(players_needed: 4)
+    match = Match.create!(
+      title: "M-#{SecureRandom.hex(3)}", date: Date.tomorrow,
+      time: Time.current.change(hour: 18, min: 0),
+      players_needed: players_needed, level: "Débutant", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      user: @organizer, sport: @sport
+    )
+    match.match_users.create!(user: @organizer, role: "organisateur", status: "approved")
+    match
+  end
+
+  def unenroll(match, user)
+    MatchUnenrollmentService.new(match: match, user: user).call
+  end
+
+  # ── Joueur approuvé qui part → inscription supprimée ───────────────────────
+  test "joueur approuvé → left et inscription supprimée" do
+    match = build_match
+    match.match_users.create!(user: @player, role: "joueur", status: "approved")
+
+    result = nil
+    assert_difference "MatchUser.count", -1 do
+      result = unenroll(match, @player)
+    end
+
+    assert_equal :left, result.status
+    assert_equal @player, result.leaving_user
+    assert result.was_approved
+    assert_nil match.match_users.find_by(user: @player)
+  end
+
+  # ── Départ d'un approuvé → email de départ à l'organisateur ────────────────
+  test "le départ d'un approuvé envoie un email à l'organisateur" do
+    match = build_match
+    match.match_users.create!(user: @player, role: "joueur", status: "approved")
+
+    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+      unenroll(match, @player)
+    end
+  end
+
+  # ── Non inscrit → not_registered, aucune suppression ───────────────────────
+  test "joueur non inscrit → not_registered sans suppression" do
+    match = build_match
+
+    assert_no_difference "MatchUser.count" do
+      assert_equal :not_registered, unenroll(match, @player).status
+    end
+  end
+
+  # ── Départ d'un approuvé → promotion du 1er en file d'attente ──────────────
+  test "le départ d'un approuvé promeut le premier en file d'attente" do
+    match   = build_match(players_needed: 1) # place unique
+    waiting = create_test_user(email: "waiter-mus@test.fr", first_name: "Wai", last_name: "T")
+    match.match_users.create!(user: @player, role: "joueur", status: "approved")
+    waiting_mu = match.match_users.create!(user: waiting, role: "joueur", status: "waiting")
+
+    unenroll(match, @player)
+
+    assert_equal "approved", waiting_mu.reload.status
+  end
+
+  # ── Départ d'un joueur en attente (pending) → pas d'email, pas de promotion ─
+  test "le départ d'un pending ne déclenche ni email ni promotion" do
+    match = build_match
+    match.match_users.create!(user: @player, role: "joueur", status: "pending")
+
+    result = nil
+    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      result = unenroll(match, @player)
+    end
+
+    assert_equal :left, result.status
+    assert_not result.was_approved
+  end
+end


### PR DESCRIPTION
…ation

- Carte match : liste des inscrits (Prénom N.) + joueurs en attente, rafraîchie à chaque changement d'inscription
- Bouton "Se désinscrire" (SlackUnenrollJob + MatchUnenrollmentService partagé)
- Rappel "préparez-vous" ~15 min avant le match (SlackMatchPrepJob), avec mentions des joueurs liés, garde temporelle et flag anti-doublon
- Annulation par l'organisateur depuis le site et Slack (/match-cancel éphémère), carte éditée en "Annulé" (MatchCancellationService + SlackCancelJob)
- Concern SlackEphemeralResponder pour factoriser les réponses éphémères