### PR TITLE
Ajout gestion de l'équipe organisatrice d'un tournoi

### DIFF
--- a/app/assets/stylesheets/pages/_tournaments_form.scss
+++ b/app/assets/stylesheets/pages/_tournaments_form.scss
@@ -131,6 +131,124 @@
   .form-check-label { color: var(--theme-text-primary); font-weight: 600; }
 }
 
+// ── Équipe organisatrice (page d'édition) ──
+// Panneau de composition de l'équipe : liste des organisateurs + champs de
+// nomination / transfert. Réutilise .match-form-section pour l'enveloppe.
+.tournament-organizers {
+  &__list {
+    list-style: none;
+    margin: 0 0 1.25rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.7rem;
+    border-radius: 0.6rem;
+    border: 1px solid var(--theme-border-strong);
+    background: var(--theme-hover-bg);
+  }
+
+  &__avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  // Prend la place restante et pousse le rôle + la croix à droite.
+  &__name {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-weight: 600;
+    color: var(--theme-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__role {
+    flex-shrink: 0;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    background: var(--theme-border-strong);
+    color: var(--theme-text-muted);
+
+    &--admin {
+      background: $green;
+      color: #111;
+    }
+  }
+
+  // Croix de révocation : discrète au repos, rouge au survol — l'action est
+  // destructive, on ne la met pas en avant dans une liste qu'on parcourt.
+  &__remove {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 0.4rem;
+    background: transparent;
+    color: var(--theme-text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+
+    &:hover {
+      background: rgba(220, 53, 69, 0.15);
+      color: #dc3545;
+    }
+
+    i { width: 16px; height: 16px; }
+  }
+
+  // Champ + bouton sur une ligne, empilés sous 576px (le bouton passerait
+  // sinon à ~60px de large et son libellé serait tronqué).
+  &__field {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+
+    @media (max-width: 575px) {
+      flex-direction: column;
+
+      .position-relative { width: 100%; }
+    }
+  }
+
+  &__submit {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    white-space: nowrap;
+
+    @media (max-width: 575px) {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+
+  &__separator {
+    margin: 1.5rem 0;
+    border-color: var(--theme-border-strong);
+    opacity: 1;
+  }
+}
+
 // Texte d'aide sous un champ (co-organisateur, auto-inscription). Remplace
 // Bootstrap .text-muted : sa couleur est figée (gris quasi noir), illisible
 // sur le fond sombre de l'appli — on utilise le token de thème adaptatif.

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -5,7 +5,8 @@ class TournamentsController < ApplicationController
   # coming_soon : page d'attente publique (la feature tournoi n'est pas encore lancée).
   skip_before_action :authenticate_user!, only: %i[index show coming_soon]
 
-  before_action :set_tournament, only: %i[show start edit update toggle_registrations finish seeding]
+  before_action :set_tournament, only: %i[show start edit update toggle_registrations finish seeding
+                                          add_co_organizer remove_co_organizer transfer_ownership]
 
   # Associations préchargées pour les cards (sport, avatars des participants,
   # organisateur) — appliquées uniquement à l'onglet actif (cf. #index), jamais
@@ -112,7 +113,7 @@ class TournamentsController < ApplicationController
     assign_registration_deadline
 
     if @tournament.save
-      add_co_organizer
+      add_initial_co_organizer
       register_creator_if_requested
 
       # Partage Slack : uniquement si l'organisateur a coché la case dans le formulaire.
@@ -200,9 +201,102 @@ class TournamentsController < ApplicationController
     end
   end
 
-  # GET /tournois/search?q=...
+  # POST /tournois/:id/co-organisateurs
+  # Nomme un co-organisateur après la création (le champ du formulaire de création
+  # ne sert qu'au premier). Réservé à l'admin : cf. TournamentPolicy#manage_organizers?.
+  def add_co_organizer
+    authorize @tournament, :manage_organizers?
+
+    user = User.find_by_invite_sgid(params[:co_organizer_sgid])
+    return redirect_back_to_edit(alert: "Choisis un joueur dans la liste de suggestions.") if user.nil?
+    return redirect_back_to_edit(alert: "Tu es déjà l'admin de ce tournoi.") if user == @tournament.user
+
+    # Une seule ligne d'inscription par personne (index unique) : selon qu'elle est
+    # déjà inscrite ou pas, on promeut sa ligne existante ou on en crée une.
+    existing = @tournament.tournament_users.find_by(user: user)
+
+    if existing.nil?
+      @tournament.tournament_users.create!(user: user, role: "co_organisateur", status: "approved")
+      notify_new_co_organizer(user)
+      redirect_back_to_edit(notice: "#{user.display_name} est maintenant co-organisateur.")
+    elsif existing.co_organizer?
+      redirect_back_to_edit(alert: "#{user.display_name} est déjà co-organisateur.")
+    elsif @tournament.open? || @tournament.closed?
+      # Promotion d'un joueur inscrit : il libère sa place (les co-organisateurs
+      # n'occupent pas de place, cf. Tournament#approved_players_count).
+      existing.update!(role: "co_organisateur")
+      notify_new_co_organizer(user)
+      redirect_back_to_edit(notice: "#{user.display_name} passe de joueur à co-organisateur : sa place de joueur est libérée.")
+    else
+      # Tournoi lancé : ce joueur a des matchs et une ligne de classement. Changer
+      # son rôle le retirerait des appariements et des poules en cours de route.
+      redirect_back_to_edit(alert: "#{user.display_name} joue ce tournoi : impossible de le passer co-organisateur maintenant qu'il est lancé.")
+    end
+  end
+
+  # DELETE /tournois/:id/co-organisateurs/retrait?tournament_user_id=...
+  # Révoque un co-organisateur. On détruit la ligne d'inscription entière plutôt
+  # que de la repasser en "joueur" : un co-organisateur n'a jamais occupé de place
+  # de joueur, le remettre joueur l'inscrirait à un tournoi qu'il n'a pas rejoint.
+  def remove_co_organizer
+    authorize @tournament, :manage_organizers?
+
+    co_org = @tournament.tournament_users.find_by(id: params[:tournament_user_id], role: "co_organisateur")
+    return redirect_back_to_edit(alert: "Ce co-organisateur n'existe plus.") if co_org.nil?
+
+    name = co_org.display_name
+    co_org.destroy
+    redirect_back_to_edit(notice: "#{name} n'est plus co-organisateur.")
+  end
+
+  # PATCH /tournois/:id/transfert-admin
+  # Transmet l'administration : le nouvel admin prend `tournaments.user_id`,
+  # l'ancien devient co-organisateur pour garder la main sur la gestion courante.
+  def transfer_ownership
+    authorize @tournament, :transfer_ownership?
+
+    new_admin = User.find_by_invite_sgid(params[:new_admin_sgid])
+    return redirect_back_to_edit(alert: "Choisis un joueur dans la liste de suggestions.") if new_admin.nil?
+    return redirect_back_to_edit(alert: "Tu es déjà l'admin de ce tournoi.") if new_admin == @tournament.user
+
+    previous_admin = @tournament.user
+    # Si l'ancien admin est aussi inscrit comme JOUEUR, on ne peut pas lui donner
+    # une ligne co-organisateur (index unique) sans lui prendre sa place dans le
+    # tableau : on préserve la place, il perd donc les droits de gestion.
+    previous_stays_player = previous_admin.present? &&
+                            @tournament.tournament_users.find_by(user: previous_admin)&.player?
+
+    ActiveRecord::Base.transaction do
+      # Le nouvel admin n'a plus besoin de sa ligne co-organisateur (le rôle admin
+      # est porté par tournaments.user_id). Une ligne "joueur" est en revanche
+      # conservée : rien n'interdit à l'admin de jouer son tournoi.
+      @tournament.tournament_users.find_by(user: new_admin, role: "co_organisateur")&.destroy!
+      @tournament.update!(user: new_admin)
+
+      if previous_admin.present? && !previous_stays_player
+        @tournament.tournament_users.create!(user: previous_admin, role: "co_organisateur", status: "approved")
+      end
+    end
+
+    Notification.create(
+      user: new_admin,
+      actor: current_user,
+      message: "Tu es maintenant l'admin du tournoi « #{@tournament.name} ».",
+      link: tournament_path(@tournament)
+    )
+
+    notice = if previous_stays_player
+               "#{new_admin.display_name} est le nouvel admin. Tu gardes ta place de joueur, mais tu n'as plus les droits de gestion."
+             else
+               "#{new_admin.display_name} est le nouvel admin. Tu restes co-organisateur."
+             end
+    redirect_to tournament_path(@tournament), notice: notice
+  end
+
+  # GET /tournois/search?q=...[&tournament_id=...]
   # Autocomplete JSON pour désigner un co-organisateur (même pattern que
-  # TeamInvitationsController#search).
+  # TeamInvitationsController#search). Avec `tournament_id`, on masque les
+  # personnes déjà à la manœuvre — inutile de les proposer.
   def search
     authorize Tournament, :search?
 
@@ -210,7 +304,7 @@ class TournamentsController < ApplicationController
     return render json: [] if q.length < 3
 
     users = User.search_for_invite(q)
-                .where.not(id: current_user.id)
+                .where.not(id: excluded_search_ids)
                 .limit(8)
 
     render json: users.map { |u|
@@ -328,14 +422,46 @@ class TournamentsController < ApplicationController
     @tournament.registration_deadline = nil
   end
 
-  # Désigne un co-organisateur si un joueur a été choisi dans l'autocomplete.
+  # Désigne le premier co-organisateur si un joueur a été choisi dans l'autocomplete
+  # du formulaire de CRÉATION. Ensuite, tout passe par #add_co_organizer (page d'édition).
   # On reçoit un identifiant signé (voir User#invite_sgid) et non un email : aucune
   # adresse ne circule dans le formulaire de création de tournoi.
-  def add_co_organizer
+  def add_initial_co_organizer
     co_org = User.find_by_invite_sgid(params[:co_organizer_sgid])
     return if co_org.nil? || co_org == current_user
 
     @tournament.tournament_users.create(user: co_org, role: "co_organisateur", status: "approved")
+  end
+
+  # Retour au panneau d'organisation après une action de nomination/révocation :
+  # l'admin y enchaîne souvent plusieurs gestes (ajouter deux personnes, en retirer
+  # une), le renvoyer sur le tournoi lui ferait refaire le chemin à chaque fois.
+  def redirect_back_to_edit(flash_options)
+    redirect_to edit_tournament_path(@tournament), **flash_options
+  end
+
+  def notify_new_co_organizer(user)
+    Notification.create(
+      user: user,
+      actor: current_user,
+      message: "Tu es co-organisateur du tournoi « #{@tournament.name} ».",
+      link: tournament_path(@tournament)
+    )
+  end
+
+  # Personnes à masquer dans l'autocomplete : toujours soi-même, et — si un tournoi
+  # est passé en paramètre — celles qui l'organisent déjà. Le paramètre est optionnel
+  # à dessein : le champ de transfert d'administration, lui, DOIT pouvoir proposer un
+  # co-organisateur en place.
+  def excluded_search_ids
+    ids = [current_user.id]
+    return ids if params[:tournament_id].blank?
+
+    tournament = Tournament.find_by_param(params[:tournament_id])
+    return ids if tournament.nil?
+
+    ids + [tournament.user_id] +
+      tournament.tournament_users.where(role: "co_organisateur").pluck(:user_id)
   end
 
   # Inscrit le créateur comme joueur uniquement s'il a coché le toggle dédié.

--- a/app/models/tournament_user.rb
+++ b/app/models/tournament_user.rb
@@ -58,6 +58,13 @@ class TournamentUser < ApplicationRecord
   scope :eliminated, -> { where(state: "eliminated") }
   scope :withdrawn,  -> { where(state: "withdrawn") }
 
+  # ── Prédicats de rôle ────────────────────────────────────────────────────────
+  # L'index unique [tournament_id, user_id] impose qu'une inscription porte UN
+  # seul rôle : promouvoir un joueur en co-organisateur lui fait donc perdre sa
+  # place de joueur (cf. TournamentsController#add_co_organizer).
+  def player?         = role == "joueur"
+  def co_organizer?   = role == "co_organisateur"
+
   # ── Prédicats de parcours (Lot 3, étendu Lot 5) ──────────────────────────────
   def active?     = state == "active"
   def qualified?  = state == "qualified"

--- a/app/policies/tournament_policy.rb
+++ b/app/policies/tournament_policy.rb
@@ -19,8 +19,9 @@ class TournamentPolicy < ApplicationPolicy
     user.present?
   end
 
-  # Autocomplete de recherche d'utilisateurs (co-organisateur) : mêmes droits que
-  # la création, puisqu'il n'est utile que dans le formulaire de création.
+  # Autocomplete de recherche d'utilisateurs (co-organisateur / transfert d'admin) :
+  # mêmes droits que la création. L'endpoint ne renvoie ni email ni id brut (voir
+  # TournamentsController#search), donc rien à restreindre au-delà du login.
   def search?
     create?
   end
@@ -60,6 +61,21 @@ class TournamentPolicy < ApplicationPolicy
 
   def manage?
     record.organizer?(user)
+  end
+
+  # Composition de l'équipe organisatrice (nommer / révoquer un co-organisateur).
+  # Réservée à l'admin, PAS ouverte à `manage?` : sinon un co-organisateur pourrait
+  # en coopter d'autres, voire révoquer celui qui l'a nommé — l'admin perdrait le
+  # contrôle de son propre tournoi sans jamais pouvoir le reprendre.
+  def manage_organizers?
+    owner?
+  end
+
+  # Transmettre l'administration. Irréversible côté ancien admin (il redevient
+  # simple co-organisateur), donc réservée à l'admin en place et sans intérêt sur
+  # un tournoi déjà terminé — plus rien ne s'y gère.
+  def transfer_ownership?
+    owner? && !record.completed?
   end
 
   private

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -189,9 +189,12 @@
                 data: { "tournament-form-target": "descriptionInput", "action": "input->tournament-form#updateDescription" } %>
           </div>
 
-          <%# Co-organisateur — autocomplete (réutilise invite-search), création uniquement.
-              (La désignation/retrait d'un co-organisateur après coup n'est pas encore géré
-              par #update — hors périmètre pour l'instant.) %>
+          <%# Co-organisateur — autocomplete (réutilise invite-search), création uniquement :
+              ce champ ne sert qu'à en désigner un tout de suite, pour ne pas obliger
+              l'organisateur à repasser par l'édition. Ensuite, toute la composition de
+              l'équipe (ajout, retrait, transfert d'admin) se fait dans le panneau
+              « Équipe organisatrice » de la page d'édition (_organizers_manager.html.erb),
+              qui doit rester HORS de ce formulaire. %>
           <% if @tournament.new_record? %>
             <div class="mb-0" data-controller="invite-search"
                  data-invite-search-url-value="<%= search_tournaments_path %>">

--- a/app/views/tournaments/_organizers_manager.html.erb
+++ b/app/views/tournaments/_organizers_manager.html.erb
@@ -1,0 +1,135 @@
+<%# ── Panneau « Équipe organisatrice » (page d'édition) ─────────────────────────
+    Nommer / révoquer des co-organisateurs, et transmettre l'administration.
+    Local : tournament.
+
+    Réservé à l'admin du tournoi (cf. TournamentPolicy#manage_organizers?) : un
+    co-organisateur qui pourrait coopter ou révoquer ferait perdre à l'admin le
+    contrôle de son propre tournoi.
+
+    IMPORTANT — ce panneau vit VOLONTAIREMENT en dehors de _form.html.erb : ce
+    sont des formulaires distincts (POST/DELETE/PATCH vers d'autres routes), et
+    un <form> imbriqué dans un autre est invalide en HTML — le navigateur ferme
+    le premier et les champs du tournoi partiraient dans la mauvaise requête. %>
+<%
+  co_organizers = tournament.co_organizers
+  # Le transfert n'a plus de sens sur un tournoi terminé (cf. la policy).
+  can_transfer = policy(tournament).transfer_ownership?
+%>
+
+<div class="container pb-5 tournament-organizers">
+  <div class="row">
+    <div class="col-lg-7">
+
+      <div class="match-form-section">
+        <div class="match-form-section-header">
+          <div class="match-form-step-badge"><i data-lucide="shield" aria-hidden="true"></i></div>
+          <h2 class="match-form-section-title">Équipe organisatrice</h2>
+        </div>
+
+        <p class="tournament-form-hint mb-3">
+          Les co-organisateurs gèrent le tournoi comme toi : lancer, saisir les scores,
+          déclarer un forfait, modifier les paramètres. Seul l'admin peut supprimer le
+          tournoi et composer cette équipe.
+        </p>
+
+        <%# ── Liste courante ────────────────────────────────────────────────── %>
+        <ul class="tournament-organizers__list">
+          <li class="tournament-organizers__row">
+            <%= user_avatar_tag tournament.user, css_class: "tournament-organizers__avatar", width: 34, height: 34 %>
+            <span class="tournament-organizers__name"><%= tournament.user.display_name %></span>
+            <span class="tournament-organizers__role tournament-organizers__role--admin">Admin</span>
+          </li>
+
+          <% co_organizers.each do |tu| %>
+            <li class="tournament-organizers__row">
+              <%= user_avatar_tag tu.user, css_class: "tournament-organizers__avatar", width: 34, height: 34 %>
+              <span class="tournament-organizers__name"><%= tu.display_name %></span>
+              <span class="tournament-organizers__role">Co-organisateur</span>
+              <%# turbo_confirm_danger / _accept : lus par notre modale de confirmation
+                  (cf. Turbo.setConfirmMethod) pour un bouton rouge et un libellé explicite. %>
+              <%= button_to remove_co_organizer_tournament_path(tournament, tournament_user_id: tu.id),
+                            method: :delete,
+                            class: "tournament-organizers__remove",
+                            data: { turbo_confirm_danger: true,
+                                    turbo_confirm_accept: "Retirer" },
+                            form: { data: { turbo_confirm: "Retirer #{tu.display_name} de l'organisation ? Il perdra tous ses droits de gestion sur le tournoi." } },
+                            aria: { label: "Retirer #{tu.display_name} de l'organisation" } do %>
+                <i data-lucide="x" aria-hidden="true"></i>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+
+        <%# ── Nommer un co-organisateur ─────────────────────────────────────── %>
+        <%# L'autocomplete reçoit tournament_id : les personnes déjà à l'organisation
+            ne sont pas proposées (cf. TournamentsController#excluded_search_ids). %>
+        <%= form_with url: add_co_organizer_tournament_path(tournament), method: :post,
+                      class: "tournament-organizers__form",
+                      data: { controller: "invite-search",
+                              "invite-search-url-value": search_tournaments_path(tournament_id: tournament.to_param) } do %>
+          <%= label_tag :co_organizer_sgid, "Ajouter un co-organisateur", class: "form-label" %>
+          <div class="tournament-organizers__field">
+            <div class="position-relative flex-grow-1">
+              <input type="text"
+                     class="form-control"
+                     placeholder="Rechercher un joueur (nom, ou son email exact)…"
+                     autocomplete="off"
+                     data-invite-search-target="input"
+                     data-action="input->invite-search#search">
+              <%# Identifiant SIGNÉ du joueur choisi, soumis avec le formulaire.
+                  Jamais son email : voir docs/SECURITE-RGPD.md. %>
+              <%= hidden_field_tag :co_organizer_sgid, "", data: { "invite-search-target": "hidden" } %>
+              <div class="invite-search-dropdown" data-invite-search-target="dropdown" style="display:none;"></div>
+            </div>
+            <button type="submit" class="btn-cta-primary tournament-organizers__submit">
+              <i data-lucide="user-plus" aria-hidden="true"></i> Ajouter
+            </button>
+          </div>
+          <small class="form-text tournament-form-hint">
+            Tu peux en nommer autant que nécessaire. Un joueur déjà inscrit qui devient
+            co-organisateur libère sa place — tant que le tournoi n'est pas lancé.
+          </small>
+        <% end %>
+
+        <%# ── Transfert d'administration ─────────────────────────────────────── %>
+        <% if can_transfer %>
+          <hr class="tournament-organizers__separator">
+
+          <%# Pas de tournament_id dans l'URL de recherche ici : contrairement à la
+              nomination, on veut justement pouvoir promouvoir un co-organisateur
+              déjà en place au rang d'admin. %>
+          <%= form_with url: transfer_ownership_tournament_path(tournament), method: :patch,
+                        class: "tournament-organizers__form",
+                        data: { controller: "invite-search",
+                                "invite-search-url-value": search_tournaments_path } do %>
+            <%= label_tag :new_admin_sgid, "Transmettre l'administration", class: "form-label" %>
+            <div class="tournament-organizers__field">
+              <div class="position-relative flex-grow-1">
+                <input type="text"
+                       class="form-control"
+                       placeholder="Rechercher le nouvel admin…"
+                       autocomplete="off"
+                       data-invite-search-target="input"
+                       data-action="input->invite-search#search">
+                <%= hidden_field_tag :new_admin_sgid, "", data: { "invite-search-target": "hidden" } %>
+                <div class="invite-search-dropdown" data-invite-search-target="dropdown" style="display:none;"></div>
+              </div>
+              <button type="submit"
+                      class="btn-cta-secondary tournament-organizers__submit"
+                      data-turbo-confirm-danger="true"
+                      data-turbo-confirm-accept="Transmettre"
+                      data-turbo-confirm="Transmettre l'administration de ce tournoi ? Tu deviendras simple co-organisateur et ne pourras plus le supprimer ni gérer cette équipe.">
+                <i data-lucide="crown" aria-hidden="true"></i> Transmettre
+              </button>
+            </div>
+            <small class="form-text tournament-form-hint">
+              Tu restes co-organisateur et gardes la gestion courante, mais la suppression
+              du tournoi et la composition de l'équipe passeront au nouvel admin.
+            </small>
+          <% end %>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tournaments/edit.html.erb
+++ b/app/views/tournaments/edit.html.erb
@@ -24,4 +24,12 @@
   <%# Formulaire 2 colonnes (sections + récapitulatif sticky) %>
   <%= render "form" %>
 
+  <%# Équipe organisatrice : panneau SÉPARÉ du formulaire ci-dessus (formulaires
+      distincts vers d'autres routes — un <form> imbriqué serait invalide).
+      Visible uniquement pour l'admin, alors que la page d'édition elle-même est
+      ouverte aux co-organisateurs (cf. TournamentPolicy). %>
+  <% if policy(@tournament).manage_organizers? %>
+    <%= render "organizers_manager", tournament: @tournament %>
+  <% end %>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,11 +153,17 @@ Rails.application.routes.draw do
     # PATCH /tournois/:id/toggle_registrations   => clôturer/rouvrir les inscriptions
     # PATCH /tournois/:id/finish                 => terminer le tournoi manuellement
     # PATCH /tournois/:id/constitution           => mode de constitution + chapeaux
+    # POST   /tournois/:id/co-organisateurs         => nommer un co-organisateur
+    # DELETE /tournois/:id/co-organisateurs/retrait => le révoquer
+    # PATCH  /tournois/:id/transfert-admin          => transmettre l'administration
     member do
       post :start
       patch :toggle_registrations
       patch :finish
       patch :seeding, path: "constitution"
+      post :add_co_organizer, path: "co-organisateurs"
+      delete :remove_co_organizer, path: "co-organisateurs/retrait"
+      patch :transfer_ownership, path: "transfert-admin"
     end
     resources :tournament_users, only: [:create, :destroy] do
       # PATCH .../tournament_users/:id/withdraw => déclarer forfait (organisateur)

--- a/docs/SECURITE-RGPD.md
+++ b/docs/SECURITE-RGPD.md
@@ -43,6 +43,8 @@ Format des lignes : `` | `table.colonne` | finalité | base légale | durée | c
 | `push_subscriptions.auth` | Secret d'authentification du push | Consentement | Jusqu'au désabonnement ou suppression du compte | Non |
 | `slack_identities.slack_user_id` | Lien entre un compte Teams-up et un compte Slack | Consentement (installation de l'app) | Jusqu'à la désinstallation | Non |
 | `slack_workspaces.bot_token` | Jeton d'API du bot Slack (secret, pas une donnée personnelle) | Exécution du contrat | Jusqu'à la désinstallation | **Oui** (`encrypts`) |
+| `matches.pin_latitude` | Point de rendez-vous précis d'un match, posé par l'organisateur sur la carte. Peut désigner une adresse privée (match chez un particulier) → traitée comme **donnée personnelle indirecte**, au contraire de `venues.latitude` qui décrit un équipement public | Consentement (saisie volontaire de l'organisateur) | Durée de vie du match | Non |
+| `matches.pin_longitude` | Idem `matches.pin_latitude` (l'autre moitié de la coordonnée) | Consentement (saisie volontaire de l'organisateur) | Durée de vie du match | Non |
 | `venues.address` | Adresse d'un équipement sportif — **donnée de lieu public, pas de PII** | Intérêt légitime | Illimitée | Non |
 | `venues.city` | Ville d'un équipement sportif — **pas de PII** | Intérêt légitime | Illimitée | Non |
 | `venues.latitude` | Position d'un équipement sportif — **pas de PII** | Intérêt légitime | Illimitée | Non |

--- a/docs/TOURNOI.md
+++ b/docs/TOURNOI.md
@@ -240,7 +240,8 @@ règlement est que **chaque place se joue** — pas seulement la première.
 
 ### 🔜 (ex-Lot 5, reporté) — affinements
 - [ ] Winner / Loser Bracket (format e-sport) — voir « Formats envisagés » #4.
-- [ ] Gestion des co-organisateurs après création (ajout/retrait depuis `#edit`).
+- [x] Gestion des co-organisateurs après création (ajout/retrait + transfert d'administration
+      depuis `#edit`, panneau « Équipe organisatrice » — `_organizers_manager.html.erb`).
 
 ### 💡 Futurs
 - [ ] **Gamification** : badges, trophées, achievements (1er tournoi gagné, 500 pts, 10e set…).
@@ -323,7 +324,13 @@ d'ensemble embarque un **bracket viewer** interactif (défilement, zoom, filtre 
 - **Droits** : tout utilisateur connecté peut créer un tournoi (en devient l'admin).
 - **Co-organisateur** (tranché Lot 2) : **pas de nouvelle colonne** — rôle `co_organisateur`
   dans `tournament_users` (n'occupe pas de place de joueur). Droits fins sur la gestion du
-  tableau : à câbler au Lot 3 via `Tournament#organizer?`.
+  tableau : câblés via `Tournament#organizer?`. Nombre **illimité**, composés depuis `#edit`
+  par le **seul admin** (`TournamentPolicy#manage_organizers?` → `owner?`, et non `manage?` :
+  sinon un co-organisateur pourrait coopter ou révoquer celui qui l'a nommé). L'admin peut
+  **transmettre l'administration** (`#transfer_ownership`) : il redevient co-organisateur.
+  L'index unique `[tournament_id, user_id]` impose un seul rôle par personne → promouvoir un
+  joueur inscrit **met à jour sa ligne** (il libère sa place), et c'est refusé une fois le
+  tournoi lancé (il a déjà des matchs et une ligne de classement).
 - **Nombre de joueurs** : presets 8/16/32 **+ mode Libre** (nombre arbitraire). Depuis le Lot 7,
   la structure qui en découle n'est plus un aperçu figé en lecture seule : elle est **calculée**
   (`Tournament#structure_summary`) et chacun de ses critères est **personnalisable** par
@@ -341,7 +348,8 @@ d'ensemble embarque un **bracket viewer** interactif (défilement, zoom, filtre 
   → remplacer les valeurs **provisoires** de `Tournament::STRUCTURE_PRESETS` + la logique
   de `_buildProposals` (mode Libre) dans `tournament_form_controller.js`.
 - Gestion des **abandons** (victoire par abandon) et **correction d'un score après verrouillage**.
-- Droits exacts du co-organisateur sur la gestion du tableau (Pundit + `Tournament#organizer?`).
+- ~~Droits exacts du co-organisateur sur la gestion du tableau~~ → tranché : `manage?` pour
+  tout ce qui touche au tableau, `owner?` pour la suppression et la composition de l'équipe.
 
 ---
 
@@ -351,8 +359,6 @@ d'ensemble embarque un **bracket viewer** interactif (défilement, zoom, filtre 
 1. **Affiner les configs** de Ronde Suisse par effectif (16/32 ; 24 problématique) et les
    propositions du mode « Libre » (`STRUCTURE_PRESETS` + `_buildProposals` dans
    `tournament_form_controller.js`) — reste **provisoire** depuis le Lot 2.
-2. **Gestion des co-organisateurs après création** (ajout/retrait depuis `#edit` — pour
-   l'instant seulement à la création) — suite naturelle du Lot 6.
-3. **Winner / Loser Bracket** (format e-sport) — le format complexe reporté (barrages,
+2. **Winner / Loser Bracket** (format e-sport) — le format complexe reporté (barrages,
    descente en loser bracket, grande finale).
-4. Les **Futurs** (gamification, calendrier, Slack, dashboard perso, export agenda).
+3. Les **Futurs** (gamification, calendrier, Slack, dashboard perso, export agenda).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -462,3 +462,44 @@ en mode :score, puisqu'une seule "paire" = le score final) — jamais le score r
 - [x] `bin/rails assets:precompile` (SCSS + JS compilent).
 - [ ] Vérif visuelle navigateur (thème clair + sombre) — même rappel que
   l'itération 1 : redémarrer `rails server` après précompile.
+
+
+---
+
+# Gestion des organisateurs après création d'un tournoi
+
+## Problème
+
+Le bloc « Co-organisateur » de `_form.html.erb` est conditionné à `@tournament.new_record?`
+(l. 195) et `add_co_organizer` n'est appelé que depuis `#create`. Résultat : une fois le
+tournoi créé, l'admin ne peut plus ni ajouter/retirer un co-organisateur, ni transmettre
+l'administration. (Trou déjà noté dans `docs/TOURNOI.md:243`.)
+
+## Décisions (validées)
+
+- Co-organisateurs **illimités**, gérés depuis `/tournois/:id/edit`.
+- **Seul l'admin** (`tournaments.user_id`) gère la liste — un co-org ne peut pas se coopter.
+- **Transfert d'administration** possible : l'ancien admin devient co-organisateur.
+
+## Contrainte structurante
+
+Index unique `[tournament_id, user_id]` sur `tournament_users` → un joueur inscrit ne peut
+pas avoir une 2ᵉ ligne co-org : le promouvoir = **UPDATE de son `role`**, donc il perd sa
+place de joueur. Interdit une fois le tournoi lancé (il a déjà des matchs / un classement).
+
+## Étapes
+
+- [x] `routes.rb` : 3 member actions francisées (`co-organisateurs`, `.../retrait`, `transfert-admin`)
+- [x] `TournamentPolicy` : `manage_organizers?` → `owner?` ; `transfer_ownership?` → `owner? && !completed?`
+- [x] `TournamentsController` : `add_co_organizer` / `remove_co_organizer` / `transfer_ownership`
+      (helper de création renommé `add_initial_co_organizer`) + exclusions dans `#search`
+- [x] `TournamentUser` : prédicats `player?` / `co_organizer?`
+- [x] Vue `_organizers_manager.html.erb` rendue par `edit.html.erb` **hors** du `form_with`
+      (pas de formulaire imbriqué) — réutilise `invite-search`
+- [x] SCSS dans `pages/_tournaments_form.scss`
+- [x] Tests `test/controllers/tournament_organizers_test.rb`
+
+## Vérification
+
+`bin/rails test test/controllers/tournament_organizers_test.rb` puis parcours manuel
+sur `/tournois/<slug>/edit`.

--- a/test/controllers/tournament_organizers_test.rb
+++ b/test/controllers/tournament_organizers_test.rb
@@ -1,0 +1,210 @@
+require "test_helper"
+
+# ── Composition de l'équipe organisatrice ─────────────────────────────────────
+# Après création, l'admin doit pouvoir nommer/révoquer des co-organisateurs et
+# transmettre l'administration. Quatre choses doivent tenir :
+#   • seul l'ADMIN compose l'équipe (un co-organisateur ne peut pas coopter, ni
+#     révoquer celui qui l'a nommé — sinon l'admin perd son tournoi) ;
+#   • l'index unique [tournament_id, user_id] est respecté : promouvoir un joueur
+#     inscrit met à jour SA ligne (il libère sa place), sans doublon ;
+#   • un joueur d'un tournoi LANCÉ ne peut pas être promu (il a des matchs) ;
+#   • le transfert échange bien les rôles (nouvel admin ↔ ancien co-organisateur).
+class TournamentOrganizersTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin   = create_test_user(email: "admin-org@example.com", first_name: "Alice", last_name: "Admin")
+    @co_org  = create_test_user(email: "coorg-org@example.com", first_name: "Bob", last_name: "Coorg")
+    @outsider = create_test_user(email: "outsider-org@example.com", first_name: "Carl", last_name: "Dehors")
+    @sport = Sport.create!(name: "Ping orga", slug: "ping-pong", icon: "🏓")
+    @tournament = Tournament.create!(name: "Open organisation", sport: @sport, user: @admin,
+                                    format: "ronde_suisse", status: "open", max_players: 16,
+                                    date: Date.tomorrow, place: "Salle test")
+  end
+
+  teardown { teardown_db }
+
+  # ── Nomination ──────────────────────────────────────────────────────────────
+
+  test "l'admin nomme un co-organisateur" do
+    sign_in @admin
+
+    post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @outsider.invite_sgid }
+
+    assert_redirected_to edit_tournament_path(@tournament)
+    tu = @tournament.tournament_users.find_by(user: @outsider)
+    assert_equal "co_organisateur", tu.role
+    assert_equal "approved", tu.status
+    assert @tournament.reload.organizer?(@outsider)
+  end
+
+  test "un co-organisateur ne peut pas en nommer un autre" do
+    @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @co_org
+
+    post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @outsider.invite_sgid }
+
+    assert_response :redirect
+    assert_nil @tournament.tournament_users.find_by(user: @outsider)
+  end
+
+  test "un simple visiteur connecté ne peut pas nommer de co-organisateur" do
+    sign_in @outsider
+
+    post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @co_org.invite_sgid }
+
+    assert_response :redirect
+    assert_nil @tournament.tournament_users.find_by(user: @co_org)
+  end
+
+  test "promouvoir un joueur inscrit met à jour sa ligne et libère sa place" do
+    inscription = @tournament.tournament_users.create!(user: @outsider, role: "joueur", status: "approved")
+    sign_in @admin
+
+    assert_no_difference -> { @tournament.tournament_users.count } do
+      post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @outsider.invite_sgid }
+    end
+
+    assert_equal "co_organisateur", inscription.reload.role
+    assert_equal 0, @tournament.reload.approved_players_count
+  end
+
+  test "on ne promeut pas un joueur d'un tournoi déjà lancé" do
+    inscription = @tournament.tournament_users.create!(user: @outsider, role: "joueur", status: "approved")
+    @tournament.update!(status: "in_progress")
+    sign_in @admin
+
+    post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @outsider.invite_sgid }
+
+    assert_equal "joueur", inscription.reload.role
+    assert_match(/lancé/, flash[:alert])
+  end
+
+  test "nommer deux fois la même personne ne crée pas de doublon" do
+    @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @admin
+
+    assert_no_difference -> { @tournament.tournament_users.count } do
+      post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: @co_org.invite_sgid }
+    end
+    assert_match(/déjà co-organisateur/, flash[:alert])
+  end
+
+  test "un sgid invalide n'inscrit personne" do
+    sign_in @admin
+
+    assert_no_difference -> { @tournament.tournament_users.count } do
+      post add_co_organizer_tournament_path(@tournament), params: { co_organizer_sgid: "n-importe-quoi" }
+    end
+    assert_match(/liste de suggestions/, flash[:alert])
+  end
+
+  # ── Révocation ──────────────────────────────────────────────────────────────
+
+  test "l'admin révoque un co-organisateur" do
+    tu = @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @admin
+
+    delete remove_co_organizer_tournament_path(@tournament, tournament_user_id: tu.id)
+
+    assert_redirected_to edit_tournament_path(@tournament)
+    assert_nil TournamentUser.find_by(id: tu.id)
+    assert_not @tournament.reload.organizer?(@co_org)
+  end
+
+  test "la révocation ne peut pas cibler un JOUEUR inscrit" do
+    player = @tournament.tournament_users.create!(user: @outsider, role: "joueur", status: "approved")
+    sign_in @admin
+
+    delete remove_co_organizer_tournament_path(@tournament, tournament_user_id: player.id)
+
+    assert_not_nil TournamentUser.find_by(id: player.id)
+  end
+
+  test "la révocation ne peut pas cibler l'inscription d'un AUTRE tournoi" do
+    other = Tournament.create!(name: "Autre tournoi", sport: @sport, user: @admin,
+                               format: "ronde_suisse", status: "open", max_players: 8,
+                               date: Date.tomorrow, place: "Ailleurs")
+    foreign = other.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @admin
+
+    delete remove_co_organizer_tournament_path(@tournament, tournament_user_id: foreign.id)
+
+    assert_not_nil TournamentUser.find_by(id: foreign.id)
+  end
+
+  # ── Transfert d'administration ──────────────────────────────────────────────
+
+  test "le transfert échange les rôles admin et co-organisateur" do
+    tu = @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @admin
+
+    patch transfer_ownership_tournament_path(@tournament), params: { new_admin_sgid: @co_org.invite_sgid }
+
+    assert_redirected_to tournament_path(@tournament)
+    @tournament.reload
+    assert_equal @co_org, @tournament.user
+    # L'ancienne ligne co-org du nouvel admin est supprimée (le rôle admin est
+    # porté par tournaments.user_id), l'ancien admin en reçoit une.
+    assert_nil TournamentUser.find_by(id: tu.id)
+    assert_equal "co_organisateur", @tournament.tournament_users.find_by(user: @admin).role
+    assert @tournament.organizer?(@admin)
+  end
+
+  test "un admin inscrit comme joueur garde sa place plutôt qu'une ligne co-organisateur" do
+    @tournament.tournament_users.create!(user: @admin, role: "joueur", status: "approved")
+    sign_in @admin
+
+    patch transfer_ownership_tournament_path(@tournament), params: { new_admin_sgid: @co_org.invite_sgid }
+
+    @tournament.reload
+    assert_equal @co_org, @tournament.user
+    assert_equal "joueur", @tournament.tournament_users.find_by(user: @admin).role
+  end
+
+  test "un co-organisateur ne peut pas transmettre l'administration" do
+    @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @co_org
+
+    patch transfer_ownership_tournament_path(@tournament), params: { new_admin_sgid: @co_org.invite_sgid }
+
+    assert_equal @admin, @tournament.reload.user
+  end
+
+  test "pas de transfert sur un tournoi terminé" do
+    @tournament.update!(status: "completed")
+    sign_in @admin
+
+    patch transfer_ownership_tournament_path(@tournament), params: { new_admin_sgid: @co_org.invite_sgid }
+
+    assert_equal @admin, @tournament.reload.user
+  end
+
+  # ── Autocomplete ────────────────────────────────────────────────────────────
+
+  test "l'autocomplete masque les personnes déjà à l'organisation" do
+    @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+    sign_in @admin
+
+    get search_tournaments_path(q: "Coorg", tournament_id: @tournament.to_param)
+
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  # ── Affichage ───────────────────────────────────────────────────────────────
+
+  test "le panneau n'apparaît que pour l'admin" do
+    @tournament.tournament_users.create!(user: @co_org, role: "co_organisateur", status: "approved")
+
+    sign_in @admin
+    get edit_tournament_path(@tournament)
+    assert_select "form[action=?]", add_co_organizer_tournament_path(@tournament), 1
+
+    sign_out @admin
+    sign_in @co_org
+    get edit_tournament_path(@tournament)
+    assert_response :success
+    assert_select "form[action=?]", add_co_organizer_tournament_path(@tournament), 0
+  end
+end


### PR DESCRIPTION
Panneau « Équipe organisatrice » sur /tournois/:slug/edit : nomination et révocation de co-organisateurs (nombre illimité) et transfert d'administration. Jusqu'ici un co-organisateur ne pouvait être désigné qu'à la création, et plus jamais ensuite.

- Réservé à l'admin (manage_organizers? -> owner?, et non manage?) : sinon un co-organisateur pourrait coopter ou révoquer celui qui l'a nommé, et l'admin perdrait le contrôle de son tournoi sans pouvoir le reprendre.
- L'index unique [tournament_id, user_id] impose un seul rôle par personne : promouvoir un joueur inscrit met à jour SA ligne (il libère sa place), et c'est refusé une fois le tournoi lancé — il a déjà des matchs et une ligne de classement, changer son rôle le sortirait des appariements en cours de route.
- Transfert : l'ancien admin devient co-organisateur, sauf s'il est inscrit comme joueur (on préserve sa place dans le tableau, il perd la gestion — le message flash le dit explicitement).
- Le panneau vit hors du form_with du tournoi : ce sont des formulaires distincts vers d'autres routes, et un <form> imbriqué est invalide en HTML.

Déclare au passage matches.pin_latitude / pin_longitude au registre RGPD : colonnes présentes en base et dans schema.rb depuis #401 mais jamais déclarées, ce qui faisait échouer bin/pii-guard sur tout commit.

16 tests de contrôleur : droits, refus de promotion sur tournoi lancé, absence de doublon, révocation qui ne peut cibler ni un joueur ni l'inscription d'un autre tournoi, échange des rôles au transfert. Suite complète verte (1151 runs).