### PR TITLE
Tournoi : rencontres planifiées par les joueurs, scoring par phase et…

### DIFF
--- a/app/assets/stylesheets/pages/_tournaments_form.scss
+++ b/app/assets/stylesheets/pages/_tournaments_form.scss
@@ -2,12 +2,55 @@
 // TOURNAMENTS FORM — Écarts spécifiques à la création de tournoi
 // La structure (sections, récap, boutons) réutilise _match_form.scss.
 // On ne style ici que les éléments propres au tournoi :
-//   • aperçu de structure figée
+//   • aperçu de structure
 //   • propositions du mode "Libre"
+//   • réglages de structure personnalisables (bloc dépliant)
 // Tokens de thème var(--theme-*) + accent $green.
 // =====================================================
 
-// ── Aperçu de structure figée (lecture seule) ──
+// ── Réglages de structure personnalisables (Lot 7) ──
+// Bloc dépliant sous le nombre de joueurs : replié par défaut pour ne pas alourdir
+// le formulaire (les valeurs recommandées suffisent dans la majorité des cas).
+.tournament-advanced {
+  margin: 0.25rem 0 1rem;
+
+  &__toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.7rem;
+    border-radius: 0.5rem;
+    border: 1px dashed var(--theme-border-strong);
+    background: transparent;
+    color: var(--theme-text-muted);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+
+    &:hover {
+      border-color: $green;
+      color: var(--theme-text-primary);
+    }
+
+    i { flex-shrink: 0; }
+
+    &[aria-expanded="true"] {
+      border-style: solid;
+      border-color: rgba(30, 221, 136, 0.4);
+      color: var(--theme-text-primary);
+    }
+  }
+
+  &__fields {
+    margin-top: 0.75rem;
+    padding: 0.85rem;
+    border-radius: 0.6rem;
+    border: 1px solid var(--theme-border-strong);
+    background: var(--theme-hover-bg);
+  }
+}
+
+// ── Aperçu de structure ──
 .tournament-structure-preview {
   display: flex;
   align-items: center;

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -192,10 +192,11 @@ class MatchesController < ApplicationController
     # Équipes dont l'user est capitaine (pour le select dans le formulaire)
     @my_captained_teams = current_user.captained_teams.order(:name)
 
-    # Couplage tournoi (Lot 4) : préremplissage depuis « Créer la rencontre »
-    # d'une carte, et liste des tournois qu'on organise (select du formulaire).
+    # Couplage tournoi (Lot 4, élargi Lot 7) : préremplissage depuis « Créer la
+    # rencontre » d'une carte, et listes du formulaire (tournois rattachables +
+    # confrontations rattachables, pour le préremplissage côté client).
     prefill_from_tournament_match
-    @organized_tournaments = organized_tournaments_for_select
+    load_tournament_link_options
 
     # Destinations Slack pour le partage optionnel (vide si le compte n'est pas lié)
     @slack_destinations = slack_destinations_for(current_user)
@@ -222,8 +223,9 @@ class MatchesController < ApplicationController
       end
     end
 
-    # Couplage tournoi (Lot 4) : ne conserver le rattachement que si l'utilisateur
-    # organise bien le tournoi visé (pattern défensif, comme pour team_id).
+    # Couplage tournoi (Lot 4, élargi Lot 7) : ne conserver le rattachement que si
+    # l'utilisateur y a droit (joueur de la confrontation ou organisateur du
+    # tournoi) — pattern défensif, comme pour team_id.
     sanitize_tournament_link
 
     authorize @match
@@ -259,7 +261,7 @@ class MatchesController < ApplicationController
       redirect_to @match, notice: "Match créé avec succès !"
     else
       @my_captained_teams = current_user.captained_teams.order(:name)
-      @organized_tournaments = organized_tournaments_for_select
+      load_tournament_link_options
       # En cas d'erreur, réaffiche le formulaire
       render :new, status: :unprocessable_entity
     end
@@ -544,30 +546,99 @@ class MatchesController < ApplicationController
     )
   end
 
-  # Tournois que l'utilisateur organise et qui ne sont pas terminés — proposés
-  # dans le select du formulaire pour rattacher une rencontre à un tournoi.
-  def organized_tournaments_for_select
-    Tournament.where(user_id: current_user.id).where.not(status: "completed").order(:name)
+  # ── Couplage tournoi ────────────────────────────────────────────────────────
+  # Options du bloc « Tournoi » du formulaire : les tournois rattachables + la map
+  # de leurs confrontations rattachables (pour le select « Confrontation » et le
+  # préremplissage côté client, cf. match_form_controller#updateTournament).
+  def load_tournament_link_options
+    @linkable_tournaments = linkable_tournaments_for_select
+    @linkable_tournament_matches = linkable_tournament_matches_map(@linkable_tournaments)
+  end
+
+  # Tournois non terminés auxquels l'utilisateur peut rattacher une rencontre :
+  # ceux qu'il organise ET ceux où il est inscrit (un joueur planifie lui-même sa
+  # rencontre de poule, cf. TournamentMatchPolicy#create_match?).
+  def linkable_tournaments_for_select
+    Tournament.where.not(status: "completed")
+              .left_joins(:tournament_users)
+              .where(
+                "tournaments.user_id = :id OR (tournament_users.user_id = :id AND tournament_users.status = 'approved')",
+                id: current_user.id
+              )
+              .distinct.order(:name)
+  end
+
+  # Confrontations rattachables, groupées par tournoi :
+  #   { tournament_id => [{ id:, label:, sport_id:, title:, place:, … }, …] }
+  # Filtres : pas de bye, pas déjà rattachée à une rencontre, et l'utilisateur y
+  # joue ou organise le tournoi — mêmes règles que create_match?, mais évaluées
+  # une seule fois par tournoi (organizer? interroge les co-organisateurs).
+  def linkable_tournament_matches_map(tournaments)
+    return {} if tournaments.empty?
+
+    pending = TournamentMatch.where(is_bye: false).where.missing(:match)
+                             .joins(:tournament_round)
+                             .where(tournament_rounds: { tournament_id: tournaments.map(&:id) })
+                             .includes(:tournament_round, :player_a, :player_b)
+                             .order(:position)
+
+    pending.group_by { |tm| tm.tournament_round.tournament_id }.each_with_object({}) do |(tournament_id, tms), map|
+      tournament = tournaments.find { |t| t.id == tournament_id }
+      organizer  = tournament.organizer?(current_user)
+
+      rows = tms.filter_map do |tm|
+        next if tm.player_b.nil? # carte incomplète (ne devrait pas arriver hors bye)
+        next unless organizer || [tm.player_a.user_id, tm.player_b.user_id].include?(current_user.id)
+
+        tournament_match_option(tm, tournament)
+      end
+
+      map[tournament_id] = rows if rows.any?
+    end
+  end
+
+  # Une confrontation telle que la voit le formulaire (JSON consommé par Stimulus).
+  # Les champs de préremplissage reprennent exactement ceux de
+  # prefill_from_tournament_match : une seule règle, deux points d'application.
+  def tournament_match_option(tmatch, tournament)
+    {
+      id: tmatch.id,
+      label: "#{tmatch.player_a.display_name} vs #{tmatch.player_b.display_name}",
+      title: tournament_match_title(tmatch, tournament),
+      sport_id: tournament.sport_id,
+      place: tournament.place,
+      venue_id: tournament.venue_id,
+      date: tournament.date&.to_s,
+      time: tournament.time&.strftime("%H:%M"),
+      banner_image: tournament.banner_image
+    }
+  end
+
+  # Titre par défaut d'une rencontre issue d'une confrontation de tournoi.
+  def tournament_match_title(tmatch, tournament)
+    "#{tournament.sport&.name} — #{tmatch.player_a.display_name} vs #{tmatch.player_b.display_name}"
   end
 
   # Préremplit @match depuis une carte de tournoi (?tournament_match_id=X).
-  # Sécurité : ignoré si la carte est absente, un bye, ou si l'utilisateur
-  # n'organise pas le tournoi.
+  # Sécurité : ignoré si la carte est absente ou si l'utilisateur n'a pas le droit
+  # de planifier cette rencontre (bye, rencontre déjà créée, ni joueur ni
+  # organisateur — cf. TournamentMatchPolicy#create_match?).
   def prefill_from_tournament_match
     return if params[:tournament_match_id].blank?
 
     tm = TournamentMatch.find_by(id: params[:tournament_match_id])
-    return if tm.nil? || tm.is_bye || !tm.tournament.organizer?(current_user)
+    return if tm.nil? || !policy(tm).create_match?
 
     @match.tournament_match = tm
     @match.tournament       = tm.tournament
     @match.sport            = tm.tournament.sport
     @match.level            = "Tout niveau" # niveau neutre : bypass la grille du sport
     @match.players_needed   = 2
-    @match.title            = "#{tm.tournament.sport&.name} — #{tm.player_a.display_name} vs #{tm.player_b.display_name}"
+    @match.title            = tournament_match_title(tm, tm.tournament)
 
-    # Reprend le lieu et la date/heure déjà connus du tournoi, pour éviter à
-    # l'organisateur de tout ressaisir à la main.
+    # Reprend le lieu et la date/heure déjà connus du tournoi, pour éviter de tout
+    # ressaisir à la main. Tout reste modifiable : les deux joueurs conviennent de
+    # leur créneau (un tournoi n'a d'ailleurs plus d'heure de début, cf. Lot 7).
     @match.venue_id = tm.tournament.venue_id if tm.tournament.venue_id.present?
     @match.place    = tm.tournament.place    if tm.tournament.place.present?
     @match.date     = tm.tournament.date     if tm.tournament.date.present?
@@ -579,11 +650,12 @@ class MatchesController < ApplicationController
   end
 
   # Valide le rattachement tournoi envoyé par le formulaire : ne le persiste que
-  # si l'utilisateur organise le tournoi ciblé (sinon on annule les deux refs).
+  # si l'utilisateur y a droit (joueur de la confrontation ou organisateur du
+  # tournoi), sinon on annule les deux refs.
   def sanitize_tournament_link
     if @match.tournament_match_id.present?
       tm = TournamentMatch.find_by(id: @match.tournament_match_id)
-      if tm && !tm.is_bye && tm.tournament.organizer?(current_user)
+      if tm && policy(tm).create_match?
         @match.tournament = tm.tournament
       else
         @match.tournament = nil
@@ -591,8 +663,15 @@ class MatchesController < ApplicationController
       end
     elsif @match.tournament_id.present?
       tournament = Tournament.find_by(id: @match.tournament_id)
-      @match.tournament = nil unless tournament&.organizer?(current_user)
+      @match.tournament = nil unless tournament && linkable_tournament?(tournament)
     end
+  end
+
+  # L'utilisateur peut-il rattacher une rencontre à ce tournoi (sans viser une
+  # confrontation précise) ? Organisateur ou inscrit approuvé.
+  def linkable_tournament?(tournament)
+    tournament.organizer?(current_user) ||
+      tournament.tournament_users.approved.exists?(user_id: current_user.id)
   end
 
   # Inscrit les deux joueurs de la carte de tournoi comme participants approuvés

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -267,10 +267,14 @@ class TournamentsController < ApplicationController
     @noindex = true
   end
 
-  # Verrouille format/nb de joueurs/sport/playoffs une fois le tournoi lancé : ces
-  # champs pilotent le moteur de jeu (TournamentEngine) et casseraient un
-  # tirage/tableau déjà en cours s'ils changeaient sous le pied de la mécanique.
-  STRUCTURAL_FIELDS = %i[sport_id format max_players playoffs].freeze
+  # Verrouille format/nb de joueurs/sport/playoffs et les réglages de structure
+  # (Lot 7) une fois le tournoi lancé : ces champs pilotent le moteur de jeu
+  # (TournamentEngine) et casseraient un tirage/tableau déjà en cours s'ils
+  # changeaient sous le pied de la mécanique.
+  STRUCTURAL_FIELDS = %i[
+    sport_id format max_players playoffs
+    players_per_pool bracket_size swiss_wins_to_qualify swiss_losses_to_eliminate
+  ].freeze
 
   def tournament_params
     permitted = %i[name description date time place venue_id banner_image] + STRUCTURAL_FIELDS

--- a/app/helpers/tournaments_helper.rb
+++ b/app/helpers/tournaments_helper.rb
@@ -55,15 +55,49 @@ module TournamentsHelper
   # suisse (façon Lolesports) — matérialise le bilan du groupe EN ENTRANT dans ce
   # tour (cf. Tournament#swiss_entering_records) : carrés verts = victoires, rouges
   # = défaites, gris = cases restantes avant qualification/élimination. Complétées
-  # à un total fixe (2 victoires max + 2 défaites max avant que le groupe soit
-  # qualifié/éliminé, cf. TournamentUser::WINS_TO_QUALIFY/LOSSES_TO_ELIMINATE)
-  # pour que toutes les pastilles d'une même ronde aient la même largeur.
-  SCORE_BRACKET_PIP_SLOTS = (TournamentUser::WINS_TO_QUALIFY - 1) + (TournamentUser::LOSSES_TO_ELIMINATE - 1)
-
-  def score_bracket_pips(wins, losses)
+  # à un total fixe pour que toutes les pastilles d'une même ronde aient la même
+  # largeur : le nombre de cases dépend des seuils DU TOURNOI (personnalisables
+  # depuis le Lot 7), un joueur ne pouvant entrer dans un tour qu'avec au plus
+  # (seuil - 1) victoires et (seuil - 1) défaites.
+  def score_bracket_pips(wins, losses, tournament)
+    slots = (tournament.wins_to_qualify - 1) + (tournament.losses_to_eliminate - 1)
     pips = (["win"] * wins) + (["loss"] * losses)
-    pips += ["pending"] * (SCORE_BRACKET_PIP_SLOTS - pips.size) if pips.size < SCORE_BRACKET_PIP_SLOTS
+    pips += ["pending"] * (slots - pips.size) if pips.size < slots
     safe_join(pips.map { |kind| content_tag(:span, "", class: "score-bracket__pip score-bracket__pip--#{kind}") })
+  end
+
+  # ── Modale de score ───────────────────────────────────────────────────────────
+  # Bouton d'ouverture de la modale de score partagée (contrôleur Stimulus
+  # tournament-score). Les 3 usages — « Saisir/Modifier », « Détail » (lecture
+  # seule) et « Corriger » (poste sur l'action correct) — ne diffèrent que par le
+  # libellé, la classe, l'URL de soumission et le flag `editable` : tout le reste
+  # (règles du sport, sets déjà saisis, noms des joueurs) est identique, d'où ce
+  # helper unique plutôt que 6 blocs de data-* recopiés dans _tmatch et
+  # _tmatch_scoreline.
+  #
+  # IMPORTANT : les règles viennent de `match.scoring_rules` (et NON de
+  # `match.tournament.sport.scoring_rules`), seule source qui tient compte de la
+  # phase — au ping-pong, 3 sets gagnants en poule mais 4 en phase finale.
+  def score_modal_button(match, label:, editable:, url: nil, css_class: "tmatch-card__score-btn")
+    rules = match.scoring_rules
+
+    button_tag type: "button", class: css_class, data: {
+      action: "tournament-score#open",
+      tournament_score_url_param: url,
+      tournament_score_mode_param: rules[:mode],
+      tournament_score_allow_draw_param: rules[:allow_draw],
+      tournament_score_best_of_param: rules[:best_of],
+      tournament_score_sets_to_win_param: match.sets_to_win,
+      tournament_score_target_param: rules[:target],
+      tournament_score_win_by_two_param: rules[:win_by_two],
+      tournament_score_cap_param: rules[:cap],
+      tournament_score_sets_param: match.sets.to_json,
+      tournament_score_name_a_param: match.player_a.display_name,
+      tournament_score_name_b_param: match.player_b.display_name,
+      tournament_score_editable_param: editable
+    }.compact do # compact : `cap: nil` (pas de plafond) ne doit pas devenir la chaîne ""
+      label
+    end
   end
 
   # Message affiché dans l'état vide de la page liste, selon l'onglet actif

--- a/app/javascript/controllers/match_form_controller.js
+++ b/app/javascript/controllers/match_form_controller.js
@@ -68,7 +68,12 @@ export default class extends Controller {
     "formCol",           // Colonne gauche (col-lg-7) — sert à mesurer son bas pour l'alignement
 
     // ── Boutons de niveau dynamiques (générés par JS selon le sport) ──
-    "levelButtons"       // Div recevant les boutons de niveau générés dynamiquement
+    "levelButtons",      // Div recevant les boutons de niveau générés dynamiquement
+
+    // ── Rattachement à un tournoi (Lot 7) ─────────────────
+    "tournamentInput",         // Select tournoi : porte la map JSON des confrontations
+    "tournamentMatchWrapper",  // Div du select Confrontation (masqué si aucune)
+    "tournamentMatchInput"     // Select Confrontation : son choix préremplit le formulaire
   ]
 
   // ── connect() : appelé automatiquement au chargement de la page ──
@@ -137,31 +142,83 @@ export default class extends Controller {
   // ── Banner : change le fond de .match-new-banner selon le sport ──
   // Choisit une image aléatoire dans le tableau du sport sélectionné.
   // Si aucun sport n'est sélectionné (ou sport inconnu), utilise l'image multisport.
-  // Met à jour l'élément #match-new-banner (dans new.html.erb) + le champ caché
+  // Met à jour l'élément #match-new-banner (dans new.html.erb) + le champ caché.
+  //
+  // ⚠️  Ne retire une image au hasard QUE si le sport a changé (ou si aucune image
+  // n'est encore choisie). connect() appelle updateSport() → updateBanner() : sans
+  // cette garde, ouvrir un match en édition et l'enregistrer sans rien toucher
+  // remplaçait silencieusement son image par une autre du même sport.
   updateBanner() {
     const select    = this.sportInputTarget
     const sportId   = select.value
+    const current   = this.bannerImageInputTarget.value
     // Récupère la map { sportId => [url1, url2, ...] } passée en data-images
     const imagesMap = JSON.parse(select.dataset.images || "{}")
     const images    = imagesMap[sportId] || []
+
+    // Image déjà choisie et toujours cohérente avec le sport sélectionné → on la garde.
+    const keepCurrent = current && images.includes(current)
 
     // Fallback multisport : utilisé quand aucun sport n'est sélectionné ou inconnu dans la map
     const MULTISPORT_IMG = "https://res.cloudinary.com/dfw8rlluc/image/upload/v1775061666/sports/misc/multisports-img.png"
 
     // Choisit une image au hasard dans le tableau du sport, ou l'image multisport par défaut
-    const randomImg = images.length > 0
-      ? images[Math.floor(Math.random() * images.length)]
-      : MULTISPORT_IMG
+    const image = keepCurrent
+      ? current
+      : (images.length > 0 ? images[Math.floor(Math.random() * images.length)] : MULTISPORT_IMG)
 
     // Met à jour le champ caché (sera sauvegardé en BDD à la soumission)
-    this.bannerImageInputTarget.value = randomImg
+    this.bannerImageInputTarget.value = image
 
     // Met à jour le fond de la banner dans new.html.erb (absent en edit → ok si null)
     const bannerEl = document.getElementById("match-new-banner")
     if (bannerEl) {
       // Garde le gradient sombre par-dessus l'image pour la lisibilité
-      bannerEl.style.background = `linear-gradient(rgba(0,0,0,0.65), rgba(0,0,0,0.65)), url('${randomImg}') center 25% / cover no-repeat`
+      bannerEl.style.background = `linear-gradient(rgba(0,0,0,0.65), rgba(0,0,0,0.65)), url('${image}') center 25% / cover no-repeat`
     }
+  }
+
+  // ══════════════════════════════════════════════════════════
+  // Rattachement à un tournoi (Lot 7)
+  // ══════════════════════════════════════════════════════════
+  // Choisir un tournoi remplit le select « Confrontation » avec les rencontres
+  // que l'utilisateur peut planifier dans ce tournoi (les siennes, ou toutes s'il
+  // l'organise — la liste vient du serveur, cf. linkable_tournament_matches_map).
+  updateTournament() {
+    if (!this.hasTournamentMatchInputTarget) return
+
+    const map = JSON.parse(this.tournamentInputTarget.dataset.tournamentMatches || "{}")
+    const confrontations = map[this.tournamentInputTarget.value] || []
+    const select = this.tournamentMatchInputTarget
+
+    select.innerHTML = '<option value="">Aucune (rencontre libre)</option>'
+    confrontations.forEach((c) => {
+      const option = document.createElement("option")
+      option.value = c.id
+      option.textContent = c.label
+      select.appendChild(option)
+    })
+
+    this.tournamentMatchWrapperTarget.style.display = confrontations.length ? "" : "none"
+  }
+
+  // Choisir une confrontation recharge le formulaire prérempli PAR LE SERVEUR
+  // (?tournament_match_id=X → MatchesController#prefill_from_tournament_match).
+  // On ne duplique donc pas la dizaine de champs concernés en JS : sport (qui
+  // regénère niveaux et formats), titre avec l'adversaire, lieu + venue_id, date
+  // via le date-picker custom, bannière… une seule règle de préremplissage, côté
+  // serveur, qui reste par ailleurs l'autorité sur le droit de rattachement.
+  // Ce select est tout en haut du formulaire : on recharge avant que l'utilisateur
+  // n'ait saisi quoi que ce soit d'autre.
+  applyTournamentMatch() {
+    const id = this.tournamentMatchInputTarget.value
+    // Repart de new_match_path fourni par la vue, PAS de l'URL courante : après un
+    // échec de validation, le formulaire est ré-affiché sous l'URL POST /matches —
+    // y ajouter un paramètre enverrait vers la liste des matchs.
+    const url = new URL(this.tournamentInputTarget.dataset.newMatchPath, window.location.origin)
+
+    if (id) url.searchParams.set("tournament_match_id", id)
+    Turbo.visit(url.toString(), { action: "replace" })
   }
 
   // ── Sport : affiche les boutons de format + met à jour le récap ──

--- a/app/javascript/controllers/tournament_form_controller.js
+++ b/app/javascript/controllers/tournament_form_controller.js
@@ -6,12 +6,10 @@
 //   • boutons de format générés dynamiquement selon le sport
 //   • nombre de joueurs : presets 8/16/32 OU mode "Libre" (saisie d'un
 //     nombre souhaité → 1 config recommandée + propositions alternatives)
-//   • aperçu en lecture seule de la structure figée (format + nb joueurs)
+//   • réglages de structure PERSONNALISABLES (Lot 7) : taille des poules, seuils
+//     de la ronde suisse, taille du tableau final — vides = valeurs recommandées
+//   • aperçu de la structure, recalculé en direct depuis ces réglages
 //   • toggle d'auto-inscription du créateur
-//
-// La logique de structure / propositions est PROVISOIRE : elle ne sert
-// ici qu'à guider l'organisateur. La génération réelle des tableaux
-// arrivera au Lot 3 (cf. docs/TOURNOI.md).
 // ══════════════════════════════════════════════════════════════
 
 import { Controller } from "@hotwired/stimulus"
@@ -23,6 +21,15 @@ const FORMAT_LABELS = {
   championnat:  "Championnat"
 }
 
+// Valeurs recommandées — MIROIR des défauts du modèle : Tournament::DEFAULT_POOL_SIZE
+// et TournamentUser::WINS_TO_QUALIFY / LOSSES_TO_ELIMINATE. Toute évolution doit être
+// répercutée ici (l'aperçu doit annoncer ce que le serveur appliquera réellement).
+const DEFAULTS = { poolSize: 4, wins: 3, losses: 3 }
+
+// Nom du tour d'entrée d'un tableau final selon sa taille (miroir de
+// Tournament::BRACKET_STAGE_NAMES).
+const BRACKET_STAGE_NAMES = { 2: "finale", 4: "demi-finales", 8: "quarts", 16: "huitièmes" }
+
 export default class extends Controller {
   static targets = [
     // Sources
@@ -30,17 +37,19 @@ export default class extends Controller {
     "nameInput", "descriptionInput", "placeInput", "dateInput",
     "maxPlayersInput", "presetsGroup", "countBtn", "libreBtn", "libreSection", "libreInput",
     "proposals", "structurePreview", "structureText", "selfRegister", "coOrgInput",
-    "playoffsWrapper", "playoffsInput", "playoffsBtn",
+    "playoffsWrapper", "playoffsInput", "playoffsBtn", "bannerImageInput",
+    // Réglages de structure personnalisables (Lot 7)
+    "advancedSection", "advancedToggle", "advancedFields",
+    "poolSizeField", "poolSizeInput", "winsField", "winsInput",
+    "lossesField", "lossesInput", "bracketSizeField", "bracketSizeInput",
     // Récapitulatif
     "recapName", "recapDescription", "recapSport", "recapFormat", "recapFormatRow",
-    "recapDate", "recapTime", "recapPlace", "recapPlayers",
+    "recapDate", "recapPlace", "recapPlayers",
     "recapStructure", "recapStructureRow", "recapSelfRegister", "recapDeadline", "recapCoOrg",
     "recapPlayoffsRow", "recapPlayoffs"
   ]
 
   connect() {
-    // Structures figées passées en data-attribute (JSON Tournament::STRUCTURE_PRESETS).
-    this.structures = JSON.parse(this.sportInputTarget.dataset.structures || "{}")
     // Vrai quand l'utilisateur est en saisie "Libre" (nombre arbitraire).
     this.libreMode = false
     // Vrai quand le mode Libre a été forcé par le format championnat (pas un choix
@@ -50,9 +59,8 @@ export default class extends Controller {
     // Initialise le récap avec les valeurs déjà présentes (sport par défaut, etc.).
     this.updateName()
     this.updateDescription()
-    this.updateSport()   // rend les boutons de format + applique le 1er format
+    this.updateSport()   // rend les boutons de format + applique le 1er format (+ bannière)
     this.updateDate()
-    this.updateTime()
     this.updatePlace()
   }
 
@@ -80,6 +88,38 @@ export default class extends Controller {
     } else {
       this.formatWrapperTarget.style.display  = "none"
       this.recapFormatRowTarget.style.display = "none"
+    }
+
+    this.updateBanner()
+  }
+
+  // ── Bannière : le fond de la page suit le sport sélectionné ──
+  // Même mécanique que match-form : une image tirée parmi celles du sport, écrite
+  // dans le hidden banner_image pour être persistée (la carte du tournoi et sa page
+  // afficheront ensuite exactement cette image, cf. sport_cover_image).
+  //
+  // ⚠️  Le tirage n'a lieu que si le sport a changé (ou si aucune image n'est encore
+  // retenue) : connect() appelle updateSport(), donc sans cette garde une simple
+  // édition du tournoi changerait son image à chaque enregistrement.
+  updateBanner() {
+    const select    = this.sportInputTarget
+    const imagesMap = JSON.parse(select.dataset.images || "{}")
+    const images    = imagesMap[select.value] || []
+    const current   = this.bannerImageInputTarget.value
+
+    if (!images.length) return
+
+    const image = current && images.includes(current)
+      ? current
+      : images[Math.floor(Math.random() * images.length)]
+
+    this.bannerImageInputTarget.value = image
+
+    // Bannière présente sur /tournois/new et /tournois/:id/edit — absente ailleurs.
+    const bannerEl = document.getElementById("tournament-new-banner")
+    if (bannerEl) {
+      // Gradient sombre par-dessus l'image : garde le titre lisible.
+      bannerEl.style.background = `linear-gradient(rgba(0,0,0,0.65), rgba(0,0,0,0.65)), url('${image}') center 25% / cover no-repeat`
     }
   }
 
@@ -152,6 +192,9 @@ export default class extends Controller {
       btn.classList.toggle("active", active)
       this._styleFormatBtn(btn, active)
     })
+    // Avec ou sans playoffs, la structure annoncée change (et le réglage de taille
+    // du tableau final n'a plus lieu d'être sans playoffs).
+    this._refreshStructure()
   }
 
   // ── Championnat : pas de nombre de joueurs prédéfini ─────────
@@ -243,10 +286,10 @@ export default class extends Controller {
     this.recapPlayersTarget.textContent = wanted
 
     if (format === "championnat") {
-      // Round-robin : aucune contrainte de puissance de 2, donc aucun choix à
-      // faire — ni carte "Recommandé", ni aperçu de structure : juste le champ.
-      this.structurePreviewTarget.style.display = "none"
-      this.recapStructureRowTarget.style.display = "none"
+      // Round-robin : aucune contrainte de puissance de 2, donc aucune carte de
+      // proposition à choisir — mais l'aperçu de structure reste utile (nombre de
+      // journées, playoffs ou pas, taille du tableau final si personnalisée).
+      this._showStructure(this._structureText(format, wanted))
       return
     }
 
@@ -281,37 +324,134 @@ export default class extends Controller {
     this._showStructure(btn.dataset.recap)
   }
 
-  // Génère les propositions (LOGIQUE PROVISOIRE — affinée au Lot 3).
+  // Génère les propositions d'effectif pour le mode Libre. Le récap de chaque carte
+  // est calculé par _structureText : il reflète donc les réglages personnalisés.
   // Championnat exclu : géré à part dans buildProposals() (pas de carte, aperçu direct).
   _buildProposals(format, wanted) {
     const out = []
-    const push = (players, recap, recommended = false) => {
-      if (players >= 2 && !out.some(p => p.players === players)) out.push({ players, recap, recommended })
+    const push = (players, recommended = false) => {
+      if (players >= 2 && !out.some(p => p.players === players)) {
+        out.push({ players, recap: this._structureText(format, players), recommended })
+      }
     }
 
     if (format === "poules") {
-      const nearest = Math.max(4, Math.round(wanted / 4) * 4)
-      push(nearest, `${nearest / 4} poules de 4 + tableau final`, true)
-      push(16, "4 poules de 4 + quarts")
-      push(32, "8 poules de 4 + huitièmes")
-    } else { // ronde_suisse — Final 4 jusqu'à 8 joueurs, Final 8 au-delà (cf. Tournament#final_size).
-      push(wanted, `Ronde suisse (3 V) → ${wanted <= 8 ? "Final 4" : "Final 8"}`, true)
-      push(16, "Ronde suisse (3 V) → Final 8")
-      push(32, "Ronde suisse (3 V) → Final 8")
+      // Effectif le plus proche qui remplit des poules entières.
+      const { poolSize } = this._settings()
+      push(Math.max(poolSize, Math.round(wanted / poolSize) * poolSize), true)
+    } else {
+      push(wanted, true)
     }
+    push(16)
+    push(32)
     return out.slice(0, 4)
   }
 
-  // ── Aperçu de structure figée (presets) ──────────────────────
+  // ══════════════════════════════════════════════════════════
+  // Réglages de structure personnalisables (Lot 7)
+  // ══════════════════════════════════════════════════════════
+  toggleAdvanced() {
+    const fields = this.advancedFieldsTarget
+    const open = fields.hidden
+    fields.hidden = !open
+    this.advancedToggleTarget.setAttribute("aria-expanded", String(open))
+  }
+
+  // Action des champs de réglage : l'aperçu de structure suit la saisie.
+  refreshStructure() {
+    this._refreshStructure()
+  }
+
+  // Réglages actuellement saisis, complétés par les valeurs recommandées.
+  // bracketSize reste null si vide : sa recommandation dépend du format/effectif.
+  _settings() {
+    const int = (target) => {
+      const value = parseInt(target.value)
+      return Number.isFinite(value) && value > 0 ? value : null
+    }
+
+    return {
+      poolSize:    int(this.poolSizeInputTarget) || DEFAULTS.poolSize,
+      wins:        int(this.winsInputTarget)     || DEFAULTS.wins,
+      losses:      int(this.lossesInputTarget)   || DEFAULTS.losses,
+      bracketSize: int(this.bracketSizeInputTarget)
+    }
+  }
+
+  // Miroirs de Tournament#planned_pool_count / #planned_final_size / #planned_bracket_stage.
+  _poolCount(players, poolSize) { return Math.max(Math.ceil(players / poolSize), 1) }
+
+  _finalSize(format, players, settings) {
+    if (settings.bracketSize) return settings.bracketSize
+    // Poules : 2 qualifiés par poule, arrondis à la puissance de 2 supérieure —
+    // un tableau à élimination directe n'a que 2, 4, 8, 16… places (miroir de
+    // Tournament#bracket_capacity_for).
+    if (format === "poules") {
+      const qualified = this._poolCount(players, settings.poolSize) * 2
+      let size = 2
+      while (size < qualified) size *= 2
+      return size
+    }
+
+    return players <= 8 ? 4 : 8
+  }
+
+  _stageName(size) { return BRACKET_STAGE_NAMES[size] || `tableau à ${size}` }
+
+  // Miroir de Tournament#structure_summary : ce que le serveur produira réellement.
+  _structureText(format, players) {
+    const settings = this._settings()
+    const stage = this._stageName(this._finalSize(format, players, settings))
+
+    if (format === "poules") {
+      return `${this._poolCount(players, settings.poolSize)} poules de ${settings.poolSize} + ${stage}`
+    }
+    if (format === "ronde_suisse") {
+      return `Ronde suisse (${settings.wins} V / ${settings.losses} D) + ${stage}`
+    }
+
+    const base = `${players} joueurs, ${players - 1} journées`
+    return this._withPlayoffs()
+      ? `${base}, top ${this._finalSize(format, players, settings)} en playoffs`
+      : `${base}, vainqueur = 1er du classement`
+  }
+
+  _withPlayoffs() { return this.playoffsInputTarget.value !== "false" }
+
+  // Affiche les seuls réglages pertinents pour le format, avec la valeur
+  // recommandée en placeholder. Le bloc n'apparaît qu'une fois l'effectif choisi :
+  // sans lui, aucune recommandation n'est calculable.
+  _syncAdvanced(format, players) {
+    const ready = Boolean(format) && Number.isFinite(players) && players >= 2
+    this.advancedSectionTarget.style.display = ready ? "" : "none"
+    if (!ready) return
+
+    const isPools = format === "poules"
+    const isSwiss = format === "ronde_suisse"
+    // Championnat sans playoffs : pas de tableau final, donc rien à dimensionner
+    // (cf. Tournament#bracket_expected?).
+    const hasBracket = format !== "championnat" || this._withPlayoffs()
+
+    this.poolSizeFieldTarget.style.display    = isPools ? "" : "none"
+    this.winsFieldTarget.style.display        = isSwiss ? "" : "none"
+    this.lossesFieldTarget.style.display      = isSwiss ? "" : "none"
+    this.bracketSizeFieldTarget.style.display = hasBracket ? "" : "none"
+
+    this.poolSizeInputTarget.placeholder = `Recommandé : ${DEFAULTS.poolSize}`
+    this.winsInputTarget.placeholder     = `Recommandé : ${DEFAULTS.wins}`
+    this.lossesInputTarget.placeholder   = `Recommandé : ${DEFAULTS.losses}`
+  }
+
+  // ── Aperçu de structure ──────────────────────────────────────
   _refreshStructure() {
+    const format  = this.formatInputTarget.value
+    const players = parseInt(this.maxPlayersInputTarget.value)
+    this._syncAdvanced(format, players)
+
     if (this.libreMode) { this.buildProposals(); return }
 
-    const fmt     = this.formatInputTarget.value
-    const players = parseInt(this.maxPlayersInputTarget.value)
-    const preset  = (this.structures[fmt] || {})[players]
-
-    if (preset) {
-      this._showStructure(preset)
+    if (format && Number.isFinite(players) && players >= 2) {
+      this._showStructure(this._structureText(format, players))
     } else {
       this.structurePreviewTarget.style.display = "none"
       this.recapStructureRowTarget.style.display = "none"
@@ -360,12 +500,6 @@ export default class extends Controller {
     const d = new Date(iso)
     this.recapDateTarget.textContent = isNaN(d) ? iso
       : d.toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })
-  }
-
-  updateTime() {
-    const h = this.element.querySelector("[name='tournament[time(4i)]']")?.value
-    const m = this.element.querySelector("[name='tournament[time(5i)]']")?.value
-    this.recapTimeTarget.textContent = (h ? `${String(h).padStart(2, "0")}h${String(m || 0).padStart(2, "0")}` : "—")
   }
 
   updateDeadline() {

--- a/app/javascript/controllers/tournament_score_controller.js
+++ b/app/javascript/controllers/tournament_score_controller.js
@@ -1,9 +1,18 @@
 // Stimulus controller : tournament-score
 // Pilote la modale de score partagée du tableau de tournoi (Lot 4).
-// - open()   : lit les data-* de la carte cliquée (URL PATCH, best_of, cible, sets
-//              existants, noms), construit une ligne d'inputs par set, préremplit, et
-//              ouvre la modale Bootstrap. Mode « Détail » = lecture seule (submit masqué).
-// - close()  : ferme la modale après un enregistrement réussi (turbo:submit-end).
+// - open()        : lit les data-* de la carte cliquée (URL PATCH, règles du sport,
+//                   sets existants, noms), construit les lignes d'inputs, préremplit,
+//                   et ouvre la modale Bootstrap. Mode « Détail » = lecture seule.
+// - refreshRows() : (Lot 7) recalcule le nombre de lignes À CHAQUE SAISIE. On part du
+//                   minimum de sets nécessaires (3 au ping-pong en poule, 4 en phase
+//                   finale) et on n'ajoute une ligne QUE si le match n'est pas encore
+//                   décidé — un 2-1 fait apparaître un 4e set, un 3-0 n'en propose
+//                   aucun. Évite les 5 (ou 7) lignes vides affichées d'emblée.
+// - close()       : ferme la modale après un enregistrement réussi (turbo:submit-end).
+//
+// Le nombre de sets à gagner vient du serveur (data-...-sets-to-win-param, dérivé de
+// TournamentMatch#scoring_rules qui connaît la phase) : le JS ne redéfinit aucune règle,
+// et la validation de score reste faite côté modèle (source de vérité).
 //
 // Le contrôleur vit HORS de #tournament_board : il survit aux remplacements Turbo Stream
 // du tableau. Ses cibles situées dans le board (aucune ici) seraient de toute façon
@@ -33,10 +42,14 @@ export default class extends Controller {
 
   // Ouvre la modale à partir des données de la carte (data-tournament-score-*-param).
   open(event) {
-    const { url, mode, allowDraw, bestOf, target, sets, nameA, nameB, editable } = event.params
+    const { url, mode, allowDraw, bestOf, setsToWin, target, winByTwo, cap, sets, nameA, nameB, editable } = event.params
     const existing = Array.isArray(sets) ? sets : []
-    const isScoreMode = mode === "score"
-    const rows = isScoreMode ? 1 : Math.max(bestOf || 3, existing.length)
+
+    // Contexte de la carte courante, relu par refreshRows() à chaque frappe.
+    this.isScoreMode = mode === "score"
+    this.bestOf = bestOf || 3
+    this.setsToWin = setsToWin || Math.floor(this.bestOf / 2) + 1
+    this.editable = editable
 
     if (url) this.formTarget.action = url
     this.nameATarget.textContent = nameA || "Joueur A"
@@ -44,17 +57,27 @@ export default class extends Controller {
     this.titleTarget.textContent = editable ? "Saisir le score" : "Détail du score"
     this.submitTarget.style.display = editable ? "" : "none"
     this.hintTarget.textContent = editable
-      ? this.buildHint(isScoreMode, allowDraw, bestOf, target)
+      ? this.buildHint(allowDraw, target, winByTwo, cap)
       : ""
 
-    this.buildRows(rows, existing, editable, isScoreMode)
+    this.renderRows(existing)
     this.modal.show()
   }
 
-  buildHint(isScoreMode, allowDraw, bestOf, target) {
-    if (!isScoreMode) return `Au meilleur des ${bestOf} sets · cible ${target} jeux/points par set.`
+  // Rappel de la règle réellement appliquée par le serveur (cf. Sport#scoring_rules).
+  buildHint(allowDraw, target, winByTwo, cap) {
+    if (this.isScoreMode) {
+      return allowDraw ? "Score final du match (match nul autorisé)." : "Score final du match (pas de match nul)."
+    }
 
-    return allowDraw ? "Score final du match (match nul autorisé)." : "Score final du match (pas de match nul)."
+    const parts = [`${this.setsToWin} sets gagnants (au meilleur des ${this.bestOf})`]
+    if (target) {
+      // « 11 points, 2 points d'écart » : au-delà de 10-10 il faut deux points d'avance.
+      parts.push(winByTwo ? `set en ${target} points avec 2 points d'écart` : `set en ${target} points`)
+    }
+    if (cap) parts.push(`${cap} points maximum (tie-break)`)
+
+    return `${parts.join(" · ")}.`
   }
 
   // Ferme la modale uniquement si l'enregistrement a réussi.
@@ -63,25 +86,87 @@ export default class extends Controller {
     this.modal.hide()
   }
 
-  // (Re)génère `count` lignes de sets, préremplies avec `existing` ([[a, b], …]).
-  // `isScoreMode` : sport collectif à score final unique → 1 seule ligne, libellée
-  // "Score final" plutôt que "Set 1".
-  buildRows(count, existing, editable, isScoreMode = false) {
+  // Recalcule les lignes après une saisie, en conservant ce qui est déjà tapé.
+  refreshRows() {
+    this.renderRows(this.currentSets(), { keepFocus: true })
+  }
+
+  // Sets actuellement dans le DOM, y compris les lignes incomplètes (on ne veut pas
+  // effacer un « 11 » en attente de son adversaire) : [[a, b], …] en chaînes.
+  currentSets() {
+    return Array.from(this.rowsTarget.querySelectorAll(".score-modal__set")).map((row) => {
+      const [a, b] = row.querySelectorAll("input")
+      return [a.value, b.value]
+    })
+  }
+
+  // Nombre de lignes à afficher : au minimum les sets nécessaires pour gagner, plus
+  // une ligne d'appoint tant que personne n'a atteint setsToWin — plafonné à bestOf.
+  // Ex. ping-pong en poule (3 sets gagnants, best_of 5) : 3 lignes au départ ; à 1-1
+  // toujours 3 ; à 2-1 une 4e apparaît ; à 3-1 on s'arrête (les lignes en trop, vides,
+  // sont retirées). Un set incomplet compte comme « en cours » : sa ligne reste.
+  rowCount(sets) {
+    if (this.isScoreMode) return 1
+
+    let wins = [0, 0]
+    let playedRows = 0
+
+    sets.forEach(([a, b]) => {
+      if (a === "" && b === "") return
+
+      playedRows += 1
+      if (a !== "" && b !== "") {
+        const scoreA = Number(a)
+        const scoreB = Number(b)
+        if (scoreA > scoreB) wins[0] += 1
+        else if (scoreB > scoreA) wins[1] += 1
+      }
+    })
+
+    // Match décidé : on n'affiche que les sets réellement joués (au moins setsToWin).
+    if (Math.max(...wins) >= this.setsToWin) return Math.max(playedRows, this.setsToWin)
+
+    return Math.min(Math.max(this.setsToWin, playedRows + 1), this.bestOf)
+  }
+
+  // (Re)construit les lignes de sets, préremplies avec `sets` ([[a, b], …]).
+  // Ne recrée les inputs que si leur nombre change, pour ne pas perdre le focus /
+  // le curseur pendant la frappe (refreshRows est appelé à chaque `input`).
+  renderRows(sets, { keepFocus = false } = {}) {
+    const count = this.rowCount(sets)
+    const existingRows = this.rowsTarget.querySelectorAll(".score-modal__set").length
+    if (keepFocus && existingRows === count) return
+
+    const active = document.activeElement
+    const activeIndex = keepFocus ? Array.from(this.rowsTarget.querySelectorAll("input")).indexOf(active) : -1
+
+    // data-action sur les inputs générés : Stimulus observe le DOM et les branche
+    // tout seul, y compris injectés (inutile d'ajouter des listeners à la main).
+    // Uniquement en saisie de sets : en lecture seule ou en mode :score, rien à
+    // recalculer.
+    const attrs = [this.editable ? "" : "readonly", this.editable && !this.isScoreMode ? 'data-action="input->tournament-score#refreshRows"' : ""].join(" ")
+
     this.rowsTarget.innerHTML = ""
     for (let i = 0; i < count; i++) {
-      const pair = existing[i] || ["", ""]
+      const pair = sets[i] || ["", ""]
       const row = document.createElement("div")
       row.className = "score-modal__set"
+      // isScoreMode : sport collectif à score final unique → 1 seule ligne, libellée
+      // "Score final" plutôt que "Set 1".
       row.innerHTML = `
-        <span class="score-modal__set-label">${isScoreMode ? "Score final" : `Set ${i + 1}`}</span>
+        <span class="score-modal__set-label">${this.isScoreMode ? "Score final" : `Set ${i + 1}`}</span>
         <input type="number" min="0" inputmode="numeric" class="score-modal__input"
-               name="tournament_match[games_a][]" value="${pair[0]}" ${editable ? "" : "readonly"}>
+               name="tournament_match[games_a][]" value="${pair[0] ?? ""}" ${attrs}>
         <span class="score-modal__sep">–</span>
         <input type="number" min="0" inputmode="numeric" class="score-modal__input"
-               name="tournament_match[games_b][]" value="${pair[1]}" ${editable ? "" : "readonly"}>
+               name="tournament_match[games_b][]" value="${pair[1] ?? ""}" ${attrs}>
       `
       this.rowsTarget.appendChild(row)
     }
+
+    // Les lignes ont été recréées : on rend le focus à l'input qui l'avait (son index
+    // est stable, on n'ajoute/retire qu'en fin de liste).
+    if (activeIndex >= 0) this.rowsTarget.querySelectorAll("input")[activeIndex]?.focus()
   }
 
   get modal() {

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -197,6 +197,12 @@ class Match < ApplicationRecord
   # Validation : l'heure de fin ne peut pas être identique à l'heure de début
   validate :end_time_differs_from_start, on: %i[create update]
 
+  # Une confrontation de tournoi n'a qu'UNE rencontre (index unique en base).
+  # Depuis le Lot 7, les deux joueurs peuvent la créer : sans cette validation, le
+  # second à valider le formulaire déclencherait une RecordNotUnique (erreur 500)
+  # au lieu d'un message lisible.
+  validates :tournament_match_id, uniqueness: { message: "a déjà une rencontre planifiée" }, allow_nil: true
+
   # Validation : le lien de réservation doit être une URL valide si renseigné
   validates :booking_link, format: {
     with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),

--- a/app/models/sport.rb
+++ b/app/models/sport.rb
@@ -130,6 +130,10 @@ class Sport < ApplicationRecord
   #     target     : score à atteindre pour remporter un set (jeux au tennis, points ailleurs)
   #     win_by_two : faut-il 2 d'écart pour conclure un set (règle du ping-pong / badminton)
   #     cap        : plafond au-delà duquel 1 point d'écart suffit (tie-break) ; nil = pas de plafond
+  #     final_best_of : best_of RENFORCÉ en phase finale (tableau à élimination directe),
+  #       comme le veut le règlement du tennis de table : 3 sets gagnants en poule /
+  #       ronde suisse, 4 en phase finale. Absent = mêmes règles à toutes les phases.
+  #       Appliqué par TournamentMatch#scoring_rules, seul endroit qui connaît la phase.
   #   :score (sports collectifs) — un seul score final saisi :
   #     allow_draw : le nul est-il un résultat possible pour ce sport
   # Le fallback (sports sans configuration) reste jouable au meilleur des 3 sets.
@@ -137,7 +141,7 @@ class Sport < ApplicationRecord
     case slug
     when "tennis", "padel" then { mode: :sets, best_of: 3, target: 6,  win_by_two: true, cap: 7,   allow_draw: false }
     when "badminton"       then { mode: :sets, best_of: 3, target: 21, win_by_two: true, cap: 30,  allow_draw: false }
-    when "ping-pong"       then { mode: :sets, best_of: 5, target: 11, win_by_two: true, cap: nil, allow_draw: false }
+    when "ping-pong"       then { mode: :sets, best_of: 5, target: 11, win_by_two: true, cap: nil, allow_draw: false, final_best_of: 7 }
     when "volleyball"      then { mode: :sets, best_of: 5, target: 25, win_by_two: true, cap: nil, allow_draw: false }
     when "football", "handball" then { mode: :score, allow_draw: true }
     when "basketball"           then { mode: :score, allow_draw: false }

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -44,18 +44,9 @@ class Tournament < ApplicationRecord
   # Ce n'est PAS une contrainte : le mode "Libre" autorise n'importe quel entier.
   PLAYER_COUNTS = [8, 16, 32].freeze
 
-  # Structures figées, dérivées de (format + nombre de joueurs) — rien n'est stocké
-  # en base, c'est un simple aperçu en lecture seule affiché à la création.
-  # Ronde suisse (Lot 3) : le nombre de rondes est dynamique (3 V pour se qualifier /
-  # 3 D pour être éliminé), la seule constante est la taille du tableau final :
-  # Final 4 jusqu'à 8 joueurs, Final 8 au-delà (cf. Tournament#final_size).
-  # Poules / championnat restent provisoires (formats des lots ultérieurs).
-  STRUCTURE_PRESETS = {
-    "ronde_suisse" => { 8 => "Ronde suisse (3 V) + Final 4", 16 => "Ronde suisse (3 V) + Final 8", 32 => "Ronde suisse (3 V) + Final 8" },
-    "poules" => { 8 => "2 poules de 4 + demi-finales", 16 => "4 poules de 4 + quarts", 32 => "8 poules de 4 + huitièmes" },
-    "championnat" => { 8 => "8 joueurs, 7 journées, top 4 en playoffs", 16 => "16 joueurs, top 8 en playoffs",
-                       32 => "32 joueurs, top 8 en playoffs" }
-  }.freeze
+  # Nom du tour d'entrée d'un tableau final selon sa taille (4 places → on entre en
+  # demi-finales). Sert aux résumés de structure ; au-delà de 16, on nomme la taille.
+  BRACKET_STAGE_NAMES = { 2 => "finale", 4 => "demi-finales", 8 => "quarts", 16 => "huitièmes" }.freeze
 
   # ── Recherche full-text (pg_search) ──────────────────────────────────────────
   pg_search_scope :search_by_name,
@@ -76,6 +67,18 @@ class Tournament < ApplicationRecord
   validates :date, presence: true
   validates :place, presence: true
   validates :status, inclusion: { in: STATUSES }
+
+  # Réglages de structure (Lot 7) — tous facultatifs : vide = valeur recommandée.
+  # Une poule se joue à 2 joueurs minimum ; il faut au moins 1 victoire pour se
+  # qualifier et 1 défaite pour être éliminé (sinon la ronde suisse ne finirait jamais).
+  validates :players_per_pool, numericality: { only_integer: true, greater_than_or_equal_to: 2 }, allow_nil: true
+  validates :swiss_wins_to_qualify, :swiss_losses_to_eliminate,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1 }, allow_nil: true
+  # Le tableau final se joue par élimination directe : sa taille doit être une
+  # puissance de 2 (4 = demies, 8 = quarts, 16 = huitièmes…), sinon les tours ne
+  # s'enchaînent pas (cf. BracketBuilder + #expected_bracket_round_count).
+  validates :bracket_size, numericality: { only_integer: true, greater_than_or_equal_to: 2 }, allow_nil: true
+  validate  :bracket_size_is_power_of_two
 
   # La date/heure d'un tournoi ne peut pas être dans le passé à la création.
   # `on: :create` uniquement : TournamentsController#start et
@@ -193,15 +196,54 @@ class Tournament < ApplicationRecord
     user_id == user.id || tournament_users.any? { |tu| tu.user_id == user.id && tu.role == "co_organisateur" }
   end
 
-  # Aperçu de structure figée pour la combinaison (format + nombre de joueurs).
-  # nil si la combinaison n'a pas de preset (ex. nombre "Libre" hors 8/16/32).
-  # Championnat SANS playoffs (Lot 6) : on réécrit la fin du texte plutôt que de
-  # dupliquer STRUCTURE_PRESETS pour une simple variante d'affichage.
+  # Résumé lisible de la structure PRÉVUE, calculé depuis le format, l'effectif
+  # attendu (max_players) et les réglages de l'organisateur — donc juste même quand
+  # il personnalise la taille des poules ou du tableau final, et valable pour
+  # n'importe quel effectif (mode « Libre » compris).
+  # Le miroir côté client vit dans tournament_form_controller.js (_structureText).
   def structure_summary
-    preset = STRUCTURE_PRESETS.dig(format, max_players)
-    return preset if preset.nil? || format != "championnat" || playoffs?
+    return nil if format.blank? || max_players.blank?
 
-    preset.sub(/,\s*top \d+ en playoffs/, ", vainqueur = 1er du classement")
+    case format
+    when "poules"
+      "#{planned_pool_count} poules de #{pool_size} + #{planned_bracket_stage}"
+    when "ronde_suisse"
+      "Ronde suisse (#{wins_to_qualify} V / #{losses_to_eliminate} D) + #{planned_bracket_stage}"
+    else # championnat
+      base = "#{max_players} joueurs, #{max_players - 1} journées"
+      playoffs? ? "#{base}, top #{planned_final_size} en playoffs" : "#{base}, vainqueur = 1er du classement"
+    end
+  end
+
+  # Structure prévue AVANT le lancement : les mêmes règles que #pool_count /
+  # #final_size mais basées sur l'effectif ATTENDU (max_players) et non sur les
+  # inscrits du moment — un tournoi vide doit déjà annoncer sa structure.
+  def planned_pool_count
+    [(max_players.to_i / pool_size.to_f).ceil, 1].max
+  end
+
+  def planned_final_size
+    return bracket_size if bracket_size.present?
+    return bracket_capacity_for(planned_pool_count * 2) if format == "poules"
+
+    max_players.to_i <= 8 ? 4 : 8
+  end
+
+  # Arrondit un nombre de qualifiés à la puissance de 2 immédiatement supérieure :
+  # un tableau à élimination directe ne peut avoir que 2, 4, 8, 16… places (les
+  # places excédentaires sont des byes, cf. BracketBuilder). Ex. 3 poules → 6
+  # qualifiés → tableau de 8. Garantit que la valeur recommandée respecte la même
+  # contrainte que celle qu'on impose à un réglage manuel (bracket_size).
+  def bracket_capacity_for(qualified_count)
+    size = 2
+    size *= 2 while size < qualified_count
+    size
+  end
+
+  # Tour d'entrée du tableau final prévu ("quarts", "demi-finales"…).
+  def planned_bracket_stage
+    size = planned_final_size
+    BRACKET_STAGE_NAMES[size] || "tableau à #{size}"
   end
 
   # ── Ronde Suisse + tableau final (Lot 3) ─────────────────────────────────────
@@ -280,26 +322,50 @@ class Tournament < ApplicationRecord
     approved_players.select { |tu| tu.pool.present? }.group_by(&:pool)
   end
 
-  # Nombre de poules (~4 joueurs par poule, cf. STRUCTURE_PRESETS "poules") — seule
-  # source de vérité, réutilisée par PoolBuilder pour la répartition ET ici pour
-  # dimensionner le tableau final (2 qualifiés par poule, cf. #final_size).
+  # ── Structure : réglages recommandés, personnalisables (Lot 7) ───────────────
+  # Les 4 méthodes ci-dessous sont la SEULE source de vérité de la structure, lue
+  # par tous les moteurs (PoolBuilder, SwissPairing, BracketBuilder). Chacune
+  # renvoie le réglage choisi par l'organisateur s'il en a saisi un, sinon la
+  # valeur recommandée — historiquement la seule possible.
+  #
+  # Les colonnes portent un nom différent des méthodes (players_per_pool vs
+  # #pool_size…) précisément pour que ces méthodes ne masquent aucun attribut :
+  # `players_per_pool` reste la valeur brute (nil = « recommandé »), lisible telle
+  # quelle par le formulaire.
+
+  # Joueurs par poule (format "poules").
+  DEFAULT_POOL_SIZE = 4
+
+  def pool_size = players_per_pool.presence || DEFAULT_POOL_SIZE
+
+  # Nombre de poules, déduit de l'effectif et de la taille de poule voulue —
+  # réutilisé par PoolBuilder pour la répartition ET ici pour dimensionner le
+  # tableau final (cf. #final_size).
   def pool_count
-    [(approved_players_count / 4.0).ceil, 1].max
+    [(approved_players_count / pool_size.to_f).ceil, 1].max
   end
 
-  # Taille du tableau final selon le format :
+  # Taille du tableau final. Réglage explicite (bracket_size) sinon, selon le format :
   #   - poules : le double du nombre de poules — les 2 premiers de chaque poule
-  #     (règle classique, ex. Coupe du monde) — reproduit exactement
-  #     STRUCTURE_PRESETS["poules"] : 2 poules de 4 → demi-finales (4), 4 poules →
-  #     quarts (8), 8 poules → huitièmes (16).
+  #     (règle classique, ex. Coupe du monde) : 2 poules de 4 → demi-finales (4),
+  #     4 poules → quarts (8), 8 poules → huitièmes (16).
   #   - ronde suisse / championnat : Final 4 pour un petit tournoi (≤ 8 joueurs),
-  #     Final 8 au-delà (aligné sur le seuil du formulaire, plafond volontaire —
-  #     contrairement aux poules, ne grandit pas avec l'effectif au-delà de 8).
+  #     Final 8 au-delà (plafond volontaire — contrairement aux poules, ne grandit
+  #     pas avec l'effectif au-delà de 8).
   def final_size
-    return pool_count * 2 if format == "poules"
+    bracket_size.presence || recommended_final_size
+  end
+
+  def recommended_final_size
+    return bracket_capacity_for(pool_count * 2) if format == "poules"
 
     approved_players_count <= 8 ? 4 : 8
   end
+
+  # Ronde suisse : seuils de qualification / élimination (bilan V-D).
+  def wins_to_qualify = swiss_wins_to_qualify.presence || TournamentUser::WINS_TO_QUALIFY
+
+  def losses_to_eliminate = swiss_losses_to_eliminate.presence || TournamentUser::LOSSES_TO_ELIMINATE
 
   # Nombre de tours qu'aura le tableau final une fois complet (ex. final_size 16
   # → 4 tours : 8es, quarts, demies, finale) — sert à afficher la structure
@@ -337,5 +403,13 @@ class Tournament < ApplicationRecord
 
   def tournament_datetime
     Time.zone.local(date.year, date.month, date.day, time.hour, time.min, 0)
+  end
+
+  # Puissance de 2 : 4 & 3 == 0, 8 & 7 == 0… (un seul bit à 1 en binaire).
+  def bracket_size_is_power_of_two
+    return if bracket_size.blank? || bracket_size < 2
+    return if bracket_size.nobits?(bracket_size - 1)
+
+    errors.add(:bracket_size, "doit être une puissance de 2 (4, 8, 16, 32…)")
   end
 end

--- a/app/models/tournament_match.rb
+++ b/app/models/tournament_match.rb
@@ -111,6 +111,34 @@ class TournamentMatch < ApplicationRecord
     points_won_by(opponent_of(player))
   end
 
+  # ── Règles de score applicables À CE MATCH ────────────────────────────────────
+  # Part des règles du sport (cf. Sport#scoring_rules) et les durcit en phase finale
+  # quand le sport le prévoit (`final_best_of`) : au ping-pong, un match de poule /
+  # ronde suisse se joue en 3 sets gagnants (best_of 5) mais un match du tableau
+  # final en 4 (best_of 7).
+  #
+  # C'est LE point d'entrée unique : `sets_to_win`, les validations et les vues
+  # (data-* de la modale de score) passent tous par ici — jamais par
+  # `tournament.sport.scoring_rules`, qui ignore la phase.
+  def scoring_rules
+    rules = tournament&.sport&.scoring_rules || Sport.new.scoring_rules
+    return rules unless final_phase? && rules[:final_best_of].present?
+
+    rules.merge(best_of: rules[:final_best_of])
+  end
+
+  # Sets nécessaires pour gagner le match (best_of 5 → 3, best_of 7 → 4).
+  # nil en mode :score (sports collectifs) : la notion de set n'existe pas.
+  def sets_to_win
+    best_of = scoring_rules[:best_of]
+    return nil if best_of.blank?
+
+    (best_of / 2) + 1
+  end
+
+  # Ce match appartient-il au tableau à élimination directe ?
+  def final_phase? = tournament_round&.phase == "bracket"
+
   private
 
   # ── Dérivation du vainqueur ───────────────────────────────────────────────────
@@ -184,14 +212,6 @@ class TournamentMatch < ApplicationRecord
     return nil if retired_player_id.blank?
 
     retired_player_id == player_a_id ? player_b_id : player_a_id
-  end
-
-  # Sets nécessaires pour gagner le match selon le sport (best_of 3 → 2, best_of 5 → 3).
-  def sets_to_win = (scoring_rules[:best_of] / 2) + 1
-
-  # Règles de score du sport du tournoi (fallback sûr si le sport est absent).
-  def scoring_rules
-    tournament&.sport&.scoring_rules || Sport.new.scoring_rules
   end
 
   # ── Validations ───────────────────────────────────────────────────────────────

--- a/app/models/tournament_user.rb
+++ b/app/models/tournament_user.rb
@@ -13,17 +13,21 @@ class TournamentUser < ApplicationRecord
   # (sorti par le score) ; "withdrawn" = a déclaré forfait / abandonné (Lot 5).
   STATES = %w[active qualified eliminated withdrawn].freeze
 
-  # Seuils de la ronde suisse : 3 victoires pour se qualifier, 3 défaites pour être éliminé.
+  # Seuils PAR DÉFAUT de la ronde suisse : 3 victoires pour se qualifier, 3 défaites
+  # pour être éliminé. Depuis le Lot 7 l'organisateur peut les personnaliser par
+  # tournoi (colonnes swiss_wins_to_qualify / swiss_losses_to_eliminate) : passer
+  # par Tournament#wins_to_qualify / #losses_to_eliminate, qui appliquent le réglage
+  # ou retombent sur ces constantes.
   WINS_TO_QUALIFY = 3
   LOSSES_TO_ELIMINATE = 3
 
-  # État suisse dérivé d'un bilan V/D donné (mêmes seuils que ci-dessus). Utilisé
+  # État suisse dérivé d'un bilan V/D donné, selon les seuils du tournoi. Utilisé
   # par SwissPairing pour l'état réel du joueur ET par le ruban de rondes (onglet
   # Matchs) pour colorer les pastilles de bilan par groupe en en-tête de colonne
   # — d'où la version "pure" (sans lire l'état persisté d'un joueur en particulier).
-  def self.state_for(wins, losses)
-    return "qualified" if wins >= WINS_TO_QUALIFY
-    return "eliminated" if losses >= LOSSES_TO_ELIMINATE
+  def self.state_for(wins, losses, wins_to_qualify: WINS_TO_QUALIFY, losses_to_eliminate: LOSSES_TO_ELIMINATE)
+    return "qualified" if wins >= wins_to_qualify
+    return "eliminated" if losses >= losses_to_eliminate
 
     "active"
   end

--- a/app/policies/tournament_match_policy.rb
+++ b/app/policies/tournament_match_policy.rb
@@ -1,4 +1,5 @@
-# Autorisations sur un match de tournoi (Lot 4 — saisie du score).
+# Autorisations sur un match de tournoi (Lot 4 — saisie du score, Lot 7 —
+# planification de la rencontre par les joueurs).
 # La saisie/modification du score est ouverte à 4 rôles : l'admin et les
 # co-organisateurs du tournoi (via Tournament#organizer?), ainsi que les DEUX
 # joueurs du match. Elle reste possible tant que le tour n'est pas verrouillé
@@ -11,6 +12,19 @@ class TournamentMatchPolicy < ApplicationPolicy
   def update?
     return false if user.blank?
     return false if record.tournament_round.status == "completed" # tour verrouillé
+
+    record.tournament.organizer?(user) || player_of_match?
+  end
+
+  # Planifier la rencontre réelle (modèle Match) de cette confrontation : ouvert
+  # aux DEUX joueurs concernés en plus des organisateurs, pour qu'ils conviennent
+  # eux-mêmes de la date et de l'heure sans dépendre de l'admin. Un seul Match par
+  # confrontation (index unique sur matches.tournament_match_id) : le premier des
+  # deux joueurs à créer la rencontre ferme la porte, l'autre voit « Voir la rencontre ».
+  # Un bye n'a pas de rencontre à jouer.
+  def create_match?
+    return false if user.blank?
+    return false if record.is_bye || record.match.present?
 
     record.tournament.organizer?(user) || player_of_match?
   end

--- a/app/services/swiss_pairing.rb
+++ b/app/services/swiss_pairing.rb
@@ -143,8 +143,13 @@ class SwissPairing
 
   # ── Persistance : helpers ─────────────────────────────────────────────────────
 
-  # État suisse dérivé du bilan V/D (appelé par RoundRobinStats via apply_state).
-  def state_for(wins, losses) = TournamentUser.state_for(wins, losses)
+  # État suisse dérivé du bilan V/D (appelé par RoundRobinStats via apply_state),
+  # avec les seuils propres à CE tournoi (personnalisables depuis le Lot 7).
+  def state_for(wins, losses)
+    TournamentUser.state_for(wins, losses,
+                             wins_to_qualify: @tournament.wins_to_qualify,
+                             losses_to_eliminate: @tournament.losses_to_eliminate)
+  end
 
   # Faut-il arrêter la ronde suisse et lancer le tableau final ?
   def ready_for_bracket?

--- a/app/views/matches/_form.html.erb
+++ b/app/views/matches/_form.html.erb
@@ -72,17 +72,47 @@
         </p>
 
         <%# ────────────────────────────────────────────────
-            Rattachement à un tournoi (Lot 4) — optionnel.
-            Visible seulement si l'utilisateur organise au moins un tournoi.
-            Le lien précis à une carte (tournament_match_id) est posé quand on
-            arrive via « Créer la rencontre » ; on le transmet en champ caché.
+            Rattachement à un tournoi (Lot 4, élargi Lot 7) — optionnel.
+            Visible dès que l'utilisateur organise OU est inscrit à un tournoi non
+            terminé (cf. MatchesController#linkable_tournaments_for_select).
+            Choisir un tournoi révèle ses confrontations rattachables ; en choisir
+            une préremplit le reste du formulaire (sport, titre avec l'adversaire,
+            lieu, date) — tout reste modifiable, les deux joueurs conviennent de
+            leur créneau. Le lien est aussi posé côté serveur quand on arrive via
+            « Créer la rencontre » (?tournament_match_id=X).
             ──────────────────────────────────────────────── %>
-        <% if @organized_tournaments&.any? %>
+        <% if @linkable_tournaments&.any? %>
           <div class="mb-3">
             <%= f.label :tournament_id, "Tournoi (optionnel)", class: "form-label" %>
-            <%= f.collection_select :tournament_id, @organized_tournaments, :id, :name,
-                  { include_blank: "Aucun (match indépendant)" }, class: "form-select" %>
-            <%= f.hidden_field :tournament_match_id %>
+            <%= f.collection_select :tournament_id, @linkable_tournaments, :id, :name,
+                  { include_blank: "Aucun (match indépendant)" },
+                  class: "form-select",
+                  data: {
+                    "match-form-target": "tournamentInput",
+                    "action": "change->match-form#updateTournament",
+                    "tournament-matches": (@linkable_tournament_matches || {}).to_json,
+                    "new-match-path": new_match_path
+                  } %>
+          </div>
+
+          <%# Confrontation du tournoi. Les options du tournoi COURANT sont rendues
+              côté serveur (état initial, y compris à l'arrivée via « Créer la
+              rencontre ») ; le JS les remplace quand on change de tournoi. %>
+          <% current_confrontations = (@linkable_tournament_matches || {})[@match.tournament_id] || [] %>
+          <div class="mb-3" data-match-form-target="tournamentMatchWrapper"
+               style="<%= 'display:none;' if current_confrontations.empty? %>">
+            <%= f.label :tournament_match_id, "Confrontation (optionnel)", class: "form-label" %>
+            <%= f.select :tournament_match_id,
+                  options_for_select(current_confrontations.map { |c| [c[:label], c[:id]] }, @match.tournament_match_id),
+                  { include_blank: "Aucune (rencontre libre)" },
+                  class: "form-select",
+                  data: {
+                    "match-form-target": "tournamentMatchInput",
+                    "action": "change->match-form#applyTournamentMatch"
+                  } %>
+            <small class="form-text text-muted">
+              Rattacher la rencontre à ta confrontation préremplit le lieu, la date et l'adversaire.
+            </small>
           </div>
         <% end %>
 

--- a/app/views/tournaments/_board.html.erb
+++ b/app/views/tournaments/_board.html.erb
@@ -38,7 +38,7 @@
     <% if tournament.swiss_rounds.any? %>
       <section class="tournament-phase" data-tournament-phase-switch-target="section" data-phase="main">
         <h2 class="tournament-phase__title">Ronde Suisse</h2>
-        <%= render "tournaments/round_ribbon", rounds: tournament.swiss_rounds, can_manage: can_manage,
+        <%= render "tournaments/round_ribbon", rounds: tournament.swiss_rounds,
                     title_for: ->(round) { "Ronde #{round.number}" }, group_by_record: true,
                     extra_columns: render("tournaments/qualification_panel", tournament: tournament) %>
       </section>
@@ -48,14 +48,14 @@
     <% if tournament.league_rounds.any? %>
       <section class="tournament-phase" data-tournament-phase-switch-target="section" data-phase="main">
         <h2 class="tournament-phase__title">Championnat</h2>
-        <%= render "tournaments/round_ribbon", rounds: tournament.league_rounds, can_manage: can_manage,
+        <%= render "tournaments/round_ribbon", rounds: tournament.league_rounds,
                     title_for: ->(round) { "Journée #{round.number}" }, paginated: true %>
       </section>
     <% end %>
 
     <%# Poules : round-robin par poule, matchs groupés par poule dans chaque journée. %>
     <% if tournament.pool_rounds.any? %>
-      <%= render "tournaments/pool_phase", tournament: tournament, can_manage: can_manage %>
+      <%= render "tournaments/pool_phase", tournament: tournament %>
     <% end %>
 
     <%# Tableau final / playoffs à élimination directe (commun à tous les formats).
@@ -66,7 +66,7 @@
         Tournament#bracket_expected? (PAS juste `playoffs?`, qui n'a de sens que
         pour le championnat et peut valoir n'importe quoi pour les autres formats). %>
     <% if (tournament.in_progress? || tournament.completed?) && tournament.bracket_expected? %>
-      <%= render "tournaments/bracket", tournament: tournament, can_manage: can_manage %>
+      <%= render "tournaments/bracket", tournament: tournament %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/tournaments/_bracket.html.erb
+++ b/app/views/tournaments/_bracket.html.erb
@@ -22,7 +22,7 @@
         <div class="bracket__matches">
           <% if round %>
             <% round.tournament_matches.order(:position).each do |match| %>
-              <%= render "tournaments/tmatch", match: match, can_manage: can_manage %>
+              <%= render "tournaments/tmatch", match: match %>
             <% end %>
           <% else %>
             <% (tournament.final_size / (2**(index + 1))).times do %>

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -12,8 +12,12 @@
   # Maps JSON passées au contrôleur Stimulus :
   #   - nom lisible du sport (emoji + nom) pour le récap
   #   - formats de TOURNOI compatibles par sport (adapte les boutons de format)
+  #   - images de bannière par sport (comme à la création d'un match) : le fond de
+  #     la page suit le sport sélectionné, et l'URL retenue est persistée dans
+  #     banner_image pour que la carte du tournoi affiche la MÊME image ensuite.
   sports_names   = Sport.order(:name).each_with_object({}) { |s, h| h[s.id] = "#{sport_icon_text(s)} #{s.name}".strip }
   sports_formats = Sport.order(:name).each_with_object({}) { |s, h| h[s.id] = s.available_tournament_formats }
+  sports_images  = Sport.order(:name).each_with_object({}) { |s, h| h[s.id] = sport_images_for(s.slug) }
 
   # Jours / mois FR pour l'affichage initial du date-picker (comme le match).
   fr_days   = %w[Dim Lun Mar Mer Jeu Ven Sam]
@@ -83,15 +87,19 @@
             <%= f.label :sport_id, class: "form-label" do %>Sport <span class="required-star">*</span><% end %>
 
             <%# Le hidden porte les maps JSON lues par tournament-form :
-                - data-tournament-formats   : formats compatibles par sport
-                - data-tournament-structures: structures figées (format → nb → texte) %>
+                - data-formats : formats compatibles par sport
+                - data-images  : bannières disponibles par sport %>
             <%= f.hidden_field :sport_id,
                 data: {
                   "tournament-form-target": "sportInput",
                   "sport-names": sports_names.to_json,
                   "formats":     sports_formats.to_json,
-                  "structures":  Tournament::STRUCTURE_PRESETS.to_json
+                  "images":      sports_images.to_json
                 } %>
+
+            <%# Image de fond retenue (choisie par le JS parmi celles du sport, puis
+                figée : une image déjà enregistrée n'est jamais retirée au hasard). %>
+            <%= f.hidden_field :banner_image, data: { "tournament-form-target": "bannerImageInput" } %>
 
             <div style="position:relative;" data-controller="sport-picker">
               <button type="button"
@@ -209,17 +217,20 @@
         </div><%# fin section 2 %>
 
         <%# ────────────────────────────────────────────────
-            SECTION 3 : Date / heure / lieu
+            SECTION 3 : Date / lieu
             ──────────────────────────────────────────────── %>
         <div class="match-form-section" data-controller="place-search">
           <div class="match-form-section-header">
             <div class="match-form-step-badge">3</div>
-            <h2 class="match-form-section-title">Date, heure & lieu</h2>
+            <h2 class="match-form-section-title">Date & lieu</h2>
           </div>
 
           <div class="row g-3">
 
-            <%# Date %>
+            <%# Date. Volontairement PAS d'heure de début (Lot 7) : un tournoi
+                s'étale sur des rencontres planifiées une par une par les joueurs
+                (« Créer la rencontre » depuis leur carte de poule), chacune avec sa
+                propre date et son propre horaire. %>
             <div class="col-md-6">
               <%= f.label :date, class: "form-label" do %>Date du tournoi <span class="required-star">*</span><% end %>
               <div style="position:relative;" data-controller="date-picker">
@@ -246,59 +257,6 @@
                 </button>
                 <div data-date-picker-target="dropdown" class="dp-dropdown"
                      style="display:none; position:absolute; top:calc(100% + 4px); left:0; z-index:400; min-width:280px;"></div>
-              </div>
-            </div>
-
-            <%# Heure %>
-            <div class="col-md-6">
-              <%= f.label :time, "Heure", class: "form-label" %>
-              <div class="d-flex gap-2" data-action="change->tournament-form#updateTime">
-                <%# Heures %>
-                <div style="position:relative; flex:1;" data-controller="time-picker">
-                  <%= f.hidden_field "time(4i)", value: @tournament.time&.hour, data: { "time-picker-target": "input" } %>
-                  <button type="button"
-                          class="form-select w-100 <%= 'sport-picker-placeholder' unless @tournament.time %>"
-                          data-time-picker-target="trigger"
-                          data-action="click->time-picker#toggle"
-                          style="cursor:pointer; text-align:left;">
-                    <%= @tournament.time ? ("%02dh" % @tournament.time.hour) : "Heure" %>
-                  </button>
-                  <div class="time-picker-dropdown" data-time-picker-target="dropdown"
-                       style="display:none; position:absolute; top:calc(100% + 4px); left:0; right:0; z-index:400; overflow-y:auto; max-height:200px;">
-                    <% (0..23).each do |h| %>
-                      <button type="button"
-                              class="time-picker-item w-100 <%= 'time-picker-item--active' if @tournament.time&.hour == h %>"
-                              style="background:<%= @tournament.time&.hour == h ? 'rgba(30,221,136,0.12)' : 'transparent' %> !important;"
-                              data-time-picker-item
-                              data-action="click->time-picker#select"
-                              data-value="<%= h %>"
-                              data-label="<%= "%02dh" % h %>"><%= "%02dh" % h %></button>
-                    <% end %>
-                  </div>
-                </div>
-                <%# Minutes %>
-                <div style="position:relative; flex:1;" data-controller="time-picker">
-                  <%= f.hidden_field "time(5i)", value: @tournament.time&.min, data: { "time-picker-target": "input" } %>
-                  <button type="button"
-                          class="form-select w-100 <%= 'sport-picker-placeholder' unless @tournament.time %>"
-                          data-time-picker-target="trigger"
-                          data-action="click->time-picker#toggle"
-                          style="cursor:pointer; text-align:left;">
-                    <%= @tournament.time ? ("%02d" % @tournament.time.min) : "Min" %>
-                  </button>
-                  <div class="time-picker-dropdown" data-time-picker-target="dropdown"
-                       style="display:none; position:absolute; top:calc(100% + 4px); left:0; right:0; z-index:400; overflow-y:auto; max-height:200px;">
-                    <% [[0, "00"], [15, "15"], [30, "30"], [45, "45"]].each do |val, lbl| %>
-                      <button type="button"
-                              class="time-picker-item w-100 <%= 'time-picker-item--active' if @tournament.time&.min == val %>"
-                              style="background:<%= @tournament.time&.min == val ? 'rgba(30,221,136,0.12)' : 'transparent' %> !important;"
-                              data-time-picker-item
-                              data-action="click->time-picker#select"
-                              data-value="<%= val %>"
-                              data-label="<%= lbl %>"><%= lbl %></button>
-                    <% end %>
-                  </div>
-                </div>
               </div>
             </div>
 
@@ -378,6 +336,66 @@
                 placeholder: "Ex: 20",
                 data: { "tournament-form-target": "libreInput", "action": "input->tournament-form#buildProposals" } %>
             <div class="tournament-proposals" data-tournament-form-target="proposals"></div>
+          </div>
+
+          <%# ── Réglages de structure (Lot 7) ─────────────────────────────────
+              Révélés dès qu'un nombre de joueurs est choisi. Chaque champ est
+              FACULTATIF : laissé vide, il applique la valeur recommandée affichée
+              en placeholder (cf. Tournament#pool_size / #final_size /
+              #wins_to_qualify / #losses_to_eliminate). Seuls les champs pertinents
+              pour le format courant sont affichés. %>
+          <div class="tournament-advanced" data-tournament-form-target="advancedSection" style="display:none;">
+            <button type="button" class="tournament-advanced__toggle"
+                    data-tournament-form-target="advancedToggle"
+                    data-action="click->tournament-form#toggleAdvanced"
+                    aria-expanded="false">
+              <i data-lucide="sliders-horizontal" style="width:14px;height:14px;" aria-hidden="true"></i>
+              Personnaliser la structure
+            </button>
+
+            <div class="tournament-advanced__fields" data-tournament-form-target="advancedFields" hidden>
+              <p class="tournament-form-hint mb-3">
+                Laisse un champ vide pour garder la valeur recommandée.
+              </p>
+
+              <div class="row g-3">
+                <%# Poules : taille de poule %>
+                <div class="col-md-6" data-tournament-form-target="poolSizeField" style="display:none;">
+                  <%= f.label :players_per_pool, "Joueurs par poule", class: "form-label" %>
+                  <%= f.number_field :players_per_pool, min: 2, class: "form-control",
+                      data: { "tournament-form-target": "poolSizeInput",
+                              "action": "input->tournament-form#refreshStructure" } %>
+                </div>
+
+                <%# Ronde suisse : seuils de qualification / élimination %>
+                <div class="col-md-6" data-tournament-form-target="winsField" style="display:none;">
+                  <%= f.label :swiss_wins_to_qualify, "Victoires pour se qualifier", class: "form-label" %>
+                  <%= f.number_field :swiss_wins_to_qualify, min: 1, class: "form-control",
+                      data: { "tournament-form-target": "winsInput",
+                              "action": "input->tournament-form#refreshStructure" } %>
+                </div>
+
+                <div class="col-md-6" data-tournament-form-target="lossesField" style="display:none;">
+                  <%= f.label :swiss_losses_to_eliminate, "Défaites avant élimination", class: "form-label" %>
+                  <%= f.number_field :swiss_losses_to_eliminate, min: 1, class: "form-control",
+                      data: { "tournament-form-target": "lossesInput",
+                              "action": "input->tournament-form#refreshStructure" } %>
+                </div>
+
+                <%# Taille du tableau final — un select : seules les puissances de 2
+                    sont jouables en élimination directe (cf. validation du modèle). %>
+                <div class="col-md-6" data-tournament-form-target="bracketSizeField" style="display:none;">
+                  <%= f.label :bracket_size, "Taille du tableau final", class: "form-label" %>
+                  <%= f.select :bracket_size,
+                        [["Finale directe (2)", 2], ["Demi-finales (4)", 4], ["Quarts (8)", 8],
+                         ["Huitièmes (16)", 16], ["Seizièmes (32)", 32]],
+                        { include_blank: "Recommandé (auto)" },
+                        class: "form-select",
+                        data: { "tournament-form-target": "bracketSizeInput",
+                                "action": "change->tournament-form#refreshStructure" } %>
+                </div>
+              </div>
+            </div>
           </div>
 
           </div><%# fin wrapper verrouillage nb de joueurs %>
@@ -519,13 +537,6 @@
             <span class="recap-label">Date</span>
             <span class="recap-value" data-tournament-form-target="recapDate">
               <%= @tournament.date.present? ? @tournament.date.strftime("%d %b %Y") : "—" %>
-            </span>
-          </div>
-
-          <div class="match-recap-row">
-            <span class="recap-label">Heure</span>
-            <span class="recap-value" data-tournament-form-target="recapTime">
-              <%= @tournament.time.present? ? @tournament.time.strftime("%Hh%M") : "—" %>
             </span>
           </div>
 

--- a/app/views/tournaments/_pool_phase.html.erb
+++ b/app/views/tournaments/_pool_phase.html.erb
@@ -4,10 +4,10 @@
     group_by_pool: true, dérivé de player_a.pool). Le classement par poule vit
     dans l'onglet Classement (_ranking.html.erb) — pas ici, "Matchs" ne montre
     que des matchs.
-    Locals : tournament, can_manage. %>
+    Locals : tournament. %>
 <section class="tournament-phase" data-tournament-phase-switch-target="section" data-phase="main">
   <h2 class="tournament-phase__title">Poules</h2>
 
-  <%= render "tournaments/round_ribbon", rounds: tournament.pool_rounds, can_manage: can_manage,
+  <%= render "tournaments/round_ribbon", rounds: tournament.pool_rounds,
               title_for: ->(round) { "Journée #{round.number}" }, group_by_pool: true, paginated: true %>
 </section>

--- a/app/views/tournaments/_round_column.html.erb
+++ b/app/views/tournaments/_round_column.html.erb
@@ -4,7 +4,7 @@
     (Vue d'ensemble, lecture seule) mais avec des cartes _tmatch_scoreline
     cliquables (le tableau final, lui, garde _tmatch — cf. _bracket.html.erb).
     `id="round_<id>"` : ancre stable pour un éventuel deep-link direct vers un tour.
-    Locals : round, can_manage, title (optionnel, défaut "Ronde N"),
+    Locals : round, title (optionnel, défaut "Ronde N"),
     group_by_pool (optionnel, défaut false — regroupe les matchs par poule,
     format "poules" uniquement), group_by_record (optionnel, défaut false —
     regroupe les matchs par bilan V/D EN ENTRANT dans ce tour — ex. 2V-0D /
@@ -28,23 +28,23 @@
       <% round.tournament_matches.order(:position).group_by { |m| m.player_a.pool }.sort_by { |pool, _| pool.to_i }.each do |pool_index, matches| %>
         <h4 class="pool-label">Poule <%= ("A".ord + pool_index.to_i).chr %></h4>
         <% matches.each do |match| %>
-          <%= render "tournaments/tmatch_scoreline", match: match, can_manage: can_manage %>
+          <%= render "tournaments/tmatch_scoreline", match: match %>
         <% end %>
       <% end %>
     <% elsif score_groups %>
       <% score_groups.each do |(wins, losses), matches| %>
         <% if score_groups.size > 1 %>
           <div class="score-bracket__header" title="<%= wins %> victoire(s) / <%= losses %> défaite(s) avant ce tour">
-            <%= score_bracket_pips(wins, losses) %>
+            <%= score_bracket_pips(wins, losses, round.tournament) %>
           </div>
         <% end %>
         <% matches.each do |match| %>
-          <%= render "tournaments/tmatch_scoreline", match: match, can_manage: can_manage %>
+          <%= render "tournaments/tmatch_scoreline", match: match %>
         <% end %>
       <% end %>
     <% else %>
       <% round.tournament_matches.order(:position).each do |match| %>
-        <%= render "tournaments/tmatch_scoreline", match: match, can_manage: can_manage %>
+        <%= render "tournaments/tmatch_scoreline", match: match %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/tournaments/_round_ribbon.html.erb
+++ b/app/views/tournaments/_round_ribbon.html.erb
@@ -1,7 +1,7 @@
 <%# ── Ruban horizontal de colonnes (une par tour) ─────────────────────────────
     Réutilisé pour la ronde suisse, le championnat et les poules dans l'onglet
     Matchs éditable. Locals : rounds (array ordonné de TournamentRound),
-    can_manage, title_for (proc round -> String), group_by_pool / group_by_record
+    title_for (proc round -> String), group_by_pool / group_by_record
     (optionnels, défaut false, transmis tels quels à _round_column), extra_columns
     (optionnel, HTML déjà rendu ajouté APRÈS la dernière colonne — ex. la colonne
     Qualifiés/Éliminés de la ronde suisse, en continuité horizontale du ruban).
@@ -44,13 +44,13 @@
     <% if paginated %>
       <div class="round-ribbon__page" data-journee-selector-target="column" data-round-number="<%= round.number %>"
            <%= "hidden" unless round == current_round %>>
-        <%= render "tournaments/round_column", round: round, can_manage: can_manage,
+        <%= render "tournaments/round_column", round: round,
                     title: title_for.call(round),
                     group_by_pool: local_assigns.fetch(:group_by_pool, false),
                     group_by_record: local_assigns.fetch(:group_by_record, false) %>
       </div>
     <% else %>
-      <%= render "tournaments/round_column", round: round, can_manage: can_manage,
+      <%= render "tournaments/round_column", round: round,
                   title: title_for.call(round),
                   group_by_pool: local_assigns.fetch(:group_by_pool, false),
                   group_by_record: local_assigns.fetch(:group_by_record, false) %>

--- a/app/views/tournaments/_score_modal.html.erb
+++ b/app/views/tournaments/_score_modal.html.erb
@@ -1,7 +1,11 @@
 <%# ── Modale de score partagée (Lot 4) ────────────────────────────────────────
     Une seule modale pour tout le tableau : le contrôleur Stimulus tournament-score
-    la remplit à l'ouverture (URL PATCH du match, noms des joueurs, sets existants,
-    nombre de lignes selon le sport) et bascule entre saisie et lecture seule (Détail).
+    la remplit à l'ouverture (URL PATCH du match, noms des joueurs, sets existants)
+    et bascule entre saisie et lecture seule (Détail). Les lignes de sets sont
+    ajoutées AU FUR ET À MESURE : on part du nombre de sets à gagner (3 au ping-pong
+    en poule, 4 en phase finale) et une ligne n'apparaît que si le match n'est pas
+    encore décidé (2-1 → 4e set). Les boutons qui l'ouvrent sont générés par
+    TournamentsHelper#score_modal_button.
     Le formulaire poste deux tableaux parallèles games_a[] / games_b[] (une entrée par
     set) que le controller zippe en paires. %>
 <div class="modal fade score-modal" id="scoreModal" tabindex="-1" aria-labelledby="scoreModalTitle" aria-hidden="true"

--- a/app/views/tournaments/_tmatch.html.erb
+++ b/app/views/tournaments/_tmatch.html.erb
@@ -4,11 +4,16 @@
     (contrôleur Stimulus tournament-score) — le vainqueur en est dérivé. Le bouton
     de saisie n'apparaît que si l'utilisateur peut éditer ce match (organisateur OU
     joueur du match, tour non verrouillé — cf. TournamentMatchPolicy).
+    Le nombre de sets à gagner suit la PHASE (match.scoring_rules) : 4 sets gagnants
+    au ping-pong ici, contre 3 en poule / ronde suisse.
     Réservé au tableau final (_bracket.html.erb) : les journées de championnat/
     poules et les rondes suisses utilisent _tmatch_scoreline (scoreline centrée),
     cf. _round_column.html.erb. %>
-<% rules = match.tournament.sport&.scoring_rules || Sport.new.scoring_rules %>
 <% can_edit = user_signed_in? && policy(match).update? %>
+<%# Création/consultation de la rencontre réelle : ouverte aux 2 joueurs du match
+    ET aux organisateurs (cf. TournamentMatchPolicy#create_match?), pour que les
+    joueurs puissent convenir eux-mêmes de la date et de l'heure. %>
+<% can_create_match = user_signed_in? && policy(match).create_match? %>
 <%# Correction après verrouillage : réservée à l'organisateur, seulement quand le
     tour est verrouillé (sinon la saisie normale can_edit suffit). %>
 <% round_locked = match.tournament_round.status == "completed" %>
@@ -43,8 +48,8 @@
     <% end %>
 
     <%# Score global + accès à la modale (saisie ou détail selon les droits) +
-        rattachement d'une rencontre standard (organisateur uniquement). %>
-    <% if match.score_entered? || can_edit || can_manage || can_correct %>
+        rattachement d'une rencontre standard (joueurs du match ou organisateurs). %>
+    <% if match.score_entered? || can_edit || can_create_match || match.match || can_correct %>
       <div class="tmatch-card__footer">
         <% if match.score_entered? %>
           <span class="tmatch-card__score" title="Score (<%= match.player_a.display_name %> – <%= match.player_b.display_name %>)">
@@ -52,59 +57,29 @@
           </span>
         <% end %>
 
-        <% if can_manage %>
-          <% if match.match %>
-            <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
-          <% else %>
-            <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
-          <% end %>
+        <% if match.match %>
+          <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
+        <% elsif can_create_match %>
+          <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
         <% end %>
 
         <% if can_edit %>
-          <button type="button" class="tmatch-card__score-btn"
-                  data-action="tournament-score#open"
-                  data-tournament-score-url-param="<%= tournament_tournament_match_path(match.tournament, match) %>"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="true">
-            <%= match.score_entered? ? "Modifier" : "Saisir le score" %>
-          </button>
+          <%= score_modal_button match,
+                label: match.score_entered? ? "Modifier" : "Saisir le score",
+                editable: true,
+                url: tournament_tournament_match_path(match.tournament, match) %>
         <% elsif match.score_entered? %>
-          <button type="button" class="tmatch-card__detail-btn"
-                  data-action="tournament-score#open"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="false">
-            Détail
-          </button>
+          <%= score_modal_button match, label: "Détail", editable: false, css_class: "tmatch-card__detail-btn" %>
         <% end %>
 
         <%# Correction organisateur d'un tour verrouillé : rouvre la modale en édition,
             mais poste sur l'action `correct` (régénère l'aval si le vainqueur change). %>
         <% if can_correct %>
-          <button type="button" class="tmatch-card__score-btn tmatch-card__score-btn--correct"
-                  data-action="tournament-score#open"
-                  data-tournament-score-url-param="<%= correct_tournament_tournament_match_path(match.tournament, match) %>"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="true">
-            Corriger
-          </button>
+          <%= score_modal_button match,
+                label: "Corriger",
+                editable: true,
+                url: correct_tournament_tournament_match_path(match.tournament, match),
+                css_class: "tmatch-card__score-btn tmatch-card__score-btn--correct" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tournaments/_tmatch_scoreline.html.erb
+++ b/app/views/tournaments/_tmatch_scoreline.html.erb
@@ -8,8 +8,11 @@
     Réservé à _round_column.html.erb : le tableau final utilise _tmatch (carte
     empilée classique), cf. _bracket.html.erb — la scoreline ne concerne que les
     tours en ruban/paginés. %>
-<% rules = match.tournament.sport&.scoring_rules || Sport.new.scoring_rules %>
 <% can_edit = user_signed_in? && policy(match).update? %>
+<%# Création/consultation de la rencontre réelle : ouverte aux 2 joueurs du match
+    ET aux organisateurs (cf. TournamentMatchPolicy#create_match?), pour que les
+    joueurs puissent convenir eux-mêmes de la date et de l'heure de leur rencontre. %>
+<% can_create_match = user_signed_in? && policy(match).create_match? %>
 <%# Correction après verrouillage : réservée à l'organisateur, seulement quand le
     tour est verrouillé (sinon la saisie normale can_edit suffit). %>
 <% round_locked = match.tournament_round.status == "completed" %>
@@ -60,66 +63,36 @@
     </div>
 
     <%# Accès à la modale (saisie ou détail selon les droits) + rattachement d'une
-        rencontre standard (organisateur uniquement). Le score global est déjà
-        visible dans la scoreline centrale ci-dessus, pas besoin de le répéter ici. %>
-    <% if can_edit || can_manage || can_correct || match.score_entered? %>
+        rencontre standard (joueurs du match ou organisateurs). Le score global est
+        déjà visible dans la scoreline centrale ci-dessus, pas besoin de le répéter ici. %>
+    <% if can_edit || can_create_match || match.match || can_correct || match.score_entered? %>
       <%# --inline : boutons groupés à gauche à la suite (pas de space-between)
           — sur une carte pleine largeur (paginated), space-between les écartait
           sur toute la largeur de la ligne. %>
       <div class="tmatch-card__footer tmatch-card__footer--inline">
-        <% if can_manage %>
-          <% if match.match %>
-            <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
-          <% else %>
-            <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
-          <% end %>
+        <% if match.match %>
+          <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
+        <% elsif can_create_match %>
+          <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
         <% end %>
 
         <% if can_edit %>
-          <button type="button" class="tmatch-card__score-btn"
-                  data-action="tournament-score#open"
-                  data-tournament-score-url-param="<%= tournament_tournament_match_path(match.tournament, match) %>"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="true">
-            <%= match.score_entered? ? "Modifier" : "Saisir le score" %>
-          </button>
+          <%= score_modal_button match,
+                label: match.score_entered? ? "Modifier" : "Saisir le score",
+                editable: true,
+                url: tournament_tournament_match_path(match.tournament, match) %>
         <% elsif match.score_entered? %>
-          <button type="button" class="tmatch-card__detail-btn"
-                  data-action="tournament-score#open"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="false">
-            Détail
-          </button>
+          <%= score_modal_button match, label: "Détail", editable: false, css_class: "tmatch-card__detail-btn" %>
         <% end %>
 
         <%# Correction organisateur d'un tour verrouillé : rouvre la modale en édition,
             mais poste sur l'action `correct` (régénère l'aval si le vainqueur change). %>
         <% if can_correct %>
-          <button type="button" class="tmatch-card__score-btn tmatch-card__score-btn--correct"
-                  data-action="tournament-score#open"
-                  data-tournament-score-url-param="<%= correct_tournament_tournament_match_path(match.tournament, match) %>"
-                  data-tournament-score-mode-param="<%= rules[:mode] %>"
-                  data-tournament-score-allow-draw-param="<%= rules[:allow_draw] %>"
-                  data-tournament-score-best-of-param="<%= rules[:best_of] %>"
-                  data-tournament-score-target-param="<%= rules[:target] %>"
-                  data-tournament-score-sets-param="<%= match.sets.to_json %>"
-                  data-tournament-score-name-a-param="<%= match.player_a.display_name %>"
-                  data-tournament-score-name-b-param="<%= match.player_b.display_name %>"
-                  data-tournament-score-editable-param="true">
-            Corriger
-          </button>
+          <%= score_modal_button match,
+                label: "Corriger",
+                editable: true,
+                url: correct_tournament_tournament_match_path(match.tournament, match),
+                css_class: "tmatch-card__score-btn tmatch-card__score-btn--correct" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tournaments/edit.html.erb
+++ b/app/views/tournaments/edit.html.erb
@@ -9,8 +9,8 @@
 
 <div class="match-create-page">
 
-  <%# Bannière d'en-tête %>
-  <div class="match-new-banner">
+  <%# Bannière d'en-tête (fond piloté par le sport, cf. tournament-form#updateBanner) %>
+  <div class="match-new-banner" id="tournament-new-banner">
     <div class="container">
       <%= render "shared/nav_button", url: tournament_path(@tournament), label: "Retour au tournoi", direction: "back", extra_class: "mb-3" %>
 

--- a/app/views/tournaments/new.html.erb
+++ b/app/views/tournaments/new.html.erb
@@ -9,8 +9,9 @@
 
 <div class="match-create-page">
 
-  <%# Bannière d'en-tête %>
-  <div class="match-new-banner">
+  <%# Bannière d'en-tête. L'id est la cible de tournament-form#updateBanner : son
+      fond suit le sport sélectionné (comme à la création d'un match). %>
+  <div class="match-new-banner" id="tournament-new-banner">
     <div class="container">
       <%= render "shared/nav_button", label: "Retour", direction: "back", extra_class: "mb-3" %>
 

--- a/db/migrate/20260804112657_add_structure_settings_to_tournaments.rb
+++ b/db/migrate/20260804112657_add_structure_settings_to_tournaments.rb
@@ -1,0 +1,23 @@
+# Paramètres de structure personnalisables (Lot 7).
+#
+# Jusqu'ici la structure d'un tournoi était entièrement déduite du format et de
+# l'effectif (poules de 4, Final 4/8, 3 victoires pour se qualifier en ronde
+# suisse) : l'organisateur voyait un aperçu en LECTURE SEULE. Ces 4 colonnes lui
+# permettent de personnaliser chaque critère.
+#
+# Toutes NULLABLES et NULL par défaut : NULL = « recommandé », c'est-à-dire la
+# valeur calculée comme avant (cf. Tournament#pool_size / #final_size /
+# #wins_to_qualify / #losses_to_eliminate). Les tournois existants gardent donc
+# exactement leur comportement actuel, sans backfill.
+#
+# Noms de colonnes distincts des méthodes du modèle (players_per_pool vs
+# #pool_size, bracket_size vs #final_size…) : les méthodes appliquent le fallback,
+# sans jamais masquer un attribut ActiveRecord.
+class AddStructureSettingsToTournaments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tournaments, :players_per_pool, :integer
+    add_column :tournaments, :bracket_size, :integer
+    add_column :tournaments, :swiss_wins_to_qualify, :integer
+    add_column :tournaments, :swiss_losses_to_eliminate, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_163829) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_112657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -484,6 +484,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_163829) do
 
   create_table "tournaments", force: :cascade do |t|
     t.string "banner_image"
+    t.integer "bracket_size"
     t.datetime "created_at", null: false
     t.date "date"
     t.text "description"
@@ -491,11 +492,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_163829) do
     t.integer "max_players"
     t.string "name", null: false
     t.string "place"
+    t.integer "players_per_pool"
     t.boolean "playoffs", default: true, null: false
     t.datetime "registration_deadline"
     t.string "slug", null: false
     t.bigint "sport_id"
     t.string "status", default: "open", null: false
+    t.integer "swiss_losses_to_eliminate"
+    t.integer "swiss_wins_to_qualify"
     t.time "time"
     t.datetime "updated_at", null: false
     t.bigint "user_id"

--- a/docs/TOURNOI.md
+++ b/docs/TOURNOI.md
@@ -149,8 +149,57 @@ c'est de l'élimination directe d'emblée).
 - [x] Affichage : libellé "participants attendus" (au lieu de "joueurs") quand `max_players`
       vient d'une saisie Libre plutôt qu'un preset 8/16/32 (`Tournament#preset_capacity?`).
 
+### ✅ Refonte UI (post-Lot 6) — ruban de rondes, phases, tableau complet `[FAIT]`
+Détail par étape dans `tasks/todo.md` (phases A → E2). Livré : ruban horizontal de rondes
+(`_round_ribbon` / `_round_column`, qui **remplacent l'ancien `_swiss_round`**), sélecteur de
+phase round-robin ↔ tableau final (`tournament_phase_switch_controller.js`), panneau
+« Qualifiés / Éliminés » (`_qualification_panel`), structure complète du tableau final avec
+cases « À déterminer » (`_bracket_placeholder_cell`), vrai tirage au sort (`draw_order`),
+liens vers les profils, sélecteur de journée pour les longs championnats
+(`journee_selector_controller.js`). Phases D et E2 (connecteurs CSS) abandonnées après retour
+utilisateur. Reste ouvert : les vérifications visuelles navigateur (impossibles en CI).
+
+### ✅ Lot 7 — Rencontres planifiées par les joueurs, scoring par phase & structure réglable `[FAIT]`
+- [x] **Scoring dépendant de la phase** : `Sport#scoring_rules` accepte `final_best_of`
+      (ping-pong : 7 au lieu de 5). `TournamentMatch#scoring_rules` devient **public** et
+      applique ce durcissement quand `tournament_round.phase == "bracket"` → **3 sets gagnants
+      en poule / ronde suisse, 4 en phase finale**. `sets_to_win` et les validations en
+      héritent. Les vues passent par `match.scoring_rules` (jamais `sport.scoring_rules`).
+- [x] **Modale de score progressive** : les lignes de sets sont ajoutées **au fur et à mesure**
+      (`tournament_score_controller#refreshRows`) — 3 lignes au départ, une 4e apparaît à 2-1,
+      rien de plus dès qu'un joueur atteint le nombre de sets requis. Fini les 5 lignes vides.
+      Les 6 blocs de `data-*` recopiés dans `_tmatch`/`_tmatch_scoreline` sont remplacés par
+      le helper `score_modal_button`.
+- [x] **Rencontre planifiée par les JOUEURS** : `TournamentMatchPolicy#create_match?` (2 joueurs
+      + admin + co-organisateur, hors bye, une seule rencontre par confrontation). Le bouton
+      « Créer la rencontre » n'est plus réservé à l'organisateur ; les joueurs choisissent
+      **leur date et leur heure**. `Match` valide l'unicité de `tournament_match_id` (plus de
+      500 sur l'index unique quand les deux joueurs cliquent). Le local `can_manage` devenu
+      inutile a été retiré de la chaîne `_board` → `_round_ribbon` → `_round_column`.
+- [x] **Rattachement élargi** : le select « Tournoi » du formulaire de match liste les tournois
+      **où l'on est inscrit**, pas seulement ceux qu'on organise
+      (`MatchesController#linkable_tournaments_for_select`) + un select « Confrontation »
+      (`linkable_tournament_matches_map`). Le choisir recharge le formulaire prérempli par le
+      serveur (`?tournament_match_id=X`) : une seule règle de préremplissage, côté serveur.
+- [x] **Bannière du tournoi pilotée par le sport**, comme à la création d'un match
+      (`tournament-form#updateBanner`, persistée dans `banner_image`). Bug corrigé au passage
+      côté match : `updateBanner()` re-tirait une image au hasard à chaque `connect()`, donc
+      une simple édition changeait l'image — le tirage n'a plus lieu que si le sport change.
+- [x] **Plus d'heure de début sur un tournoi** : l'horaire se décide par rencontre. Le champ
+      a disparu du formulaire (la colonne `time` reste lue pour les tournois existants).
+- [x] **Structure personnalisable** (remplace l'aperçu figé et le `STRUCTURE_PRESETS`
+      provisoire du Lot 2) : 4 colonnes nullables `players_per_pool`, `bracket_size`,
+      `swiss_wins_to_qualify`, `swiss_losses_to_eliminate` — **vide = valeur recommandée**,
+      donc aucun changement pour les tournois existants. Lues par `Tournament#pool_size` /
+      `#final_size` / `#wins_to_qualify` / `#losses_to_eliminate`, seules sources de vérité des
+      moteurs. `#structure_summary` est désormais **calculé** (juste pour tout effectif, mode
+      Libre compris) et son miroir client vit dans `_structureText`. Réglages verrouillés une
+      fois le tournoi lancé (`STRUCTURAL_FIELDS`) ; `bracket_size` validé puissance de 2, et la
+      recommandation des poules est arrondie de même (3 poules → 6 qualifiés → tableau de 8).
+
 ### 🔜 (ex-Lot 5, reporté) — affinements
 - [ ] Winner / Loser Bracket (format e-sport) — voir « Formats envisagés » #4.
+- [ ] Gestion des co-organisateurs après création (ajout/retrait depuis `#edit`).
 
 ### 💡 Futurs
 - [ ] **Gamification** : badges, trophées, achievements (1er tournoi gagné, 500 pts, 10e set…).
@@ -163,13 +212,17 @@ c'est de l'élimination directe d'emblée).
 
 ## 📌 État courant
 
-**Lots 1 à 6 livrés.** Les 3 formats (`ronde_suisse`, `championnat`, `poules`) sont jouables de
+**Lots 1 à 7 livrés.** Les 3 formats (`ronde_suisse`, `championnat`, `poules`) sont jouables de
 bout en bout via la façade `TournamentEngine`. Un organisateur peut déclarer un **forfait**
 (exclusion du joueur, victoires par forfait) et **corriger un score verrouillé** (avec
 régénération cohérente de l'aval). Depuis le Lot 6, l'organisateur **et le co-organisateur**
 peuvent aussi **éditer le tournoi**, **clôturer/rouvrir les inscriptions** et **terminer
-manuellement** un tournoi. Prochain chantier envisagé : Winner/Loser Bracket, puis les
-« Futurs » ci-dessous (gamification, calendrier, Slack…).
+manuellement** un tournoi. Depuis le Lot 7, **les joueurs planifient eux-mêmes leur rencontre**
+(date et heure de leur choix) depuis leur carte de poule, le **scoring dépend de la phase**
+(ping-pong : 3 sets gagnants en poule, 4 en phase finale) et l'organisateur **personnalise la
+structure** de son tournoi (taille des poules, seuils de la ronde suisse, taille du tableau
+final) avec des valeurs recommandées par défaut. Prochain chantier envisagé : Winner/Loser
+Bracket, puis les « Futurs » ci-dessous (gamification, calendrier, Slack…).
 
 <details><summary>Historique Lots 1 à 4</summary>
 
@@ -189,13 +242,23 @@ d'ensemble embarque un **bracket viewer** interactif (défilement, zoom, filtre 
 - `tournament_matches` : player_a/player_b/winner (→ `tournament_users`), is_bye, position,
   status, **`sets` (jsonb, `[[a, b], …]`)**, **`forfeit` + `retired_player_id`** (Lot 5) ;
   index unique `[tournament_round_id, position]`.
-- `tournament_users` (+ colonnes) : wins, losses, seed, state
+- `tournament_users` (+ colonnes) : wins, **draws**, losses, seed, state
   (`active`/`qualified`/`eliminated`/**`withdrawn`**), `sets_won/sets_lost`, `points_won/points_lost`,
-  **`pool`** (Lot 5, index `[tournament_id, pool]`).
+  **`pool`** (Lot 5, index `[tournament_id, pool]`), **`draw_order`** (tirage au sort figé au lancement).
 - `matches` (couplage) : **`tournament_id`** (rattachement lâche) + **`tournament_match_id`**
   (lien 1↔1, index unique).
 
 </details>
+
+### Modèle de données — compléments (Lots 6 & 7)
+- `tournaments` : **`playoffs`** (Lot 6, booléen — n'a de sens que pour le championnat,
+  cf. `Tournament#bracket_expected?`), **`banner_image`** (image suivie du sport, Lot 7).
+- `tournaments` — réglages de structure (Lot 7, **tous nullables : `nil` = recommandé**) :
+  **`players_per_pool`**, **`bracket_size`**, **`swiss_wins_to_qualify`**,
+  **`swiss_losses_to_eliminate`**. Ne jamais les lire directement dans un moteur : passer par
+  `Tournament#pool_size` / `#final_size` / `#wins_to_qualify` / `#losses_to_eliminate`, qui
+  appliquent le fallback (les noms de colonnes diffèrent volontairement de ceux des méthodes
+  pour qu'aucune méthode ne masque un attribut ActiveRecord).
 
 ### Décisions actées
 - **Statuts** (`tournaments.status`) : `open` / `closed` / `in_progress` / `completed`
@@ -209,9 +272,10 @@ d'ensemble embarque un **bracket viewer** interactif (défilement, zoom, filtre 
 - **Co-organisateur** (tranché Lot 2) : **pas de nouvelle colonne** — rôle `co_organisateur`
   dans `tournament_users` (n'occupe pas de place de joueur). Droits fins sur la gestion du
   tableau : à câbler au Lot 3 via `Tournament#organizer?`.
-- **Nombre de joueurs** : presets 8/16/32 **+ mode Libre** (nombre arbitraire). Structures
-  figées (`Tournament::STRUCTURE_PRESETS`) et propositions du mode Libre **provisoires** —
-  affichées en aperçu lecture seule, à affiner au Lot 3.
+- **Nombre de joueurs** : presets 8/16/32 **+ mode Libre** (nombre arbitraire). Depuis le Lot 7,
+  la structure qui en découle n'est plus un aperçu figé en lecture seule : elle est **calculée**
+  (`Tournament#structure_summary`) et chacun de ses critères est **personnalisable** par
+  l'organisateur, avec la valeur recommandée en placeholder.
 - **Formats par sport** : `Sport#available_tournament_formats` (raquette → RS/Poules ;
   collectif → Championnat/Poules).
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -81,3 +81,15 @@ Un sport est **piloté par la base** (table `sports` : `name`, `icon`, `slug`) m
   2. Un `ILIKE '%…%'` sur une colonne identifiante (email, téléphone) est un endpoint d'énumération, même derrière une autorisation : le rôle « capitaine » est accessible à quiconque crée une équipe.
   3. Pour désigner un utilisateur depuis le front sans exposer son identité : `signed_id(purpose:, expires_in:)`. Signé ≠ révocable → durée de vie courte obligatoire.
   4. Autoriser en **tête** d'action, pas après les guard-clauses : sinon `verify_authorized` transforme chaque cas d'erreur métier en 500.
+
+## 2026-08-04 — `connect()` + tirage aléatoire = donnée écrasée en silence
+- **Symptôme** : aucun — trouvé en transposant la bannière « image selon le sport » du formulaire de match vers celui de tournoi.
+- **Cause racine** : `match_form_controller#updateBanner()` tirait une image **au hasard** parmi celles du sport et l'écrivait dans le champ caché `banner_image`. Or `connect()` appelle `updateSport()` → `updateBanner()`. En **édition**, ouvrir un match et l'enregistrer sans rien toucher changeait donc son image : le formulaire écrasait une donnée persistée que l'utilisateur n'avait pas modifiée.
+- **Correctif** : ne tirer une nouvelle image que si le champ est vide **ou** si l'image courante n'appartient plus au sport sélectionné (`images.includes(current)`). Même garde posée d'emblée dans `tournament_form_controller#updateBanner`.
+- **Leçon** : un contrôleur Stimulus qui **écrit** dans un champ depuis `connect()` doit distinguer « initialiser une valeur absente » de « recalculer après une action utilisateur ». Tout ce qui est non déterministe (aléatoire, `Time.now`) rend le piège invisible en création et destructeur en édition. Vérifier systématiquement le chemin `connect()` → écriture de champ.
+
+## 2026-08-04 — Une méthode de modèle ne doit pas porter le nom de sa colonne « brute »
+- **Contexte** : rendre la structure d'un tournoi personnalisable (taille des poules, seuils de ronde suisse, taille du tableau final) avec `nil` = « valeur recommandée », donc un fallback à appliquer à la lecture.
+- **Piège évité** : nommer la colonne `pool_size` **et** vouloir `def pool_size = self[:pool_size] || 4` fait masquer l'attribut ActiveRecord par la méthode. Plus aucun moyen de lire la valeur brute sans `self[:…]`, et le formulaire (`f.number_field :pool_size`) afficherait la valeur *calculée* — qu'un simple enregistrement transformerait alors en réglage explicite, faisant perdre l'auto-adaptation.
+- **Choix** : colonnes `players_per_pool` / `bracket_size` / `swiss_wins_to_qualify` / `swiss_losses_to_eliminate` (valeur brute, lue par le formulaire), méthodes `#pool_size` / `#final_size` / `#wins_to_qualify` / `#losses_to_eliminate` (valeur effective, lue par les moteurs). Aucun recouvrement de nom.
+- **Leçon** : pour un réglage « nullable = défaut », donner **deux noms distincts** — un pour la saisie, un pour l'usage. Les colonnes nullables évitent par ailleurs tout backfill : les enregistrements existants gardent exactement leur comportement.

--- a/test/controllers/matches_controller_test.rb
+++ b/test/controllers/matches_controller_test.rb
@@ -467,6 +467,81 @@ class MatchesControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: /Score du tournoi : #{Regexp.escape(tmatch.score_summary)}/
   end
 
+  # ── Planification par les JOUEURS (Lot 7) ───────────────────────────────────
+  # Un tournoi organisé par @other_user, où @user n'est qu'un joueur inscrit.
+  def build_tournament_match_as_player
+    tournament = Tournament.create!(name: "Tournoi joueur", sport: @sport, user: @other_user,
+                                    format: "poules", status: "in_progress", max_players: 8,
+                                    date: Date.tomorrow, place: "Gymnase test")
+    opponent = create_test_user(email: "opp-#{SecureRandom.hex(3)}@example.com")
+    a = tournament.tournament_users.create!(user: @user, role: "joueur", status: "approved")
+    b = tournament.tournament_users.create!(user: opponent, role: "joueur", status: "approved")
+    round = tournament.tournament_rounds.create!(phase: "pool", number: 1, status: "in_progress")
+    [tournament, round.tournament_matches.create!(player_a: a, player_b: b, position: 0)]
+  end
+
+  test "un JOUEUR (non organisateur) peut préremplir la rencontre de sa confrontation" do
+    sign_in @user
+    tournament, tmatch = build_tournament_match_as_player
+
+    get new_match_path(tournament_match_id: tmatch.id)
+    assert_response :success
+
+    # Lieu et date du tournoi repris ; le titre nomme les deux adversaires.
+    assert_match(/value="Gymnase test"/, response.body)
+    assert_match(/value="#{tournament.date}"/, response.body)
+    assert_match(/#{Regexp.escape(tmatch.player_b.display_name)}/, response.body)
+    # Le tournoi apparaît dans le select : on y est inscrit, sans l'organiser.
+    assert_match(/Tournoi joueur/, response.body)
+
+    # Select « Confrontation » alimenté et présélectionné sur la carte visée.
+    assert_select "select[name='match[tournament_match_id]']" do
+      assert_select "option[selected][value=?]", tmatch.id.to_s
+    end
+  end
+
+  test "un JOUEUR peut créer la rencontre de sa confrontation" do
+    sign_in @user
+    tournament, tmatch = build_tournament_match_as_player
+
+    assert_difference "Match.count", 1 do
+      post matches_path, params: { match: {
+        title: "Ma rencontre de poule", date: Date.tomorrow,
+        'time(4i)': "20", 'time(5i)': "30", # créneau choisi par les joueurs eux-mêmes
+        players_needed: 2, level: "Tout niveau", visibility: "public",
+        validation_mode: "automatic", genre_restriction: "tous",
+        sport_id: @sport.id, tournament_id: tournament.id, tournament_match_id: tmatch.id
+      } }
+    end
+
+    match = Match.last
+    assert_equal tmatch.id, match.tournament_match_id
+    assert_equal tournament.id, match.tournament_id
+    assert_equal 20, match.time.hour, "l'heure choisie par le joueur est conservée"
+    assert_includes match.match_users.map(&:user_id), tmatch.player_b.user_id
+  end
+
+  test "une confrontation déjà rattachée ne peut pas recevoir une 2e rencontre" do
+    _tournament, tmatch = build_tournament_match_as_player
+    Match.create!(title: "Déjà planifiée", date: Date.tomorrow, time: "18:00", end_time: "19:00",
+                  players_needed: 2, level: "Tout niveau", visibility: "public",
+                  validation_mode: "automatic", genre_restriction: "tous",
+                  user: tmatch.player_b.user, sport: @sport, tournament_match: tmatch)
+
+    sign_in @user
+    post matches_path, params: { match: {
+      title: "Doublon", date: Date.tomorrow,
+      'time(4i)': "18", 'time(5i)': "00",
+      players_needed: 2, level: "Tout niveau", visibility: "public",
+      validation_mode: "automatic", genre_restriction: "tous",
+      sport_id: @sport.id, tournament_match_id: tmatch.id
+    } }
+
+    # Le lien est effacé par sanitize_tournament_link : la rencontre reste créée,
+    # mais indépendante (pas de 500 sur l'index unique).
+    assert_nil Match.last.tournament_match_id
+  end
+
   test "POST /matches ignore le rattachement à un tournoi qu'on n'organise pas" do
     tournament, tmatch = build_tournament_match(owner: @other_user)
     sign_in @user # @user n'organise pas ce tournoi

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -80,6 +80,19 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "form"
     assert_select ".match-form-section", 4 # 4 sections numérotées
+
+    # Bannière pilotée par le sport (Lot 7) : la cible du JS et le champ persisté.
+    assert_select "#tournament-new-banner"
+    assert_select "input[name='tournament[banner_image]']"
+    assert_select "input[data-tournament-form-target='sportInput'][data-images]"
+
+    # Réglages de structure personnalisables + plus aucun champ heure de début.
+    assert_select ".tournament-advanced"
+    assert_select "input[name='tournament[players_per_pool]']"
+    assert_select "select[name='tournament[bracket_size]']"
+    assert_select "input[name='tournament[swiss_wins_to_qualify]']"
+    assert_select "input[name='tournament[swiss_losses_to_eliminate]']"
+    assert_select "input[name='tournament[time(4i)]']", 0
   end
 
   test "GET /tournois/new redirige un visiteur non connecté" do
@@ -105,6 +118,58 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "open", t.status
     assert_equal 0, t.approved_players_count # pas inscrit comme joueur par défaut
     assert_redirected_to tournament_path(t)
+  end
+
+  # ─── Bannière + réglages de structure (Lot 7) ───────────────────────────────
+  test "POST /tournois persiste la bannière choisie et les réglages de structure" do
+    sign_in @user
+    banner = "https://res.cloudinary.com/test/image/upload/pingpong.png"
+
+    post tournaments_path, params: {
+      tournament: {
+        name: "Open réglé", sport_id: @sport.id, format: "poules",
+        max_players: 16, date: Date.tomorrow.to_s, place: "Club Test",
+        banner_image: banner, players_per_pool: 8, bracket_size: 4
+      }
+    }
+
+    t = Tournament.last
+    assert_equal banner, t.banner_image, "l'image suivie du sport est enregistrée"
+    assert_equal 8, t.pool_size
+    assert_equal 4, t.final_size
+    assert_equal "2 poules de 8 + demi-finales", t.structure_summary
+  end
+
+  test "POST /tournois : un réglage vide retombe sur la recommandation" do
+    sign_in @user
+
+    post tournaments_path, params: {
+      tournament: {
+        name: "Open auto", sport_id: @sport.id, format: "poules",
+        max_players: 16, date: Date.tomorrow.to_s, place: "Club Test",
+        players_per_pool: "", bracket_size: ""
+      }
+    }
+
+    t = Tournament.last
+    assert_nil t.players_per_pool
+    assert_equal Tournament::DEFAULT_POOL_SIZE, t.pool_size
+    assert_equal "4 poules de 4 + quarts", t.structure_summary
+  end
+
+  test "POST /tournois refuse un tableau final qui n'est pas une puissance de 2" do
+    sign_in @user
+
+    assert_no_difference "Tournament.count" do
+      post tournaments_path, params: {
+        tournament: {
+          name: "Open cassé", sport_id: @sport.id, format: "poules",
+          max_players: 16, date: Date.tomorrow.to_s, place: "Club Test",
+          bracket_size: 6
+        }
+      }
+    end
+    assert_response :unprocessable_entity
   end
 
   # ─── Co-organisateur + auto-inscription ─────────────────────────────────────

--- a/test/models/tournament_match_test.rb
+++ b/test/models/tournament_match_test.rb
@@ -175,4 +175,78 @@ class TournamentMatchTest < ActiveSupport::TestCase
     assert_equal p1.id, m.winner_id
     assert_equal "completed", m.status
   end
+
+  # ── Scoring dépendant de la phase (Lot 7) ─────────────────────────────────
+  # Règlement du tennis de table : 3 sets gagnants en poule / ronde suisse,
+  # 4 en phase finale. Seule la phase de la ronde change entre les deux cas.
+  class PingPongPhaseTest < ActiveSupport::TestCase
+    def setup
+      @sport = Sport.create!(name: "Ping Pong", slug: "ping-pong", icon: "🏓")
+      @tournament = Tournament.create!(name: "PP phases", sport: @sport, format: "poules",
+                                       status: "in_progress", max_players: 8,
+                                       date: Date.tomorrow, place: "Terrain test")
+      @p1 = player("f1")
+      @p2 = player("f2")
+    end
+
+    def teardown
+      teardown_db
+    end
+
+    def player(tag)
+      @tournament.tournament_users.create!(user: create_test_user(email: "#{tag}-#{SecureRandom.hex(3)}@t.fr"),
+                                          role: "joueur", status: "approved")
+    end
+
+    # Match A vs B dans une ronde de la phase donnée.
+    def match_in(phase, sets)
+      round = @tournament.tournament_rounds.find_by(phase: phase) ||
+              @tournament.tournament_rounds.create!(phase: phase, number: 1, status: "in_progress")
+      m = round.tournament_matches.new(player_a: @p1, player_b: @p2, position: rand(1_000_000))
+      m.assign_score(sets)
+      m
+    end
+
+    test "phase de poule : best_of 5, 3 sets gagnants" do
+      m = match_in("pool", [[11, 5], [11, 6], [11, 7]])
+      assert_equal 5, m.scoring_rules[:best_of]
+      assert_equal 3, m.sets_to_win
+      m.save!
+      assert_equal @p1.id, m.winner_id, "3 sets gagnés → match gagné en poule"
+    end
+
+    test "phase finale : best_of 7, 4 sets gagnants" do
+      m = match_in("bracket", [[11, 5], [11, 6], [11, 7]])
+      assert_equal 7, m.scoring_rules[:best_of]
+      assert_equal 4, m.sets_to_win
+      m.save!
+      assert_nil m.winner_id, "3 sets ne suffisent pas en phase finale"
+      assert_equal "pending", m.status
+
+      m.assign_score([[11, 5], [11, 6], [5, 11], [11, 7], [11, 9]])
+      m.save!
+      assert_equal @p1.id, m.winner_id, "4 sets gagnés → match gagné en phase finale"
+      assert_equal "completed", m.status
+    end
+
+    test "phase de poule : un 6e set est refusé" do
+      m = match_in("pool", [[11, 0]] * 6)
+      refute m.valid?
+      assert(m.errors[:sets].any? { |msg| msg.include?("trop de sets") })
+    end
+
+    test "phase finale : jusqu'à 7 sets, le 8e est refusé" do
+      assert match_in("bracket", [[11, 0], [0, 11], [11, 0], [0, 11], [11, 0], [0, 11], [11, 0]]).valid?,
+             "7 sets sont valides en phase finale"
+      refute match_in("bracket", [[11, 0]] * 8).valid?
+    end
+
+    test "les autres sports gardent les mêmes règles à toutes les phases" do
+      tennis = Sport.create!(name: "Tennis test", slug: "tennis", icon: "🎾")
+      @tournament.update!(sport: tennis)
+
+      assert_equal 3, match_in("pool", [[6, 4]]).scoring_rules[:best_of]
+      assert_equal 3, match_in("bracket", [[6, 4]]).scoring_rules[:best_of]
+    end
+  end
 end

--- a/test/models/tournament_test.rb
+++ b/test/models/tournament_test.rb
@@ -76,4 +76,97 @@ class TournamentTest < ActiveSupport::TestCase
     assert open_tournament(max_players: 16).preset_capacity?
     refute open_tournament(max_players: 20).preset_capacity?
   end
+
+  # ─── Réglages de structure personnalisables (Lot 7) ─────────────────────────
+  # Chaque réglage vide = valeur recommandée (comportement historique).
+  test "valeurs recommandées quand aucun réglage n'est saisi" do
+    t = open_tournament(max_players: 8)
+    assert_equal Tournament::DEFAULT_POOL_SIZE, t.pool_size
+    assert_equal TournamentUser::WINS_TO_QUALIFY, t.wins_to_qualify
+    assert_equal TournamentUser::LOSSES_TO_ELIMINATE, t.losses_to_eliminate
+    assert_equal 4, t.planned_final_size, "≤ 8 joueurs en ronde suisse → Final 4"
+  end
+
+  test "les réglages saisis prennent le pas sur les recommandations" do
+    t = open_tournament(max_players: 16)
+    t.update!(players_per_pool: 3, bracket_size: 16, swiss_wins_to_qualify: 2, swiss_losses_to_eliminate: 1)
+
+    assert_equal 3, t.pool_size
+    assert_equal 2, t.wins_to_qualify
+    assert_equal 1, t.losses_to_eliminate
+    assert_equal 16, t.final_size
+    assert_equal 16, t.planned_final_size
+  end
+
+  test "pool_count et final_size suivent la taille de poule choisie" do
+    t = open_tournament(max_players: 12)
+    t.update!(format: "poules")
+    3.times { |i| join!(t, "p#{i}") } # 3 inscrits… mais 12 attendus
+
+    assert_equal 3, t.planned_pool_count, "12 joueurs attendus / poules de 4"
+    # 3 poules → 6 qualifiés, arrondis au tableau à 8 (2 byes) : une phase finale
+    # ne peut compter que 2, 4, 8, 16… places.
+    assert_equal 8, t.planned_final_size
+
+    t.update!(players_per_pool: 6)
+    assert_equal 2, t.planned_pool_count
+    assert_equal 4, t.planned_final_size
+  end
+
+  test "bracket_size doit être une puissance de 2" do
+    t = open_tournament(max_players: 8)
+    t.bracket_size = 6
+    refute t.valid?
+    assert(t.errors[:bracket_size].any? { |m| m.include?("puissance de 2") })
+
+    t.bracket_size = 8
+    assert t.valid?
+  end
+
+  test "réglages de structure invalides refusés" do
+    t = open_tournament(max_players: 8)
+    t.players_per_pool = 1 # une poule se joue à 2 minimum
+    refute t.valid?
+
+    t.players_per_pool = nil
+    t.swiss_wins_to_qualify = 0 # il faut au moins 1 victoire pour se qualifier
+    refute t.valid?
+  end
+
+  # Les seuils du tournoi pilotent l'état suisse (SwissPairing#state_for les
+  # transmet à TournamentUser.state_for à chaque recompute).
+  test "state_for suit les seuils passés" do
+    assert_equal "active", TournamentUser.state_for(2, 2)
+    assert_equal "qualified", TournamentUser.state_for(3, 0)
+    assert_equal "eliminated", TournamentUser.state_for(0, 3)
+
+    # Tournoi express : 2 victoires suffisent, 1 défaite élimine.
+    assert_equal "qualified", TournamentUser.state_for(2, 0, wins_to_qualify: 2, losses_to_eliminate: 1)
+    assert_equal "eliminated", TournamentUser.state_for(0, 1, wins_to_qualify: 2, losses_to_eliminate: 1)
+    assert_equal "active", TournamentUser.state_for(1, 0, wins_to_qualify: 2, losses_to_eliminate: 1)
+  end
+
+  # ─── structure_summary ──────────────────────────────────────────────────────
+  test "structure_summary reflète le format et les réglages" do
+    t = open_tournament(max_players: 16)
+    assert_equal "Ronde suisse (3 V / 3 D) + quarts", t.structure_summary
+
+    t.update!(swiss_wins_to_qualify: 2, bracket_size: 4)
+    assert_equal "Ronde suisse (2 V / 3 D) + demi-finales", t.structure_summary
+
+    t.update!(format: "poules", swiss_wins_to_qualify: nil, bracket_size: nil)
+    assert_equal "4 poules de 4 + quarts", t.structure_summary
+
+    t.update!(players_per_pool: 8)
+    assert_equal "2 poules de 8 + demi-finales", t.structure_summary
+  end
+
+  test "structure_summary du championnat mentionne les playoffs" do
+    t = open_tournament(max_players: 8)
+    t.update!(format: "championnat", playoffs: true)
+    assert_equal "8 joueurs, 7 journées, top 4 en playoffs", t.structure_summary
+
+    t.update!(playoffs: false)
+    assert_equal "8 joueurs, 7 journées, vainqueur = 1er du classement", t.structure_summary
+  end
 end

--- a/test/policies/tournament_match_policy_test.rb
+++ b/test/policies/tournament_match_policy_test.rb
@@ -64,4 +64,40 @@ class TournamentMatchPolicyTest < ActiveSupport::TestCase
   def test_show_public
     assert TournamentMatchPolicy.new(nil, @match).show?
   end
+
+  # ── create_match? (Lot 7) : planifier la rencontre réelle ───────────────────
+  def test_joueurs_et_organisateurs_peuvent_creer_la_rencontre
+    assert TournamentMatchPolicy.new(@player_a.user, @match).create_match?
+    assert TournamentMatchPolicy.new(@player_b.user, @match).create_match?
+    assert TournamentMatchPolicy.new(@admin, @match).create_match?
+    assert TournamentMatchPolicy.new(@co_org, @match).create_match?
+  end
+
+  def test_tiers_et_visiteur_ne_peuvent_pas_creer_la_rencontre
+    refute TournamentMatchPolicy.new(@stranger, @match).create_match?
+    refute TournamentMatchPolicy.new(nil, @match).create_match?
+  end
+
+  def test_pas_de_rencontre_pour_un_bye
+    bye = @round.tournament_matches.create!(player_a: @player_a, is_bye: true, position: 1)
+    refute TournamentMatchPolicy.new(@player_a.user, bye).create_match?
+  end
+
+  # Index unique sur matches.tournament_match_id : une seule rencontre par
+  # confrontation. Le 2e joueur ne doit donc plus voir « Créer la rencontre ».
+  def test_confrontation_deja_rattachee
+    Match.create!(user: @player_a.user, sport: @sport, tournament: @tournament, tournament_match: @match,
+                  title: "Rencontre", date: Date.tomorrow, time: Time.current, end_time: 1.hour.from_now,
+                  place: "Terrain test", level: "Tout niveau", players_needed: 2, validation_mode: "automatic")
+
+    refute TournamentMatchPolicy.new(@player_b.user, @match.reload).create_match?
+    refute TournamentMatchPolicy.new(@admin, @match).create_match?
+  end
+
+  # Le verrou de tour ne concerne QUE la saisie de score : une rencontre peut
+  # toujours être planifiée (ex. match à rejouer, ou création tardive).
+  def test_tour_verrouille_n_empeche_pas_la_creation
+    @round.update!(status: "completed")
+    assert TournamentMatchPolicy.new(@player_a.user, @match).create_match?
+  end
 end


### PR DESCRIPTION
… structure personnalisable

Scoring dépendant de la phase :
- ping-pong en 4 sets gagnants en phase finale (final_best_of), 3 en poule/suisse
- TournamentMatch#scoring_rules devient public et phase-aware
- modale de score : n'affiche que les sets utiles, ajoute une ligne tant que le match est indécis, plus rien dès qu'un joueur atteint le compte requis

Rencontres planifiées par les joueurs :
- TournamentMatchPolicy#create_match? : 2 joueurs + admin + co-organisateur
- select Tournoi + select Confrontation dans le formulaire de match, préremplissage serveur (sport, adversaire, lieu, date) modifiable
- unicité de Match#tournament_match_id pour éviter un 500 sur l'index unique

Création de tournoi :
- bannière pilotée par le sport, comme pour un match
- structure personnalisable : taille des poules, seuils de ronde suisse, taille du tableau final ; nil = valeur recommandée, calculée par format
- taille recommandée du tableau arrondie à la puissance de 2 supérieure
- suppression du champ Heure

Fix : updateBanner() re-tirait une image au hasard à chaque connect(), donc ouvrir puis enregistrer un match en édition changeait son image.