### PR TITLE
Fix Slack : ne plus masquer une panne de destinations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -211,17 +211,22 @@ class ApplicationController < ActionController::Base
 
   # Destinations Slack de TOUS les workspaces liés de l'utilisateur, pour permettre une
   # sélection en deux temps (workspace puis channel/DM). Renvoie un tableau :
-  #   [{ id:, name:, destinations: { "Channels" => [...], "Messages directs" => [...] } }]
+  #   [{ id:, name:, destinations: { "Channels" => [...], "Messages directs" => [...] },
+  #      needs_reinstall: false }]
+  # `needs_reinstall` = le token du bot est mort → l'app doit être réinstallée (le
+  # dropdown vide n'est alors PAS un bug de config mais une connexion Slack expirée).
   # Vide si le compte n'est pas lié. Utilisé par matches#new, tournaments#new et le partage.
   def slack_destinations_for(user)
     return [] unless user.slack_linked?
 
     user.slack_identities.includes(:slack_workspace).map do |identity|
-      ws = identity.slack_workspace
+      ws     = identity.slack_workspace
+      result = Slack::ChannelLister.resolve(ws)
       {
         id: ws.id,
         name: ws.team_name.presence || ws.team_id,
-        destinations: Slack::ChannelLister.destinations(ws)
+        destinations: result[:groups],
+        needs_reinstall: result[:auth_failed]
       }
     end
   end

--- a/app/controllers/profils_controller.rb
+++ b/app/controllers/profils_controller.rb
@@ -151,6 +151,10 @@ class ProfilsController < ApplicationController
     skip_authorization
     @slack_identities = current_user.slack_identities.includes(:slack_workspace)
     @slack_configured = Slack.configured?
+    # Au moins un espace lié dont le token du bot est mort → invite à réinstaller.
+    @slack_needs_reinstall = @slack_identities.any? do |identity|
+      Slack::ChannelLister.resolve(identity.slack_workspace)[:auth_failed]
+    end
   end
 
   # POST /profil/dismiss_onboarding

--- a/app/services/slack/channel_lister.rb
+++ b/app/services/slack/channel_lister.rb
@@ -10,25 +10,40 @@
 # un ID d'utilisateur (U...) comme `channel` — dans ce dernier cas Slack ouvre/poste
 # le message direct. Aucune distinction n'est donc nécessaire côté envoi.
 #
-# Robustesse : renvoie {} en cas d'erreur (token révoqué, réseau, scope manquant)
-# plutôt que de faire planter le rendu du formulaire.
+# Robustesse : chaque appel API est isolé (une erreur sur users.list ne doit pas faire
+# disparaître les channels, et inversement) et on distingue les erreurs FATALES
+# d'authentification (token révoqué/invalide → réinstallation requise) des erreurs
+# partielles (un scope manquant). Le rendu du formulaire ne plante jamais.
 module Slack
   class ChannelLister
     CONVERSATIONS_LIST_URL = "#{Slack::API_BASE_URL}/conversations.list".freeze
     USERS_LIST_URL         = "#{Slack::API_BASE_URL}/users.list".freeze
 
-    def self.destinations(workspace)
-      return {} unless workspace&.bot_token.present?
+    # Erreurs Slack signifiant que le jeton du bot est mort : seule une RÉINSTALLATION
+    # de l'app (nouveau bot_token) répare, pas une simple nouvelle liaison d'identité.
+    FATAL_AUTH_ERRORS = %w[invalid_auth token_revoked account_inactive not_authed].freeze
+
+    # Version riche : hash groupé des destinations + drapeau `auth_failed` indiquant que
+    # le workspace doit être réinstallé (token mort ou bot_token illisible).
+    #   { groups: { "Channels" => [...], "Messages directs" => [...] }, auth_failed: false }
+    def self.resolve(workspace)
+      token = read_token(workspace)
+      return { groups: {}, auth_failed: false }         if token == :missing
+      return { groups: {}, auth_failed: true }          if token == :unreadable
+
+      channels, ch_fatal = safe_fetch { fetch_channels(workspace) }
+      members,  mb_fatal = safe_fetch { fetch_members(workspace) }
 
       groups = {}
-      channels = fetch_channels(workspace)
-      members  = fetch_members(workspace)
-      groups["Channels"] = channels if channels.any?
-      groups["Messages directs"] = members if members.any?
-      groups
-    rescue Slack::ApiClient::Error, StandardError => e
-      Rails.logger.warn("[Slack::ChannelLister] #{e.message}")
-      {}
+      groups["Channels"]         = channels if channels.any?
+      groups["Messages directs"] = members  if members.any?
+
+      { groups: groups, auth_failed: ch_fatal || mb_fatal }
+    end
+
+    # Compat : renvoie directement le hash groupé (formulaire de partage + JS Stimulus).
+    def self.destinations(workspace)
+      resolve(workspace)[:groups]
     end
 
     # Channels publics et privés → paires ["#nom", id].
@@ -54,6 +69,31 @@ module Slack
         .sort_by { |name, _id| name.to_s.downcase }
     end
 
-    private_class_method :fetch_channels, :fetch_members
+    # Lit le bot_token en gérant le cas où il n'existe pas (:missing) et celui où il
+    # existe mais n'est plus déchiffrable — clés Active Record Encryption changées —
+    # auquel cas la réinstallation est nécessaire (:unreadable).
+    def self.read_token(workspace)
+      return :missing unless workspace
+
+      token = workspace.bot_token
+      token.present? ? token : :missing
+    rescue StandardError => e
+      Rails.logger.warn("[Slack::ChannelLister] bot_token illisible: #{e.class}")
+      :unreadable
+    end
+
+    # Exécute un appel API isolé. Renvoie [valeurs, fatal?] : en cas d'erreur, une liste
+    # vide et un booléen indiquant si l'erreur est une panne d'authentification fatale.
+    def self.safe_fetch
+      [yield, false]
+    rescue Slack::ApiClient::Error => e
+      Rails.logger.warn("[Slack::ChannelLister] #{e.slack_error}")
+      [[], FATAL_AUTH_ERRORS.include?(e.slack_error)]
+    rescue StandardError => e
+      Rails.logger.warn("[Slack::ChannelLister] #{e.class}: #{e.message}")
+      [[], false]
+    end
+
+    private_class_method :fetch_channels, :fetch_members, :read_token, :safe_fetch
   end
 end

--- a/app/views/profils/integrations.html.erb
+++ b/app/views/profils/integrations.html.erb
@@ -38,6 +38,17 @@
         </div>
       <% end %>
 
+      <% if @slack_needs_reinstall %>
+        <%# Token du bot mort : « Se connecter » (liaison d'identité) ne répare pas,
+            seule la réinstallation régénère le bot_token. On oriente vers la bonne action. %>
+        <div class="alert alert-warning small mb-3" role="alert">
+          <i data-lucide="alert-triangle" style="width:16px; height:16px; vertical-align:-3px;"></i>
+          La connexion à ton espace Slack a expiré : les matchs ne peuvent plus y être postés.
+          Clique <strong>« Installer sur un espace Slack »</strong> ci-dessous pour la rétablir
+          (réservé aux admins Slack). Inutile de simplement te reconnecter.
+        </div>
+      <% end %>
+
       <% if @slack_identities.any? %>
         <%# ── Identités déjà liées ──────────────────────────────────────── %>
         <div class="mb-3">

--- a/app/views/shared/_slack_share_field.html.erb
+++ b/app/views/shared/_slack_share_field.html.erb
@@ -38,6 +38,16 @@
       <%# En mode formulaire : masqué tant que la case n'est pas cochée (Stimulus).
           En mode standalone (modale) : toujours visible. %>
       <div data-slack-share-target="wrapper" style="<%= "display:none;" unless standalone %>">
+        <% if workspaces.any? { |w| w[:needs_reinstall] } %>
+          <%# Connexion Slack expirée (token du bot révoqué/invalide) : relier l'identité
+              ne répare PAS — il faut réinstaller l'app pour obtenir un nouveau bot_token. %>
+          <div class="alert alert-warning small mb-3" role="alert">
+            <i data-lucide="alert-triangle" style="width:16px; height:16px; vertical-align:-3px;"></i>
+            La connexion à ton espace Slack a expiré. Les destinations ne peuvent plus être
+            chargées — <%= link_to "réinstalle l'app Teams-up", slack_install_path, class: "alert-link" %>
+            (réservé aux admins Slack) pour la rétablir.
+          </div>
+        <% end %>
         <% if workspaces.size > 1 %>
           <div class="mb-2">
             <%# Couleur theme-aware (pas le .text-muted fixe de Bootstrap, illisible sur fond sombre) %>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -115,3 +115,15 @@ Un sport est **piloté par la base** (table `sports` : `name`, `icon`, `slug`) m
 **Édition d'horaire gérée** : `Match#after_update_commit :resync_slack_messages` (si `date`/`time`/`end_time` change ET cartes suivies) → rafraîchit les cartes immédiatement (nouveau « Quand ») + `SlackMatchStatusJob.schedule_transitions` rebranche les bascules aux nouveaux horaires. Les anciens jobs planifiés restent inoffensifs (statut recalculé à T par un job idempotent).
 
 **Piège CSS** : `.btn-cta-primary` ne fournit QUE `border-radius` + `:hover` ; le fond vert vient de Bootstrap `.btn-primary`. Un bouton `btn btn-sm btn-cta-primary` (sans `btn-primary`) est donc transparent → invisible sur fond sombre. Toujours coupler `btn-primary btn-cta-primary` (cf bouton « Connecter Slack » du profil).
+
+## 2026-07-20 — Panne Slack transitoire masquée (dropdown de destinations vide)
+
+**Symptôme** : plus aucun channel dans le modal « Partager sur Slack » (seul « Ma destination par défaut » restait), un matin sans déploiement.
+
+**Cause racine** : incident réseau/Slack **transitoire** (`conversations.list`/`users.list` en échec quelques minutes). `Slack::ChannelLister.destinations` avait un `rescue StandardError` global qui renvoyait `{}` **en silence** → dropdown vide sans aucune explication. Le cache **Turbo Drive** figeait ensuite le HTML (destinations vides embarquées dans `data-slack-share-data-value`) → le vide persistait à la navigation même après rétablissement de Slack. Un **hard refresh** (Cmd+Shift+R) suffisait à récupérer les channels.
+
+**Diagnostic** : `railway run bin/rails runner` + un script bouclant sur `SlackWorkspace.find_each` (PAS `.first` : il y a 2 workspaces, Test + CACD2) → `auth.test` / `conversations.list` / `users.list` par workspace. Tout OK au moment du diagnostic = panne passagère confirmée.
+
+**Correctifs** : (1) `ChannelLister` isole chaque appel (`safe_fetch`) — une erreur sur `users.list` ne fait plus disparaître les channels ; (2) `resolve` renvoie `auth_failed` (erreurs FATALES `invalid_auth`/`token_revoked`/`account_inactive` + bot_token illisible) ; (3) bandeau « réinstalle l'app » dans le modal de partage + page Intégrations quand `auth_failed` → oriente vers `/slack/install` (réinstaller), PAS `/slack/connect` (relier une identité ne régénère aucun bot_token).
+
+**Leçon** : ne jamais avaler une erreur d'API externe en `{}` silencieux dans du contenu mis en cache par Turbo — soit dégrader avec un signal visible (bandeau), soit `turbo-cache-control no-cache` sur les vues dépendant d'un état externe volatil.

--- a/test/integration/slack_integration_test.rb
+++ b/test/integration/slack_integration_test.rb
@@ -101,6 +101,38 @@ class SlackIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal [["Bob", "U9"]], dest["Messages directs"] # le bot est exclu
   end
 
+  # ── Robustesse : un appel qui échoue ne fait pas disparaître l'autre liste ─────
+  test "ChannelLister isole les appels : users.list en échec garde les channels" do
+    ws = link_slack!
+    stub_request(:post, "https://slack.com/api/conversations.list")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" },
+                 body: { ok: true, channels: [{ id: "C1", name: "general" }] }.to_json)
+    # Scope manquant sur users.list (erreur NON fatale) → les DM sont perdus, pas les channels.
+    stub_request(:post, "https://slack.com/api/users.list")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" },
+                 body: { ok: false, error: "missing_scope" }.to_json)
+
+    result = Slack::ChannelLister.resolve(ws)
+    assert_equal [["#general", "C1"]], result[:groups]["Channels"]
+    assert_nil result[:groups]["Messages directs"]
+    assert_not result[:auth_failed] # missing_scope n'exige pas une réinstallation
+  end
+
+  # ── Robustesse : token mort → auth_failed pour piloter le bandeau « réinstalle » ─
+  test "ChannelLister signale auth_failed quand le token du bot est révoqué" do
+    ws = link_slack!
+    stub_request(:post, "https://slack.com/api/conversations.list")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" },
+                 body: { ok: false, error: "invalid_auth" }.to_json)
+    stub_request(:post, "https://slack.com/api/users.list")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" },
+                 body: { ok: false, error: "invalid_auth" }.to_json)
+
+    result = Slack::ChannelLister.resolve(ws)
+    assert_empty result[:groups]
+    assert result[:auth_failed]
+  end
+
   # ── Partage manuel depuis la page match : organisateur lié → job enqueue ───────
   test "POST share_on_slack par l'organisateur lié enqueue SlackNotifyJob avec la destination" do
     ws = link_slack!


### PR DESCRIPTION
Une erreur transitoire de conversations.list/users.list vidait le dropdown de partage en silence (rescue {} global) + le cache Turbo figeait ce vide.

- ChannelLister : appels isolés (une erreur ne masque plus l'autre liste), resolve renvoie auth_failed, log du code Slack exact
- Bandeau "connexion Slack expirée, réinstalle l'app" (modal de partage + page Intégrations) au lieu d'un vide muet
- Tests : isolation des appels + détection auth_failed