### PR TITLE
Refonte de la phase de poules et durcissement des scores

### DIFF
--- a/app/assets/stylesheets/pages/_tournament_bracket.scss
+++ b/app/assets/stylesheets/pages/_tournament_bracket.scss
@@ -692,6 +692,73 @@
   white-space: nowrap;
 }
 
+// ── Carte empilée (poules, barrages) ─────────────────
+// Joueur A au-dessus de joueur B, score de chacun aligné à droite — une feuille
+// de match. Choisie là où plusieurs confrontations s'affichent en GRILLE (toutes
+// celles d'une poule d'un coup) : les scores forment alors une colonne qu'on
+// parcourt d'un seul coup d'œil, ce que la scoreline centrée, dont les scores se
+// baladent au milieu de noms de longueurs variables, ne permet pas.
+.tmatch-card__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.tmatch-card__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 8px;
+  min-width: 0;
+
+  // Ma ligne : même repère que .tmatch-card__player--me sur les autres cartes.
+  &--me .tmatch-card__name {
+    color: var(--theme-text-strong);
+    font-weight: 800;
+  }
+}
+
+// Poule d'origine, en barrage (cf. _tmatch_scoreline). Gris et discret, à l'inverse
+// de la pastille « Toi » : c'est une provenance, pas un état — elle doit se lire
+// sans jamais concurrencer le nom du joueur.
+.tmatch-card__pool {
+  flex: 0 0 auto;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background-color: var(--theme-hover-bg);
+  border: 1px solid var(--theme-border);
+  color: var(--theme-text-muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+// Colonne de score : largeur mini fixe + chiffres tabulaires, pour que les scores
+// de deux lignes (et de deux cartes voisines dans la grille) restent alignés.
+.tmatch-card__row-score {
+  flex: 0 0 auto;
+  margin-left: auto;
+  min-width: 1.4rem;
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.05rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--theme-text-strong);
+
+  // Même code couleur que la scoreline centrée : le vert sur le SEUL score du
+  // vainqueur suffit à le désigner, sans aplat plein cadre ni nom barré.
+  &.is-winner {
+    color: $green;
+    border-bottom: 2px solid $green;
+  }
+
+  &--pending {
+    color: var(--theme-text-muted);
+    font-weight: 600;
+  }
+}
+
 // Pied de carte : score global + bouton d'accès à la modale.
 .tmatch-card__footer {
   display: flex;
@@ -1374,7 +1441,8 @@
   }
 }
 
-// Sous-titre de poule dans le board (phase poules) : « Poule A », « Poule B »…
+// Sous-titre de poule (constitution des poules) : « Poule A », « Poule B »…
+// `__mine` sert aussi dans le sélecteur de poules du board (cf. .pool-switcher).
 .pool-label {
   margin: 0.6rem 0 0.35rem;
   font-size: 0.78rem;
@@ -1395,55 +1463,146 @@
   }
 }
 
-// ── Poules d'une journée, côte à côte ────────────────
-// DEUX poules par ligne, pas « autant que la largeur en permet » : à 4 colonnes
-// les cartes tombent sous ~250 px et les noms des joueurs sont tronqués
-// (« Pongi… vs Pongi… »), ce qui rend la lecture impossible. Deux colonnes
-// laissent la place au nom complet tout en gardant les poules comparables d'un
-// coup d'œil. Une seule colonne en mobile.
-// `minmax(0, 1fr)` et non `1fr` : la taille mini par défaut d'une piste de
-// grille est `auto`, donc un long nom élargirait la colonne et ferait déborder
-// la rangée.
-.pool-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+// ── Sélecteur de poules (onglet Matchs) ──────────────
+// Une rangée de pastilles-onglets, une poule affichée à la fois. Même gabarit que
+// .phase-nav (pastille remplie quand active) : les deux font la même chose — un
+// clic bascule le contenu affiché — et inventer un 3e style de pastille dans la
+// même page n'aurait fait qu'ajouter du bruit.
+.pool-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  align-items: start;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
 
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
+  // Scroll horizontal plutôt qu'un retour à la ligne : au-delà de 5-6 poules, une
+  // 2e rangée de pastilles pousse tout le contenu vers le bas sur mobile.
+  &__tabs {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    @include themed-scrollbar;
   }
 
-  &__col {
+  &__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background-color: var(--theme-bg-card);
+    border: 1px solid var(--theme-border);
+    border-radius: 999px;
+    padding: 0.45rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+
+    &:hover { color: var(--theme-text-primary); }
+
+    &[aria-selected="true"] {
+      color: #fff;
+      background-color: $green;
+      border-color: $green;
+
+      // Sur fond vert plein, la pastille « ta poule » doit s'inverser : sa teinte
+      // verte translucide y devient invisible.
+      .pool-label__mine {
+        background-color: rgba(#fff, 0.22);
+        color: #fff;
+      }
+    }
+  }
+
+  // Masquer/afficher le classement. Secondaire par rapport aux poules : contour
+  // seul, jamais rempli — ce n'est pas un onglet, ça ne change pas de contenu.
+  &__toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: transparent;
+    border: 1px solid var(--theme-border);
+    border-radius: 999px;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+      color: var(--theme-text-primary);
+      border-color: var(--theme-border-strong);
+    }
+
+    i { width: 16px; height: 16px; }
+  }
+}
+
+// ── Panneau d'une poule : ses matchs + son classement ─
+// Les confrontations à gauche, le classement à droite : c'est la lecture directe
+// d'une série de scores, et l'obliger à un aller-retour vers l'onglet Classement
+// n'avait pas de sens.
+// Colonne de classement à largeur FIXE (pas un fr) : elle contient un tableau de
+// 4 colonnes dont la largeur naturelle ne varie pas, autant donner toute
+// l'élasticité restante aux cartes de match.
+.pool-view {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 1.5rem;
+  align-items: start;
+  margin-bottom: 1.75rem;
+
+  // Classement masqué : la grille des matchs récupère toute la largeur et se
+  // répartit donc sur PLUS de colonnes (auto-fill) — c'est tout l'intérêt du
+  // bouton, voir plus de rencontres d'un coup.
+  &--full {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  @media (max-width: 900px) {
+    // Le classement passe SOUS les matchs : à 900 px, deux colonnes tronquent
+    // les noms des deux côtés.
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  // `minmax(0, 1fr)` et non `1fr` : la taille mini par défaut d'une piste de
+  // grille est `auto`, donc un long nom élargirait la colonne et ferait déborder
+  // la rangée.
+  &__matches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 0.75rem;
+    align-items: start;
+  }
+
+  &--full &__matches {
+    // Cartes un peu plus larges quand la place est libre : sous ~280 px les noms
+    // commencent à être tronqués côté score.
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
+
+  &__standings {
     background-color: var(--theme-bg-card);
     border: 1px solid var(--theme-border);
     border-radius: 14px;
     padding: 0.9rem;
-
-    // Ma poule. Teinte de fond plutôt qu'une bordure verte : les cartes de match
-    // qu'elle contient en portent déjà une, deux cadres verts imbriqués seraient
-    // illisibles.
-    &--mine {
-      border-color: rgba($green, 0.45);
-      background-color: rgba($green, 0.05);
-    }
-    // min-width: 0 : sans ça un long nom de joueur pousse la piste de grille
-    // au-delà du 1fr et la rangée déborde horizontalement.
     min-width: 0;
-
-    .pool-label {
-      margin: 0 0 0.6rem;
-      padding-bottom: 0.4rem;
-      border-bottom: 1px solid var(--theme-border);
-      color: var(--theme-text-strong);
-      font-size: 0.85rem;
-    }
   }
 
-  &__matches {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
+  &__standings-title {
+    margin: 0 0 0.6rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--theme-border);
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--theme-text-strong);
   }
 }
 
@@ -1523,6 +1682,16 @@
     .is-num { font-variant-numeric: tabular-nums; color: var(--theme-text-primary); }
     .is-win { font-weight: 700; color: $green; }
     .is-pts { font-weight: 700; color: var(--theme-text-strong); }
+
+    // Variante compacte (colonne latérale du sélecteur de poules) : quatre
+    // colonnes seulement, donc on resserre le rembourrage pour que la table tienne
+    // dans ~300 px sans scroll horizontal permanent.
+    &--compact {
+      font-size: 0.82rem;
+
+      th, td { padding: 0.4rem 0.45rem; }
+      .is-rank { width: 1.9rem; }
+    }
   }
 
   // Avatar + nom cliquables vers le profil, même principe que

--- a/app/helpers/tournaments_helper.rb
+++ b/app/helpers/tournaments_helper.rb
@@ -150,6 +150,47 @@ module TournamentsHelper
     safe_join(pips.map { |kind| content_tag(:span, "", class: "score-bracket__pip score-bracket__pip--#{kind}") })
   end
 
+  # ── Poules ────────────────────────────────────────────────────────────────────
+
+  # Nom d'affichage d'une poule à partir de son index 0-based : 0 → "Poule A".
+  # Source unique du libellé, partagée par le sélecteur de poules (_pool_phase) et
+  # l'onglet Classement (_ranking) — les deux doivent nommer la même poule pareil.
+  def pool_label(pool_index)
+    "Poule #{("A".ord + pool_index.to_i).chr}"
+  end
+
+  # Index de MA poule dans ce tournoi, ou nil si je n'y suis pas inscrit.
+  #
+  # Lu depuis l'INSCRIPTION et non depuis les matchs affichés : dans une poule de
+  # 3, un joueur est exempt une journée sur trois — sa poule doit rester la sienne
+  # le jour où il n'y joue pas.
+  def my_pool_index(tournament)
+    tournament.tournament_users.players.approved.find { |tu| my_player?(tu) }&.pool
+  end
+
+  # Matchs de la phase de poules, groupés par poule et ordonnés journée puis
+  # position : { index_poule => [TournamentMatch, ...] }.
+  #
+  # UNE seule requête pour toutes les poules, puis regroupement en mémoire — même
+  # motif que Tournament#pool_standings, qui charge déjà les matchs de poule en
+  # bloc : la vue affiche jusqu'à 8 poules d'un coup, une requête par poule serait
+  # un N+1 immédiat. Les associations lues par la carte (_tmatch_scoreline :
+  # joueurs, utilisateurs, rencontre rattachée, tour pour le verrouillage) sont
+  # préchargées pour la même raison.
+  #
+  # Les BYES sont exclus : « exempt cette journée » n'est pas une confrontation, et
+  # dans une poule impaire chaque joueur en a un — autant de cartes vides à faire
+  # défiler avant d'atteindre les vrais matchs.
+  def pool_matches(tournament)
+    TournamentMatch.joins(:tournament_round)
+                   .where(tournament_rounds: { tournament_id: tournament.id, phase: "pool" })
+                   .where(is_bye: false)
+                   .includes(:match, :tournament_round, player_a: :user, player_b: :user)
+                   .to_a
+                   .sort_by { |m| [m.tournament_round.number, m.position.to_i] }
+                   .group_by { |m| m.player_a.pool }
+  end
+
   # ── Modale de score ───────────────────────────────────────────────────────────
   # Bouton d'ouverture de la modale de score partagée (contrôleur Stimulus
   # tournament-score). Les 3 usages — « Saisir/Modifier », « Détail » (lecture

--- a/app/javascript/controllers/pool_selector_controller.js
+++ b/app/javascript/controllers/pool_selector_controller.js
@@ -1,0 +1,135 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Sélecteur de poules de l'onglet Matchs (cf. _pool_phase.html.erb) : des onglets
+// ARIA qui basculent la visibilité des panneaux .pool-view, plus un bouton qui
+// masque/affiche la colonne de classement.
+//
+// Deux états, tous deux MÉMORISÉS en sessionStorage :
+//   • la poule affichée ;
+//   • la présence du classement (quand il est masqué, les confrontations se
+//     répartissent sur plus de colonnes — cf. .pool-view--full).
+//
+// Pourquoi mémoriser — chaque saisie de score répond par un
+// turbo_stream.update("tournament_board") (cf. TournamentMatchesController
+// #render_board) qui re-rend TOUT le board : sans mémoire, l'organisateur qui
+// saisit les résultats de la poule C serait renvoyé sur la poule A (ou sur la
+// sienne) à chaque score validé. Le contrôleur étant ré-instancié à chaque
+// remplacement du DOM, `connect()` est exactement le moment où réappliquer l'état
+// choisi par-dessus la présélection serveur. Même mécanique que
+// journee_selector_controller.
+//
+// Clé par tournoi : deux tournois ouverts dans le même onglet ne se marchent pas
+// sur les pieds.
+export default class extends Controller {
+  static targets = ["chip", "panel", "standings", "standingsToggle", "standingsLabel"]
+  static values = { storageKey: String }
+
+  connect() {
+    this.restore()
+  }
+
+  // ── Choix de la poule ───────────────────────────────────────────────────────
+
+  choose(event) {
+    this.select(event.currentTarget.dataset.poolIndex)
+    this.persist()
+  }
+
+  // Navigation aux flèches entre onglets, attendue du motif tablist (le clavier
+  // ne doit pas obliger à tabuler à travers toutes les cartes d'une poule pour
+  // atteindre la poule suivante).
+  navigate(event) {
+    const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 }[event.key]
+    if (!step) return
+
+    event.preventDefault()
+    const chips = this.chipTargets
+    const current = chips.indexOf(event.currentTarget)
+    // Modulo positif : reculer depuis le premier onglet revient au dernier.
+    const next = chips[(current + step + chips.length) % chips.length]
+
+    this.select(next.dataset.poolIndex)
+    next.focus()
+    this.persist()
+  }
+
+  // Bascule pure (aucune écriture en sessionStorage) : partagée par le clic, les
+  // flèches et la restauration, pour que les trois chemins produisent le même état.
+  select(poolIndex) {
+    this.chipTargets.forEach((chip) => {
+      const active = chip.dataset.poolIndex === poolIndex
+      chip.setAttribute("aria-selected", active)
+      // Roving tabindex : un seul onglet dans l'ordre de tabulation, les autres
+      // s'atteignent aux flèches.
+      chip.tabIndex = active ? 0 : -1
+    })
+    this.panelTargets.forEach((panel) => {
+      panel.hidden = panel.dataset.poolIndex !== poolIndex
+    })
+  }
+
+  get selected() {
+    const active = this.chipTargets.find((chip) => chip.getAttribute("aria-selected") === "true")
+    return active ? active.dataset.poolIndex : null
+  }
+
+  // ── Colonne de classement ───────────────────────────────────────────────────
+
+  toggleStandings() {
+    this.showStandings(!this.standingsVisible)
+    this.persist()
+  }
+
+  showStandings(visible) {
+    this.standingsVisible = visible
+    // La classe vit sur les PANNEAUX (pas sur le contrôleur) : c'est .pool-view
+    // qui porte la grille « matchs | classement », donc c'est elle qui doit passer
+    // en pleine largeur.
+    this.panelTargets.forEach((panel) => panel.classList.toggle("pool-view--full", !visible))
+    this.standingsTargets.forEach((aside) => { aside.hidden = !visible })
+
+    if (this.hasStandingsToggleTarget) {
+      this.standingsToggleTarget.setAttribute("aria-pressed", visible)
+    }
+    if (this.hasStandingsLabelTarget) {
+      this.standingsLabelTarget.textContent = visible ? "Masquer le classement" : "Afficher le classement"
+    }
+  }
+
+  // ── Persistance ─────────────────────────────────────────────────────────────
+
+  persist() {
+    if (!this.storageKeyValue) return
+
+    sessionStorage.setItem(this.storageKeyValue, JSON.stringify({
+      pool: this.selected,
+      standings: this.standingsVisible
+    }))
+  }
+
+  restore() {
+    const stored = this.read()
+
+    // Une poule mémorisée peut avoir disparu (tournoi régénéré, poules
+    // reconstituées) : on ne la rejoue que si son onglet existe encore, sinon on
+    // garde la présélection du serveur — ma poule, ou la première — qui est juste.
+    const known = this.chipTargets.some((chip) => chip.dataset.poolIndex === stored.pool)
+    if (known) this.select(stored.pool)
+
+    // Le classement est visible par défaut côté serveur ; on ne le masque que si
+    // l'utilisateur l'avait explicitement fermé.
+    this.showStandings(stored.standings !== false)
+  }
+
+  read() {
+    if (!this.storageKeyValue) return {}
+
+    try {
+      return JSON.parse(sessionStorage.getItem(this.storageKeyValue)) || {}
+    } catch {
+      // sessionStorage corrompu ou format d'une version précédente : on repart de
+      // la présélection serveur plutôt que de casser tout le sélecteur.
+      return {}
+    }
+  }
+}

--- a/app/javascript/controllers/tournament_score_controller.js
+++ b/app/javascript/controllers/tournament_score_controller.js
@@ -59,7 +59,10 @@ export default class extends Controller {
     if (url) this.formTarget.action = url
     this.nameATarget.textContent = nameA || "Joueur A"
     this.nameBTarget.textContent = nameB || "Joueur B"
-    this.titleTarget.textContent = editable ? "Saisir le score" : "Détail du score"
+    // « Gérer le score » : même libellé que le bouton qui ouvre la modale (cf.
+    // _tmatch_actions), qu'un score soit déjà saisi ou non — la modale fait les
+    // deux, deux titres pour la même fenêtre ne renseignaient sur rien.
+    this.titleTarget.textContent = editable ? "Gérer le score" : "Détail du score"
     this.submitTarget.style.display = editable ? "" : "none"
     this.hintTarget.textContent = editable
       ? this.buildHint(allowDraw, target, winByTwo, cap)
@@ -206,11 +209,28 @@ export default class extends Controller {
 
     if (hi === lo) return "Un set ne peut pas se terminer sur une égalité."
     if (target && hi < target) return `Le gagnant du set doit atteindre ${target} points.`
-    if (cap && hi >= cap) return null // au plafond (tie-break), 1 point d'écart suffit
-    if (winByTwo && hi - lo < 2) {
-      return cap
-        ? `À ${hi}-${lo}, il faut 2 points d'écart (ou atteindre ${cap}).`
-        : `À ${hi}-${lo}, il faut 2 points d'écart : le set continue.`
+    if (cap && hi > cap) return `Le set ne peut pas dépasser ${cap} points.`
+
+    // Sport non configuré (pas de règle des 2 points) : atteindre la cible suffit.
+    if (!winByTwo) return null
+
+    if (hi === target) {
+      if (lo > target - 2) {
+        return cap
+          ? `À ${hi}-${lo}, il faut 2 points d'écart (ou atteindre ${cap}).`
+          : `À ${hi}-${lo}, il faut 2 points d'écart : le set continue.`
+      }
+      return null
+    }
+
+    if (cap && hi === cap) return null // au plafond, 1 point d'écart suffit
+
+    // Au-delà de la cible, on est en prolongation : elle se conclut à 2 points
+    // d'écart, jamais plus — un set ne continue pas après avoir été gagné.
+    if (hi - lo !== 2) {
+      return hi - lo < 2
+        ? `À ${hi}-${lo}, il faut 2 points d'écart : le set continue.`
+        : `Score impossible : au-delà de ${target}, le set se termine dès 2 points d'écart (${lo + 2}-${lo}).`
     }
 
     return null

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -507,12 +507,21 @@ class Tournament < ApplicationRecord
   # la bannière du vainqueur, qui doivent tous afficher le même classement.
   def standings = @standings ||= TournamentStandings.new(self)
 
-  # Ronde en cours : la dernière ronde générée. Le tableau final (bracket) est
-  # prioritaire ; sinon la dernière ronde de la phase round-robin du format
-  # (un tournoi n'emploie qu'UNE phase round-robin : swiss OU league OU pool).
+  # Ronde en cours. Le tableau final (bracket) est prioritaire ; sinon la première
+  # ronde NON TERMINÉE de la phase round-robin du format (un tournoi n'emploie
+  # qu'UNE phase round-robin : swiss OU league OU pool), à défaut la dernière.
+  #
+  # « La première non terminée » et non « la dernière générée » : en poules, tout le
+  # calendrier est créé au lancement (cf. PoolBuilder) et les rencontres ne se
+  # jouent plus dans l'ordre — la dernière journée existe dès le départ et
+  # désignerait une ronde à laquelle personne n'a encore touché. Pour la ronde
+  # suisse et le championnat, qui génèrent toujours un tour à la fois, les deux
+  # définitions coïncident.
   def current_round
-    bracket_rounds.last ||
-      tournament_rounds.where(phase: %w[swiss league pool]).ordered.last
+    bracket_rounds.last || begin
+      rounds = tournament_rounds.where(phase: %w[swiss league pool]).ordered.to_a
+      rounds.find { |round| !round.complete? } || rounds.last
+    end
   end
 
   # Regroupement des joueurs par poule (Lot 5, format "poules").

--- a/app/models/tournament_match.rb
+++ b/app/models/tournament_match.rb
@@ -259,21 +259,54 @@ class TournamentMatch < ApplicationRecord
       if a == b
         errors.add(:sets, "set #{index + 1} : un set ne peut pas être nul")
       elsif !valid_set?(a, b, rules)
-        errors.add(:sets, "set #{index + 1} : score invalide (#{a}-#{b})")
+        errors.add(:sets, "set #{index + 1} : score invalide (#{a}-#{b}) — #{set_rule_reminder(rules)}")
       end
     end
   end
 
-  # Un set est valide si le vainqueur atteint la cible avec 2 points d'écart
-  # (ou pile au plafond, où 1 point suffit — tie-break).
+  # Un set s'arrête DÈS que quelqu'un a gagné : on ne peut donc pas dépasser la
+  # cible librement. Au ping-pong (cible 11, 2 points d'écart, pas de plafond) :
+  #   11-9  ✔  cible atteinte avec 2 d'écart
+  #   11-10 ✘  1 seul point d'écart → le set continue
+  #   12-10 ✔  prolongation depuis 10-10, conclue aux 2 points d'écart
+  #   12-9  ✘  le set était déjà fini à 11-9 : ce point n'a pas pu être joué
+  #   15-3  ✘  idem, quatre points après la fin
+  # C'est le cas « hi > target » que l'ancienne version laissait passer : elle ne
+  # regardait que l'écart, or au-delà de la cible l'écart vaut TOUJOURS exactement 2
+  # (à 2 d'écart le set s'arrête, il ne peut donc jamais atteindre 3).
+  #
+  # Généralisé aux autres sports par les mêmes règles, sans cas particulier :
+  #   • `cap` (tennis 7, badminton 30) — plafond où 1 point d'écart suffit et
+  #     au-dessus duquel plus rien n'est jouable : 7-5 ✔, 7-6 ✔, 8-6 ✘.
+  #   • sans `win_by_two` ni `cap` — c'est le fallback des sports non encore
+  #     configurés : on ignore comment leur set se conclut, donc on se contente
+  #     d'exiger la cible. Durcir ici bloquerait des scores légitimes d'un sport
+  #     dont on n'a simplement pas écrit les règles.
   def valid_set?(games_a, games_b, rules)
-    hi = [games_a, games_b].max
-    lo = [games_a, games_b].min
-    return false if hi < rules[:target]
-    return true  if rules[:cap] && hi >= rules[:cap]
-    return true  unless rules[:win_by_two]
+    hi     = [games_a, games_b].max
+    lo     = [games_a, games_b].min
+    target = rules[:target]
+    cap    = rules[:cap]
 
-    (hi - lo) >= 2
+    return false if hi < target
+    return false if cap && hi > cap
+    return true unless rules[:win_by_two]
+
+    if hi == target then lo <= target - 2 # fin « normale », 2 points d'écart
+    elsif cap && hi == cap then true      # au plafond, 1 point d'écart suffit
+    else (hi - lo) == 2                   # prolongation : elle se conclut à 2, jamais plus
+    end
+  end
+
+  # Rappel de la règle appliquée, joint au message d'erreur : « score invalide »
+  # tout court laisse l'organisateur deviner ce qui cloche dans un 12-9.
+  def set_rule_reminder(rules)
+    target = rules[:target]
+    return "le gagnant du set doit atteindre #{target} points" unless rules[:win_by_two]
+    return "un set se gagne en #{target} points avec 2 points d'écart, sans dépasser #{rules[:cap]}" if rules[:cap]
+
+    "un set se gagne en #{target} points avec 2 points d'écart " \
+      "(au-delà de #{target}, il se termine dès 2 points d'écart : #{target + 1}-#{target - 1}, #{target + 2}-#{target}…)"
   end
 
   # ── Helpers de score ──────────────────────────────────────────────────────────

--- a/app/services/pool_builder.rb
+++ b/app/services/pool_builder.rb
@@ -1,13 +1,35 @@
 # ── Service PoolBuilder ───────────────────────────────────────────────────────
 # Moteur du format « Poules » (Lot 5) : on répartit les joueurs en poules, on joue
-# un round-robin DANS chaque poule (journée par journée, toutes poules en parallèle),
-# puis les meilleurs de chaque poule entrent en tableau final.
+# un round-robin DANS chaque poule (toutes poules en parallèle), puis les meilleurs
+# de chaque poule entrent en tableau final.
 #
 # Réutilise l'algorithme de calendrier round-robin de LeagueBuilder (.schedule) et
 # le recompute partagé (RoundRobinStats). Une « journée » = une TournamentRound de
 # phase "pool" regroupant la journée de MÊME index de toutes les poules (respecte
 # l'index unique (tournament_id, phase, number)). La poule d'un match se dérive de
 # player_a.pool (pas de colonne dédiée sur le match).
+#
+# ── Le calendrier ENTIER est créé au lancement ─────────────────────────────────
+# Contrairement à la ronde suisse, dont chaque ronde dépend des résultats de la
+# précédente, un round-robin est intégralement connu d'avance : dans une poule de
+# 4, chacun affronte les 3 autres, point. Le générer journée par journée n'apportait
+# donc rien et coûtait beaucoup :
+#   • un joueur ne voyait qu'un seul de ses 3 adversaires, alors que depuis le Lot 7
+#     c'est LUI qui planifie ses rencontres — il lui faut les connaître toutes pour
+#     convenir des dates ;
+#   • les poules ne pouvaient avancer qu'au même rythme, la plus lente bloquant
+#     tout le monde ;
+#   • le calendrier était recalculé à chaque journée et devait retomber à
+#     l'identique (cf. RoundRobinStats#ordered_player_scope) — un ordre de joueurs
+#     qui bougeait en cours de route dédoublait ou perdait des rencontres. Créé
+#     d'un coup, il n'est calculé qu'une fois : le problème disparaît.
+#
+# Les journées restent des TournamentRound (l'ordre du calendrier, et un repère
+# pour l'organisateur), mais elles ne sont plus une porte : toutes les rencontres
+# d'une poule sont saisissables dès le lancement, dans l'ordre que les joueurs
+# veulent. D'où le verrouillage de la phase EN BLOC, quand la dernière rencontre
+# est jouée (cf. #close_pool_rounds!), et non journée par journée : « ta journée
+# est terminée » n'a plus de sens pour qui ne voit que sa poule.
 class PoolBuilder
   include RoundRobinStats
 
@@ -15,8 +37,9 @@ class PoolBuilder
     @tournament = tournament
   end
 
-  # Génère la journée suivante (ou répartit les poules + journée 1), ou bascule
-  # sur le tableau final. Idempotent (même garde-fou anti double-clic que le suisse).
+  # Répartit les poules et crée TOUT le calendrier au premier appel, puis bascule
+  # sur le tableau final quand la dernière rencontre de poule est jouée.
+  # Idempotent (même garde-fou anti double-clic que le suisse).
   def next_round!
     ActiveRecord::Base.transaction do
       # Critérium Fédéral : dès que la phase finale a commencé, c'est CriteriumFlow
@@ -28,26 +51,30 @@ class PoolBuilder
       # de l'une parce que l'autre n'est pas finie.
       return CriteriumFlow.new(@tournament).advance! if criterium_final_phase?
 
-      current = @tournament.current_round
-      return current if current && !current.complete?
+      # Tableau final déjà lancé : la phase de poules est derrière nous, on rend la
+      # main à son moteur (même garde qu'avant, `current_round` privilégiant les
+      # tours de tableau).
+      if @tournament.bracket_started?
+        current = @tournament.current_round
+        return current if current && !current.complete?
 
-      current&.update!(status: "completed")
-
-      return BracketBuilder.new(@tournament).advance! if @tournament.bracket_started?
+        current&.update!(status: "completed")
+        return BracketBuilder.new(@tournament).advance!
+      end
 
       assign_pools! if pools_unassigned?
 
       recompute_stats_for("pool", apply_state: false)
 
-      schedules      = pool_schedules
-      total_journees = schedules.values.map(&:size).max.to_i
-      next_index     = @tournament.pool_rounds.count
+      create_missing_pool_rounds!
 
-      if next_index < total_journees
-        create_pool_round!(number: next_index + 1, schedules: schedules, index: next_index)
-      else
-        start_playoffs!
-      end
+      # Tant qu'une seule rencontre de poule manque, il n'y a rien à faire de plus :
+      # le classement vient d'être rafraîchi, et aucune poule ne peut qualifier
+      # qui que ce soit.
+      return current_pool_round unless pool_phase_complete?
+
+      close_pool_rounds!
+      start_playoffs!
     end
   end
 
@@ -80,6 +107,49 @@ class PoolBuilder
   def pool_schedules
     ordered_player_scope.to_a.group_by(&:pool).transform_values do |members|
       LeagueBuilder.schedule(members)
+    end
+  end
+
+  # Crée les journées qui manquent — donc TOUTES au premier appel, aucune ensuite.
+  # Écrit comme un rattrapage et non comme un « create_all » : c'est ce qui rend la
+  # méthode idempotente (double-clic, rechargement Turbo) et ce qui répare aussi les
+  # tournois lancés AVANT ce changement, dont seules les premières journées existent.
+  def create_missing_pool_rounds!
+    schedules      = pool_schedules
+    total_journees = schedules.values.map(&:size).max.to_i
+    existing       = @tournament.pool_rounds.count
+
+    (existing...total_journees).each do |index|
+      create_pool_round!(number: index + 1, schedules: schedules, index: index)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    # Deux requêtes concurrentes ont créé la même journée : l'index unique
+    # (tournoi, phase, branche, numéro) a tranché, il n'y a rien à réparer.
+    nil
+  end
+
+  # Journée « en cours » = la PREMIÈRE non terminée, pas la dernière créée : les
+  # rencontres ne se jouent plus dans l'ordre du calendrier (deux joueurs peuvent
+  # boucler leur 3e confrontation avant que la 1re journée soit finie).
+  def current_pool_round
+    rounds = @tournament.pool_rounds.to_a
+    rounds.find { |round| !round.complete? } || rounds.last
+  end
+
+  # Toutes les rencontres de toutes les poules sont-elles jouées ?
+  def pool_phase_complete?
+    rounds = @tournament.pool_rounds.to_a
+    rounds.any? && rounds.all?(&:complete?)
+  end
+
+  # Verrouillage EN BLOC de la phase (cf. l'en-tête) : à partir d'ici, seul
+  # l'organisateur peut corriger un score (TournamentMatchPolicy#update? refuse un
+  # tour "completed", #correct? prend le relais). Verrouiller journée par journée
+  # aurait fermé la carte d'un joueur sur un critère qu'il ne voit même pas — que
+  # l'AUTRE rencontre de la même journée de sa poule ait été saisie.
+  def close_pool_rounds!
+    @tournament.pool_rounds.where.not(status: "completed").each do |round|
+      round.update!(status: "completed")
     end
   end
 

--- a/app/views/tournaments/_barrage_phase.html.erb
+++ b/app/views/tournaments/_barrage_phase.html.erb
@@ -28,8 +28,11 @@
     <%# wide : un seul tour, donc une seule colonne — inutile de la brider à la
         largeur d'une colonne de ruban, ce qui tronquait les noms en « G... » sur les
         trois quarts d'une page vide. Deux barrages par ligne, pleine largeur. %>
+    <%# stacked : même carte empilée (A au-dessus de B, score à droite) que la
+        phase de poules et le tableau final — les trois phases du Critérium se
+        lisent ainsi de la même façon. %>
     <%= render "tournaments/round_ribbon", rounds: tournament.barrage_rounds,
-                title_for: ->(_round) { "Barrages" }, wide: true %>
+                title_for: ->(_round) { "Barrages" }, wide: true, stacked: true %>
   <% else %>
     <%# Même ossature que le ruban réel (.round-ribbon--wide > .round-col) pour que
         la phase ne change pas de gabarit le jour où le tour est créé. %>
@@ -40,11 +43,25 @@
           <span class="round-col__status round-col__status--in_progress">À venir</span>
         </div>
 
+        <%# Chaque poule fournit exactement UN 2e et UN 3e, et il y a un barrage par
+            poule (cf. Tournament#expected_barrage_count) : nommer la poule d'origine
+            du 2e sur chaque case est donc exact — l'ENSEMBLE des poules affichées
+            est celui qui jouera. Seule la ligne où chacune atterrira reste ouverte
+            (l'appariement croisé trie les 2es par force, cf. le rappel sous la
+            grille et l'avertissement en tête de fichier), et le 3e en face vient par
+            construction d'une AUTRE poule, qu'on ne peut donc pas nommer d'avance.
+            Repli sur un libellé générique si la structure prévoit un nombre de
+            barrages qui ne correspond pas au nombre de poules (effectif « Libre ») :
+            mieux vaut ne rien dire que dire faux. %>
+        <% pool_indexes = tournament.pools.keys.compact.sort %>
+        <% named = pool_indexes.size == tournament.expected_barrage_count %>
         <div class="round-col__matches round-col__matches--grid">
-          <% tournament.expected_barrage_count.times do %>
+          <% tournament.expected_barrage_count.times do |i| %>
             <div class="tmatch-card tmatch-card--placeholder tmatch-card--placeholder-known">
               <div class="tmatch-card__player tmatch-card__player--pending">
-                <span class="tmatch-card__placeholder-label">2e de poule</span>
+                <span class="tmatch-card__placeholder-label">
+                  <%= named ? "2e de #{pool_label(pool_indexes[i])}" : "2e de poule" %>
+                </span>
               </div>
               <div class="tmatch-card__player tmatch-card__player--pending">
                 <span class="tmatch-card__placeholder-label">3e d'une autre poule</span>
@@ -54,8 +71,12 @@
         </div>
 
         <p class="tournament-empty">
-          Les barrages se rempliront à la fin des poules : chaque 2e de poule y
-          affrontera le 3e d'une autre poule.
+          Les barrages se rempliront à la fin des poules : le 2e de chaque poule y
+          affrontera le 3e d'une autre poule — le règlement interdit d'opposer deux
+          joueurs venus de la même poule. Le meilleur 2e étant opposé au plus faible
+          3e, l'ordre définitif des rencontres ne sera connu qu'une fois les poules
+          jouées ; la poule d'origine des deux joueurs sera alors indiquée sur
+          chaque case.
         </p>
       </div>
     </div>

--- a/app/views/tournaments/_pool_phase.html.erb
+++ b/app/views/tournaments/_pool_phase.html.erb
@@ -1,13 +1,93 @@
 <%# ── Phase de poules ───────────────────────────────────────────────────────────
-    Ruban horizontal : une colonne par journée, matchs regroupés par poule à
-    l'intérieur de chaque colonne (Poule A, B… — cf. _round_column,
-    group_by_pool: true, dérivé de player_a.pool). Le classement par poule vit
-    dans l'onglet Classement (_ranking.html.erb) — pas ici, "Matchs" ne montre
-    que des matchs.
-    Locals : tournament. %>
+    Vue centrée sur LA POULE, pas sur la journée : on choisit sa poule dans un
+    sélecteur d'onglets, et on voit d'un coup TOUTES ses confrontations (journées
+    confondues, dans l'ordre) avec son classement à droite.
+
+    Pourquoi ce renversement — un joueur suit sa poule, pas le calendrier général :
+    l'ancien filtre par journée n'affichait qu'une journée à la fois et obligeait à
+    ouvrir un menu pour reconstituer mentalement les résultats de sa poule, pendant
+    que le classement, lui, vivait dans un autre onglet. La journée n'est plus
+    qu'un ordre de tri (cf. TournamentsHelper#pool_matches).
+
+    Poule active par défaut = LA MIENNE si je suis inscrit (cf. #my_pool_index),
+    la première sinon — présélection posée côté serveur via `hidden`, le JS ne fait
+    que basculer (même principe que _round_ribbon pour les journées).
+
+    Local : tournament. %>
+<% pools = tournament.ranked_pools %>
+<% matches_by_pool = pool_matches(tournament) %>
+<% mine = my_pool_index(tournament) %>
+<%# `pools.key?(mine)` et pas juste `mine` : un joueur retiré de sa poule (abandon,
+    re-constitution) ne doit pas ouvrir un onglet qui n'existe plus. %>
+<% active_pool = pools.key?(mine) ? mine : pools.keys.first %>
+
 <section class="tournament-phase" data-tournament-phase-switch-target="section" data-phase="main">
   <h2 class="tournament-phase__title">Poules</h2>
 
-  <%= render "tournaments/round_ribbon", rounds: tournament.pool_rounds,
-              title_for: ->(round) { "Journée #{round.number}" }, group_by_pool: true, paginated: true %>
+  <% if pools.empty? %>
+    <p class="tournament-empty">Les poules apparaîtront une fois constituées.</p>
+  <% else %>
+    <div class="pool-selector" data-controller="pool-selector"
+         data-pool-selector-storage-key-value="pool:<%= tournament.id %>">
+      <div class="pool-switcher">
+        <%# De vrais onglets ARIA (tablist/tab/tabpanel) : c'est exactement ce que
+            fait le sélecteur — une poule visible à la fois. Navigation aux flèches
+            gérée par le contrôleur, comme l'attend le motif. %>
+        <div class="pool-switcher__tabs" role="tablist" aria-label="Poules du tournoi">
+          <% pools.each_key do |index| %>
+            <button type="button" role="tab"
+                    id="pool_tab_<%= index %>"
+                    class="pool-switcher__chip <%= "pool-switcher__chip--mine" if index == mine %>"
+                    aria-controls="pool_panel_<%= index %>"
+                    aria-selected="<%= index == active_pool %>"
+                    tabindex="<%= index == active_pool ? 0 : -1 %>"
+                    data-pool-selector-target="chip"
+                    data-pool-index="<%= index %>"
+                    data-action="click->pool-selector#choose keydown->pool-selector#navigate">
+              <%= pool_label(index) %>
+              <% if index == mine %><span class="pool-label__mine">ta poule</span><% end %>
+            </button>
+          <% end %>
+        </div>
+
+        <%# Masquer le classement libère la colonne de droite : les confrontations
+            se répartissent alors sur plus de colonnes (cf. .pool-view--full). %>
+        <button type="button" class="pool-switcher__toggle"
+                data-pool-selector-target="standingsToggle"
+                data-action="click->pool-selector#toggleStandings"
+                aria-pressed="true">
+          <i data-lucide="list-ordered" aria-hidden="true"></i>
+          <span data-pool-selector-target="standingsLabel">Masquer le classement</span>
+        </button>
+      </div>
+
+      <% pools.each do |index, players| %>
+        <% matches = matches_by_pool[index] || [] %>
+        <div class="pool-view" id="pool_panel_<%= index %>" role="tabpanel"
+             aria-labelledby="pool_tab_<%= index %>" tabindex="0"
+             data-pool-selector-target="panel" data-pool-index="<%= index %>"
+             <%= "hidden" unless index == active_pool %>>
+          <div class="pool-view__matches">
+            <% if matches.any? %>
+              <% matches.each do |match| %>
+                <%= render "tournaments/tmatch_scoreline", match: match, stacked: true %>
+              <% end %>
+            <% else %>
+              <p class="tournament-empty">Aucune rencontre à jouer dans cette poule.</p>
+            <% end %>
+          </div>
+
+          <%# Le classement de la poule, ici plutôt que dans le seul onglet
+              Classement : c'est la lecture immédiate d'une série de scores, et
+              faire l'aller-retour entre deux onglets pour l'obtenir n'avait pas de
+              sens. Même source (Tournament#ranked_pools), donc jamais deux
+              classements divergents. %>
+          <aside class="pool-view__standings" data-pool-selector-target="standings">
+            <h3 class="pool-view__standings-title"><%= pool_label(index) %></h3>
+            <%= render "tournaments/ranking_table", players: players, tournament: tournament, compact: true %>
+          </aside>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </section>

--- a/app/views/tournaments/_ranking.html.erb
+++ b/app/views/tournaments/_ranking.html.erb
@@ -15,7 +15,7 @@
 
     <% if Tournament::POOL_BASED_FORMATS.include?(tournament.format) && tournament.pools.any? %>
       <% tournament.ranked_pools.each do |pool_index, players| %>
-        <h3 class="tournament-ranking__pool-title">Poule <%= ("A".ord + pool_index.to_i).chr %></h3>
+        <h3 class="tournament-ranking__pool-title"><%= pool_label(pool_index) %></h3>
         <%= render "tournaments/ranking_table", players: players, tournament: tournament %>
       <% end %>
     <% else %>

--- a/app/views/tournaments/_ranking_table.html.erb
+++ b/app/views/tournaments/_ranking_table.html.erb
@@ -16,20 +16,26 @@
     `tu.qualified?` (state posé par PoolBuilder#start_playoffs! sur les 2 premiers
     de chaque poule une fois la phase de poules terminée) — répond au besoin de
     voir qui est qualifié DANS chaque poule sans réintroduire un texte redondant. %>
-<% show_draws = tournament.sport&.ranking_points_rules&.dig(:draw)&.positive? %>
-<% show_sets  = tournament.sport&.scoring_rules&.dig(:mode) == :sets %>
+<%# compact (optionnel, défaut false) : version réduite à « # / Joueur / V / D »,
+    pour la colonne latérale du sélecteur de poules (_pool_phase). Huit colonnes
+    n'y tiendraient pas sans scroll horizontal permanent, et le détail (points de
+    classement, différentiels) reste à un clic dans l'onglet Classement — qui, lui,
+    garde la table complète. %>
+<% compact = local_assigns.fetch(:compact, false) %>
+<% show_draws = !compact && tournament.sport&.ranking_points_rules&.dig(:draw)&.positive? %>
+<% show_sets  = !compact && tournament.sport&.scoring_rules&.dig(:mode) == :sets %>
 <div class="tournament-ranking__scroll">
-  <table class="tournament-ranking__table">
+  <table class="tournament-ranking__table <%= "tournament-ranking__table--compact" if compact %>">
     <thead>
       <tr>
         <th class="is-rank">#</th>
         <th class="is-player">Joueur</th>
-        <th title="Points de classement">Pts</th>
+        <% unless compact %><th title="Points de classement">Pts</th><% end %>
         <th title="Victoires">V</th>
         <% if show_draws %><th title="Nuls">N</th><% end %>
         <th title="Défaites">D</th>
         <% if show_sets %><th title="Différentiel de sets">Sets</th><% end %>
-        <th title="Différentiel de points marqués/encaissés">+/-</th>
+        <% unless compact %><th title="Différentiel de points marqués/encaissés">+/-</th><% end %>
       </tr>
     </thead>
     <tbody>
@@ -50,14 +56,16 @@
                  title="Qualifié pour le tableau final" aria-label="Qualifié pour le tableau final"></i>
             <% end %>
           </td>
-          <td class="is-num is-pts"><%= tu.ranking_points %></td>
+          <% unless compact %><td class="is-num is-pts"><%= tu.ranking_points %></td><% end %>
           <td class="is-num is-win"><%= tu.wins %></td>
           <% if show_draws %><td class="is-num"><%= tu.draws %></td><% end %>
           <td class="is-num"><%= tu.losses %></td>
           <% if show_sets %>
             <td class="is-num"><%= tu.set_average.positive? ? "+#{tu.set_average}" : tu.set_average %></td>
           <% end %>
-          <td class="is-num"><%= tu.point_average.positive? ? "+#{tu.point_average}" : tu.point_average %></td>
+          <% unless compact %>
+            <td class="is-num"><%= tu.point_average.positive? ? "+#{tu.point_average}" : tu.point_average %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/tournaments/_round_column.html.erb
+++ b/app/views/tournaments/_round_column.html.erb
@@ -1,14 +1,16 @@
 <%# ── Une colonne du ruban horizontal (un tour) ───────────────────────────────
-    Réutilisée par la ronde suisse, le championnat et les poules (via
+    Réutilisée par la ronde suisse, le championnat et les barrages (via
     _round_ribbon) dans l'onglet Matchs ÉDITABLE — pendant du bracket-viewer
     (Vue d'ensemble, lecture seule) mais avec des cartes _tmatch_scoreline
-    cliquables (le tableau final, lui, garde _tmatch — cf. _bracket.html.erb).
+    cliquables (le tableau final, lui, garde _tmatch — cf. _bracket.html.erb ;
+    les poules ont leur propre vue par poule, cf. _pool_phase.html.erb).
     `id="round_<id>"` : ancre stable pour un éventuel deep-link direct vers un tour.
     Locals : round, title (optionnel, défaut "Ronde N"),
-    group_by_pool (optionnel, défaut false — regroupe les matchs par poule,
-    format "poules" uniquement), group_by_record (optionnel, défaut false —
+    stacked (optionnel, défaut false — cartes empilées A/B, cf. _tmatch_scoreline),
+    group_by_record (optionnel, défaut false —
     regroupe les matchs par bilan V/D EN ENTRANT dans ce tour — ex. 2V-0D /
     1V-1D / 0V-2D —, ronde suisse uniquement, cf. Tournament#swiss_entering_records). %>
+<% stacked = local_assigns.fetch(:stacked, false) %>
 <% score_groups = if local_assigns.fetch(:group_by_record, false)
                     entering = round.tournament.swiss_entering_records[round.number] || {}
                     round.tournament_matches.order(:position)
@@ -24,37 +26,9 @@
   </div>
 
   <%# wide : phase à tour unique (barrages) — les matchs se rangent deux par ligne
-      au lieu de s'empiler dans une colonne étroite. Sans effet avec group_by_pool
-      (les poules ont déjà leur propre grille) ni group_by_record. %>
+      au lieu de s'empiler dans une colonne étroite. Sans effet avec group_by_record. %>
   <div class="round-col__matches <%= "round-col__matches--grid" if local_assigns.fetch(:wide, false) %>">
-    <% if local_assigns.fetch(:group_by_pool, false) %>
-      <%# Ma poule est mise en avant : sur une grille de 8 cartes, c'est le premier
-          repère qu'on cherche. Lu depuis l'INSCRIPTION et non depuis les matchs
-          affichés : dans une poule de 3, un joueur se repose chaque journée — sa
-          poule doit rester repérable le jour où il n'y joue pas. %>
-      <% my_pool_index = round.tournament.tournament_users.players.approved
-                              .find { |tu| my_player?(tu) }&.pool %>
-      <%# Les poules d'une journée sont INDÉPENDANTES : les empiler dans une seule
-          colonne obligeait à scroller pour comparer, alors qu'elles se lisent en
-          parallèle. Une carte par poule, côte à côte (grille auto-fit), et à
-          l'intérieur les confrontations restent empilées à la verticale. %>
-      <div class="pool-grid">
-        <% round.tournament_matches.order(:position).group_by { |m| m.player_a.pool }.sort_by { |pool, _| pool.to_i }.each do |pool_index, matches| %>
-          <% my_pool = my_pool_index.present? && my_pool_index == pool_index %>
-          <div class="pool-grid__col <%= "pool-grid__col--mine" if my_pool %>">
-            <h4 class="pool-label">
-              Poule <%= ("A".ord + pool_index.to_i).chr %>
-              <% if my_pool %><span class="pool-label__mine">ta poule</span><% end %>
-            </h4>
-            <div class="pool-grid__matches">
-              <% matches.each do |match| %>
-                <%= render "tournaments/tmatch_scoreline", match: match %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% elsif score_groups %>
+    <% if score_groups %>
       <% score_groups.each do |(wins, losses), matches| %>
         <% if score_groups.size > 1 %>
           <div class="score-bracket__header" title="<%= wins %> victoire(s) / <%= losses %> défaite(s) avant ce tour">
@@ -62,12 +36,12 @@
           </div>
         <% end %>
         <% matches.each do |match| %>
-          <%= render "tournaments/tmatch_scoreline", match: match %>
+          <%= render "tournaments/tmatch_scoreline", match: match, stacked: stacked %>
         <% end %>
       <% end %>
     <% else %>
       <% round.tournament_matches.order(:position).each do |match| %>
-        <%= render "tournaments/tmatch_scoreline", match: match %>
+        <%= render "tournaments/tmatch_scoreline", match: match, stacked: stacked %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/tournaments/_round_ribbon.html.erb
+++ b/app/views/tournaments/_round_ribbon.html.erb
@@ -1,7 +1,8 @@
 <%# ── Ruban horizontal de colonnes (une par tour) ─────────────────────────────
-    Réutilisé pour la ronde suisse, le championnat et les poules dans l'onglet
-    Matchs éditable. Locals : rounds (array ordonné de TournamentRound),
-    title_for (proc round -> String), group_by_pool / group_by_record
+    Réutilisé pour la ronde suisse, le championnat et les barrages dans l'onglet
+    Matchs éditable (les poules ont leur propre vue par poule, cf. _pool_phase).
+    Locals : rounds (array ordonné de TournamentRound),
+    title_for (proc round -> String), stacked / group_by_record
     (optionnels, défaut false, transmis tels quels à _round_column), extra_columns
     (optionnel, HTML déjà rendu ajouté APRÈS la dernière colonne — ex. la colonne
     Qualifiés/Éliminés de la ronde suisse, en continuité horizontale du ruban).
@@ -83,14 +84,14 @@
            <%= "hidden" unless round == current_round %>>
         <%= render "tournaments/round_column", round: round,
                     title: title_for.call(round),
-                    group_by_pool: local_assigns.fetch(:group_by_pool, false),
+                    stacked: local_assigns.fetch(:stacked, false),
                     group_by_record: local_assigns.fetch(:group_by_record, false) %>
       </div>
     <% else %>
       <%= render "tournaments/round_column", round: round,
                   title: title_for.call(round),
                   wide: wide,
-                  group_by_pool: local_assigns.fetch(:group_by_pool, false),
+                  stacked: local_assigns.fetch(:stacked, false),
                   group_by_record: local_assigns.fetch(:group_by_record, false) %>
     <% end %>
   <% end %>

--- a/app/views/tournaments/_tmatch.html.erb
+++ b/app/views/tournaments/_tmatch.html.erb
@@ -9,15 +9,6 @@
     Réservé au tableau final (_bracket.html.erb) : les journées de championnat/
     poules et les rondes suisses utilisent _tmatch_scoreline (scoreline centrée),
     cf. _round_column.html.erb. %>
-<% can_edit = user_signed_in? && policy(match).update? %>
-<%# Création/consultation de la rencontre réelle : ouverte aux 2 joueurs du match
-    ET aux organisateurs (cf. TournamentMatchPolicy#create_match?), pour que les
-    joueurs puissent convenir eux-mêmes de la date et de l'heure. %>
-<% can_create_match = user_signed_in? && policy(match).create_match? %>
-<%# Correction après verrouillage : réservée à l'organisateur, seulement quand le
-    tour est verrouillé (sinon la saisie normale can_edit suffit). %>
-<% round_locked = match.tournament_round.status == "completed" %>
-<% can_correct = round_locked && !match.is_bye && user_signed_in? && policy(match).correct? %>
 <%# « Où suis-je ? » : la carte où je joue se repère sans lire les noms. %>
 <% mine = match.players.any? { |player| my_player?(player) } %>
 <div id="tmatch_<%= match.id %>" class="tmatch-card <%= "tmatch-card--bye" if match.is_bye %> <%= "tmatch-card--done" if match.decided? %> <%= "tmatch-card--mine" if mine %>">
@@ -52,40 +43,9 @@
     <% end %>
 
     <%# Score global + accès à la modale (saisie ou détail selon les droits) +
-        rattachement d'une rencontre standard (joueurs du match ou organisateurs). %>
-    <% if match.score_entered? || can_edit || can_create_match || match.match || can_correct %>
-      <div class="tmatch-card__footer">
-        <% if match.score_entered? %>
-          <span class="tmatch-card__score" title="Score (<%= match.player_a.display_name %> – <%= match.player_b.display_name %>)">
-            <%= match.score_summary %>
-          </span>
-        <% end %>
-
-        <% if match.match %>
-          <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
-        <% elsif can_create_match %>
-          <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
-        <% end %>
-
-        <% if can_edit %>
-          <%= score_modal_button match,
-                label: match.score_entered? ? "Modifier" : "Saisir le score",
-                editable: true,
-                url: tournament_tournament_match_path(match.tournament, match) %>
-        <% elsif match.score_entered? %>
-          <%= score_modal_button match, label: "Détail", editable: false, css_class: "tmatch-card__detail-btn" %>
-        <% end %>
-
-        <%# Correction organisateur d'un tour verrouillé : rouvre la modale en édition,
-            mais poste sur l'action `correct` (régénère l'aval si le vainqueur change). %>
-        <% if can_correct %>
-          <%= score_modal_button match,
-                label: "Corriger",
-                editable: true,
-                url: correct_tournament_tournament_match_path(match.tournament, match),
-                css_class: "tmatch-card__score-btn tmatch-card__score-btn--correct" %>
-        <% end %>
-      </div>
-    <% end %>
+        rattachement d'une rencontre standard (joueurs du match ou organisateurs).
+        show_score : seule carte à répéter le score global en pied, les scores
+        affichés plus haut étant ceux de chaque joueur pris séparément. %>
+    <%= render "tournaments/tmatch_actions", match: match, show_score: true %>
   <% end %>
 </div>

--- a/app/views/tournaments/_tmatch_actions.html.erb
+++ b/app/views/tournaments/_tmatch_actions.html.erb
@@ -1,0 +1,67 @@
+<%# ── Pied d'une carte de match de tournoi (actions) ───────────────────────────
+    Bloc commun à TOUTES les cartes de match : _tmatch (tableau final), et
+    _tmatch_scoreline dans ses deux variantes (scoreline centrée pour le
+    championnat / la ronde suisse, empilée pour les poules et les barrages).
+    Les droits sont identiques partout — les recopier dans chaque carte, c'était
+    trois endroits à corriger le jour où une règle change.
+
+    Locals :
+      • match       — le TournamentMatch
+      • show_score  — optionnel, défaut false : affiche le score global en tête du
+        pied (tableau final uniquement ; ailleurs le score est déjà lisible sur la
+        carte elle-même, l'y répéter serait redondant)
+      • inline      — optionnel, défaut false : boutons groupés à gauche à la suite
+        plutôt qu'écartés en space-between (cartes pleine largeur)
+
+    Le partial rend son propre `if` d'ouverture : sans action ni score à montrer,
+    il ne doit produire AUCUN nœud (un pied vide laisse une bande de padding). %>
+<% can_edit = user_signed_in? && policy(match).update? %>
+<%# Création/consultation de la rencontre réelle : ouverte aux 2 joueurs du match
+    ET aux organisateurs (cf. TournamentMatchPolicy#create_match?), pour que les
+    joueurs puissent convenir eux-mêmes de la date et de l'heure. %>
+<% can_create_match = user_signed_in? && policy(match).create_match? %>
+<%# Correction après verrouillage : réservée à l'organisateur, seulement quand le
+    tour est verrouillé (sinon la saisie normale can_edit suffit). %>
+<% round_locked = match.tournament_round.status == "completed" %>
+<% can_correct = round_locked && !match.is_bye && user_signed_in? && policy(match).correct? %>
+<% show_score = local_assigns.fetch(:show_score, false) %>
+
+<% if can_edit || can_create_match || can_correct || match.match || match.score_entered? %>
+  <div class="tmatch-card__footer <%= "tmatch-card__footer--inline" if local_assigns.fetch(:inline, false) %>">
+    <% if show_score && match.score_entered? %>
+      <span class="tmatch-card__score" title="Score (<%= match.player_a.display_name %> – <%= match.player_b.display_name %>)">
+        <%= match.score_summary %>
+      </span>
+    <% end %>
+
+    <% if match.match %>
+      <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
+    <% elsif can_create_match %>
+      <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
+    <% end %>
+
+    <%# Un SEUL libellé, « Gérer le score », que le score soit déjà saisi ou non :
+        la modale fait les deux (saisir, corriger, effacer) et deux libellés pour
+        un même bouton obligeaient à lire l'état de la carte avant de savoir où
+        cliquer. « Détail » reste distinct : c'est la version LECTURE SEULE,
+        pour qui n'a pas le droit de saisir. %>
+    <% if can_edit %>
+      <%= score_modal_button match,
+            label: "Gérer le score",
+            editable: true,
+            url: tournament_tournament_match_path(match.tournament, match) %>
+    <% elsif match.score_entered? %>
+      <%= score_modal_button match, label: "Détail", editable: false, css_class: "tmatch-card__detail-btn" %>
+    <% end %>
+
+    <%# Correction organisateur d'un tour verrouillé : rouvre la modale en édition,
+        mais poste sur l'action `correct` (régénère l'aval si le vainqueur change). %>
+    <% if can_correct %>
+      <%= score_modal_button match,
+            label: "Corriger",
+            editable: true,
+            url: correct_tournament_tournament_match_path(match.tournament, match),
+            css_class: "tmatch-card__score-btn tmatch-card__score-btn--correct" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/tournaments/_tmatch_scoreline.html.erb
+++ b/app/views/tournaments/_tmatch_scoreline.html.erb
@@ -1,26 +1,35 @@
-<%# ── Carte d'un match de journée/ronde (championnat, poules, ronde suisse) ────
-    Affiche les deux joueurs (ou l'exempt pour un bye) et une scoreline centrale
-    façon tableau de scores sportif (noms de part et d'autre, score au centre,
-    vainqueur surligné en vert). Lot 4 : le résultat se saisit set-par-set via la
-    modale partagée (contrôleur Stimulus tournament-score) — le vainqueur en est
-    dérivé. Le bouton de saisie n'apparaît que si l'utilisateur peut éditer ce match
-    (organisateur OU joueur du match, tour non verrouillé — cf. TournamentMatchPolicy).
-    Réservé à _round_column.html.erb : le tableau final utilise _tmatch (carte
-    empilée classique), cf. _bracket.html.erb — la scoreline ne concerne que les
-    tours en ruban/paginés. %>
-<% can_edit = user_signed_in? && policy(match).update? %>
-<%# Création/consultation de la rencontre réelle : ouverte aux 2 joueurs du match
-    ET aux organisateurs (cf. TournamentMatchPolicy#create_match?), pour que les
-    joueurs puissent convenir eux-mêmes de la date et de l'heure de leur rencontre. %>
-<% can_create_match = user_signed_in? && policy(match).create_match? %>
-<%# Correction après verrouillage : réservée à l'organisateur, seulement quand le
-    tour est verrouillé (sinon la saisie normale can_edit suffit). %>
-<% round_locked = match.tournament_round.status == "completed" %>
-<% can_correct = round_locked && !match.is_bye && user_signed_in? && policy(match).correct? %>
+<%# ── Carte d'un match de journée/ronde/poule ─────────────────────────────────
+    Deux mises en page selon le local `stacked` (défaut false) :
+
+      • false — SCORELINE CENTRÉE (championnat, ronde suisse) : les deux noms de
+        part et d'autre, le score au centre, façon tableau de scores sportif.
+        Compact, adapté à une colonne de ruban.
+
+      • true  — EMPILÉE (poules, barrages) : joueur A au-dessus de joueur B, le
+        score de chacun aligné à droite, comme une feuille de match. C'est la
+        seule lecture qui tienne quand plusieurs confrontations d'une même poule
+        s'affichent en grille : les scores forment alors une colonne qu'on
+        parcourt d'un coup d'œil, ce que la scoreline centrée ne permet pas.
+
+    Le résultat se saisit set-par-set via la modale partagée (contrôleur Stimulus
+    tournament-score) — le vainqueur en est dérivé. Les actions (saisie, création
+    de la rencontre, correction) vivent dans _tmatch_actions, commun aux deux
+    variantes ET au tableau final (_tmatch).
+
+    Locals : match, stacked (optionnel, défaut false). %>
+<% stacked = local_assigns.fetch(:stacked, false) %>
+<%# Poule d'origine affichée à côté du nom, en BARRAGE uniquement : c'est le seul
+    tour qui fait se rencontrer deux joueurs venus de poules différentes, et le
+    règlement l'impose (jamais deux joueurs de la même poule, cf.
+    CriteriumFlow#avoid_same_pool) — sans ce repère, impossible de le vérifier.
+    Dérivé de la phase plutôt que passé en local : la règle est intrinsèque au
+    match, pas à l'écran qui l'affiche. En poule, ce serait redondant (on est déjà
+    DANS la poule) ; en tableau final, l'origine n'a plus d'incidence. %>
+<% show_pool = match.tournament_round.phase == "barrage" %>
 <%# « Où suis-je ? » : la carte où je joue se repère sans lire les noms. %>
 <% mine_a = my_player?(match.player_a) %>
 <% mine_b = my_player?(match.player_b) %>
-<div id="tmatch_<%= match.id %>" class="tmatch-card <%= "tmatch-card--bye" if match.is_bye %> <%= "tmatch-card--done" if match.decided? %> <%= "tmatch-card--mine" if mine_a || mine_b %>">
+<div id="tmatch_<%= match.id %>" class="tmatch-card <%= "tmatch-card--stacked" if stacked %> <%= "tmatch-card--bye" if match.is_bye %> <%= "tmatch-card--done" if match.decided? %> <%= "tmatch-card--mine" if mine_a || mine_b %>">
   <% if match.is_bye %>
     <div class="tmatch-card__player tmatch-card__player--winner">
       <%= link_to user_profil_path(match.player_a.user), class: "tmatch-card__player-link" do %>
@@ -29,6 +38,35 @@
       <% end %>
     </div>
     <span class="tmatch-card__bye-badge">Exempt (qualifié d'office)</span>
+  <% elsif stacked %>
+    <%# Une ligne par joueur : nom à gauche, score à droite. Le vainqueur est
+        signalé par le vert sur SON SEUL score — même code couleur que la
+        scoreline centrée ci-dessous, pour que les deux variantes se lisent de la
+        même façon. %>
+    <div class="tmatch-card__rows">
+      <% [[match.player_a, mine_a], [match.player_b, mine_b]].each do |player, mine| %>
+        <div class="tmatch-card__row <%= "tmatch-card__row--me" if mine %>">
+          <%= link_to user_profil_path(player.user), class: "tmatch-card__player-link" do %>
+            <%= user_avatar_tag player.user, css_class: "tmatch-card__avatar" %>
+            <span class="tmatch-card__name"><%= player.display_name %></span>
+          <% end %>
+          <%= me_badge if mine %>
+          <% if show_pool && player.pool.present? %>
+            <span class="tmatch-card__pool"><%= pool_label(player.pool) %></span>
+          <% end %>
+
+          <% if match.score_entered? %>
+            <span class="tmatch-card__row-score <%= "is-winner" if match.winner_id == player.id %>">
+              <%= match.display_score_for(player) %>
+            </span>
+          <% else %>
+            <%# Tiret plutôt qu'une case vide : la colonne de score reste alignée
+                d'une carte à l'autre, et « pas encore joué » se lit explicitement. %>
+            <span class="tmatch-card__row-score tmatch-card__row-score--pending" aria-label="Score non saisi">–</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   <% else %>
     <%# Scoreline centrée façon tableau de scores sportif (2 noms encadrant les
         scores + un statut au centre) plutôt que 2 lignes empilées : plus compact.
@@ -66,40 +104,11 @@
         <%= me_badge if mine_b %>
       </div>
     </div>
+  <% end %>
 
-    <%# Accès à la modale (saisie ou détail selon les droits) + rattachement d'une
-        rencontre standard (joueurs du match ou organisateurs). Le score global est
-        déjà visible dans la scoreline centrale ci-dessus, pas besoin de le répéter ici. %>
-    <% if can_edit || can_create_match || match.match || can_correct || match.score_entered? %>
-      <%# --inline : boutons groupés à gauche à la suite (pas de space-between)
-          — sur une carte pleine largeur (paginated), space-between les écartait
-          sur toute la largeur de la ligne. %>
-      <div class="tmatch-card__footer tmatch-card__footer--inline">
-        <% if match.match %>
-          <%= link_to "Voir la rencontre", match_path(match.match), class: "tmatch-card__link" %>
-        <% elsif can_create_match %>
-          <%= link_to "Créer la rencontre", new_match_path(tournament_match_id: match.id), class: "tmatch-card__link" %>
-        <% end %>
-
-        <% if can_edit %>
-          <%= score_modal_button match,
-                label: match.score_entered? ? "Modifier" : "Saisir le score",
-                editable: true,
-                url: tournament_tournament_match_path(match.tournament, match) %>
-        <% elsif match.score_entered? %>
-          <%= score_modal_button match, label: "Détail", editable: false, css_class: "tmatch-card__detail-btn" %>
-        <% end %>
-
-        <%# Correction organisateur d'un tour verrouillé : rouvre la modale en édition,
-            mais poste sur l'action `correct` (régénère l'aval si le vainqueur change). %>
-        <% if can_correct %>
-          <%= score_modal_button match,
-                label: "Corriger",
-                editable: true,
-                url: correct_tournament_tournament_match_path(match.tournament, match),
-                css_class: "tmatch-card__score-btn tmatch-card__score-btn--correct" %>
-        <% end %>
-      </div>
-    <% end %>
+  <%# Le score global est déjà visible sur la carte (scoreline ou colonne de
+      droite) : show_score reste faux, seul le tableau final le répète. %>
+  <% unless match.is_bye %>
+    <%= render "tournaments/tmatch_actions", match: match, inline: true %>
   <% end %>
 </div>

--- a/db/migrate/20260815120000_backfill_missing_pool_rounds.rb
+++ b/db/migrate/20260815120000_backfill_missing_pool_rounds.rb
@@ -1,0 +1,32 @@
+# Rattrapage de données — calendrier de poules incomplet.
+#
+# Avant ce lot, PoolBuilder ne créait la journée N+1 qu'une fois la journée N
+# entièrement jouée : un tournoi en cours n'avait donc que ses premières journées
+# en base, et un joueur de poule de 4 ne voyait qu'un seul de ses 3 adversaires.
+# PoolBuilder crée désormais TOUT le calendrier au lancement (règle : poule de N
+# → N-1 rencontres par joueur), mais les tournois DÉJÀ lancés restent amputés
+# jusqu'au prochain appel du moteur — c'est-à-dire jusqu'à un score qui termine
+# une journée. Cette migration provoque cet appel une fois pour toutes.
+#
+# Aucune écriture directe ici : on relaie au moteur, qui sait seul quoi créer et
+# reste idempotent (create_missing_pool_rounds! est écrit comme un rattrapage).
+# Ses gardes internes protègent les tournois qui ne doivent pas bouger — phase
+# finale entamée, tableau lancé — et un tournoi déjà complet ne gagne rien.
+#
+# Irréversible par nature (on ne peut pas deviner quelles journées étaient
+# « en trop »), d'où le `up` seul.
+class BackfillMissingPoolRounds < ActiveRecord::Migration[8.1]
+  def up
+    Tournament.where(format: Tournament::POOL_BASED_FORMATS, status: "in_progress").find_each do |tournament|
+      TournamentEngine.for(tournament).next_round!
+    rescue StandardError => e
+      # Un tournoi bancal (poules non attribuées, données de test incohérentes)
+      # ne doit pas bloquer le déploiement : on le signale et on continue.
+      say "Tournoi ##{tournament.id} ignoré : #{e.class} — #{e.message}"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/docs/TOURNOI.md
+++ b/docs/TOURNOI.md
@@ -238,6 +238,63 @@ règlement est que **chaque place se joue** — pas seulement la première.
       d'une branche voisine (consolante) survivent. Un abandon en phase finale pose un forfait et
       les tours suivants naissent quand même (`build_match!`), sinon la branche resterait ouverte.
 
+### ✅ Refonte UI (post-Lot 8) — phase de poules centrée sur la poule `[FAIT]`
+La phase de poules était organisée **par journée** (`_round_ribbon` paginé → `_round_column`
+`group_by_pool`) : une journée à la fois, un menu à ouvrir pour balayer les autres, et le
+classement de la poule dans un **autre onglet**. Or un joueur suit **sa poule**, pas le
+calendrier général. Renversé :
+- [x] **Tout le calendrier de poule créé au lancement** (`PoolBuilder#create_missing_pool_rounds!`) :
+      un round-robin est connu d'avance (poule de N → **N-1 matchs par joueur**, chacun affronte
+      tous les autres), le générer journée par journée ne cachait que de l'information. Un joueur
+      voit donc ses N-1 adversaires d'emblée — indispensable depuis le Lot 7, où c'est **lui** qui
+      planifie ses rencontres. Conséquences : les poules n'avancent plus au rythme de la plus
+      lente ; le calendrier n'est plus recalculé à chaque journée (fin de la fragilité décrite
+      dans `RoundRobinStats#ordered_player_scope`) ; `Tournament#current_round` désigne la
+      première ronde **non terminée** et non la dernière créée. Écrit comme un rattrapage
+      idempotent : les tournois lancés avant reçoivent leurs journées manquantes au premier appel.
+- [x] **Verrouillage de la phase EN BLOC** (`PoolBuilder#close_pool_rounds!`), à la dernière
+      rencontre jouée, et non journée par journée : une journée n'est plus visible dans l'UI,
+      fermer la carte d'un joueur parce que l'AUTRE rencontre de sa journée vient d'être saisie
+      serait un critère invisible. Pendant la phase, chacun corrige son score ; après, c'est
+      « Corriger » (organisateur).
+- [x] **Sélecteur de poules** (`_pool_phase` + `pool_selector_controller.js`) : des onglets ARIA
+      `Poule A…E`, **ma poule ouverte d'emblée** (`TournamentsHelper#my_pool_index`, lu depuis
+      l'inscription — un joueur exempt une journée reste dans sa poule). Poule active et
+      visibilité du classement mémorisées en `sessionStorage`, rejouées au `connect()` : sans ça
+      le `turbo_stream.update("tournament_board")` de chaque saisie de score renverrait
+      l'organisateur sur la poule A. Même raison, même mécanique que `journee_selector`.
+- [x] **Toutes les confrontations de la poule d'un coup**, journées confondues
+      (`TournamentsHelper#pool_matches` — une requête, byes exclus). Le filtre par journée a
+      disparu de la phase de poules ; il reste au championnat.
+- [x] **Classement de la poule à côté des matchs**, masquable (`.pool-view--full` → les cartes
+      se répartissent alors sur plus de colonnes). Même source que l'onglet Classement
+      (`ranked_pools`), en version compacte (`_ranking_table`, local `compact`).
+- [x] **Carte empilée** (`_tmatch_scoreline`, local `stacked`) : A au-dessus de B, score à droite
+      — poules et barrages, comme le tableau final. Championnat et ronde suisse gardent la
+      scoreline centrée, adaptée à une colonne de ruban étroite.
+- [x] **Un seul bouton « Gérer le score »** (plus de « Saisir » / « Modifier ») : la modale fait
+      les deux. Le pied de carte commun aux trois cartes vit dans `_tmatch_actions`.
+- [x] **Poule d'origine en barrage** : badge `Poule X` sur chaque joueur d'un barrage réel
+      (`_tmatch_scoreline`, dérivé de `phase == "barrage"`), seul tour où deux poules se
+      rencontrent et où le règlement l'interdit entre joueurs d'une même poule
+      (`CriteriumFlow#avoid_same_pool`). Sur les cases **préfigurées**, le 2e est nommé
+      (`2e de Poule A`… — un barrage par poule, la bijection est certaine) mais pas le 3e :
+      il vient par construction d'une AUTRE poule, et l'appariement croisé ne sera tranché
+      qu'à la fin des poules.
+- [x] Devenus morts et supprimés : le local `group_by_pool` (`_round_ribbon` / `_round_column`)
+      et le bloc SCSS `.pool-grid`.
+- [x] **Règle du set durcie** (`TournamentMatch#valid_set?` + son miroir JS) : un set s'arrête
+      dès qu'il est gagné, on ne peut donc pas dépasser la cible librement. La validation ne
+      regardait que l'écart et acceptait `12-9` ou `15-3` au ping-pong ; au-delà de la cible,
+      l'écart vaut désormais **exactement 2** (`12-10` ✔, `13-11` ✔, `12-9` ✘). Généralisé par
+      `target` / `cap` / `win_by_two` (tennis : `7-5` ✔, `7-6` ✔, `8-6` ✘) ; les sports non
+      configurés restent tolérants, faute de connaître leur règle.
+- [x] **Migration de rattrapage** `BackfillMissingPoolRounds` : les tournois déjà en cours
+      n'auraient récupéré leurs journées manquantes qu'au prochain score terminant une journée
+      (`next_round!` n'est appelé qu'à l'écriture). Elle relaie une fois au moteur, dont les
+      gardes protègent les tournois déjà passés en phase finale. Reste ouvert : les
+      vérifications visuelles navigateur.
+
 ### 🔜 (ex-Lot 5, reporté) — affinements
 - [ ] Winner / Loser Bracket (format e-sport) — voir « Formats envisagés » #4.
 - [x] Gestion des co-organisateurs après création (ajout/retrait + transfert d'administration
@@ -265,7 +322,10 @@ manuellement** un tournoi. Depuis le Lot 7, **les joueurs planifient eux-mêmes 
 structure** de son tournoi (taille des poules, seuils de la ronde suisse, taille du tableau
 final) avec des valeurs recommandées par défaut. Le Lot 8 ajoute le **Critérium Fédéral**
 (ping-pong) : départage FFTT, barrages, consolante, matchs de classement — **chaque place se
-joue** — avec constitution des poules par chapeaux. Prochain chantier envisagé : Winner/Loser
+joue** — avec constitution des poules par chapeaux. L'onglet Matchs d'un tournoi à poules est
+depuis **centré sur la poule** : on choisit sa poule (la sienne par défaut), on y voit **toutes**
+ses confrontations et **son classement** côte à côte, et un unique bouton « Gérer le score ».
+Prochain chantier envisagé : Winner/Loser
 Bracket, puis les « Futurs » ci-dessous (gamification, calendrier, Slack…).
 
 <details><summary>Historique Lots 1 à 4</summary>

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -548,18 +548,29 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     sign_in me.user
     get tournament_path(t)
     assert_response :success
-    assert_select ".tmatch-card--mine", 1 # un seul match par journée
-    assert_select ".pool-grid__col--mine", 1
+    # Poule de 4 → je vois mes 3 confrontations d'emblée (règle générale : dans une
+    # poule de N, chacun affronte les N-1 autres).
+    assert_select ".tmatch-card--mine", 3
+    assert_select ".pool-switcher__chip--mine", 1
     assert_select ".tmatch-card__me-badge"
-    assert_select ".tournament-ranking__row.is-me", 1
+    # Ma ligne est repérée dans les DEUX classements : celui de ma poule (dans le
+    # panneau) et celui de l'onglet Classement.
+    assert_select ".pool-view__standings .tournament-ranking__row.is-me", 1
+    assert_select ".tournament-ranking .tournament-ranking__row.is-me", 1
+    # J'arrive DIRECTEMENT dans ma poule : c'est son onglet qui est sélectionné et
+    # son panneau qui est visible, sans un clic.
+    assert_select "#pool_tab_#{me.pool}[aria-selected=true]"
+    assert_select "#pool_panel_#{me.pool}:not([hidden])"
 
-    # L'organisateur, lui, ne joue pas : aucun repère ne doit s'allumer.
+    # L'organisateur, lui, ne joue pas : aucun repère ne doit s'allumer, et c'est
+    # la première poule qui s'ouvre.
     sign_in @user
     get tournament_path(t)
     assert_response :success
     assert_select ".tmatch-card--mine", 0
-    assert_select ".pool-grid__col--mine", 0
+    assert_select ".pool-switcher__chip--mine", 0
     assert_select ".tournament-ranking__row.is-me", 0
+    assert_select "#pool_tab_0[aria-selected=true]"
   end
 
   test "GET show rend la phase championnat" do
@@ -615,13 +626,46 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".tmatch-card__center-score", text: "2"
   end
 
-  test "GET show rend la phase poules (matchs groupés par poule)" do
+  # La phase de poules est centrée sur LA POULE : un onglet par poule, et chaque
+  # panneau porte toutes les confrontations de sa poule (toutes journées) plus son
+  # classement — plus aucun filtre par journée ici.
+  test "GET show rend la phase poules (un onglet et un classement par poule)" do
     sign_in @user
-    t = launched_tournament("poules", 8)
+    t = launched_tournament("poules", 8) # 8 joueurs → 2 poules de 4
     get tournament_path(t)
     assert_response :success
     assert_select ".tournament-phase__title", text: "Poules"
-    assert_select ".pool-label"
+    assert_select ".pool-switcher__chip", 2
+    assert_select ".pool-switcher__chip", text: /Poule A/
+    assert_select ".pool-switcher__chip", text: /Poule B/
+    assert_select ".pool-view", 2
+    # Une seule poule visible à la fois.
+    assert_select ".pool-view:not([hidden])", 1
+    # Le classement de la poule est dans le panneau, plus seulement dans l'onglet
+    # Classement — en version compacte (# / Joueur / V / D).
+    assert_select ".pool-view__standings .tournament-ranking__table--compact", 2
+    assert_select ".pool-switcher__toggle" # bouton masquer/afficher le classement
+    # Cartes empilées (A au-dessus de B, score à droite), pas la scoreline centrée.
+    assert_select ".pool-view .tmatch-card--stacked"
+    assert_select ".pool-view .tmatch-card__scoreline", 0
+    # Le filtre par journée a disparu de la phase de poules.
+    assert_select ".pool-selector .journee-picker", 0
+  end
+
+  # Un seul libellé pour la saisie ET la modification : la modale fait les deux.
+  test "GET show : le bouton de score s'appelle toujours « Gérer le score »" do
+    sign_in @user
+    t = launched_tournament("poules", 8)
+    match = t.pool_rounds.first.tournament_matches.reject(&:is_bye).first
+
+    get tournament_path(t)
+    assert_select ".tmatch-card__score-btn", text: "Gérer le score"
+    assert_select ".tmatch-card__score-btn", text: "Saisir le score", count: 0
+
+    # Score déjà saisi : le libellé ne change pas (avant, « Modifier »).
+    win_tournament_match!(match, match.player_a)
+    get tournament_path(t)
+    assert_select ".tmatch-card__score-btn", text: "Modifier", count: 0
   end
 
   test "GET show : bouton forfait visible pour l'organisateur d'un tournoi en cours" do

--- a/test/integration/criterium_correction_test.rb
+++ b/test/integration/criterium_correction_test.rb
@@ -148,6 +148,16 @@ class CriteriumCorrectionTest < ActionDispatch::IntegrationTest
       assert_select ".tmatch-card--placeholder", 4, "4 poules → 4 barrages préfigurés"
       assert_select ".tmatch-card:not(.tmatch-card--placeholder)", 0,
                     "aucun barrage réel tant que les poules ne sont pas jouées"
+
+      # Chaque poule fournit un 2e et il y a un barrage par poule : les quatre
+      # poules doivent donc être nommées, une fois chacune. Ce sont les cases qui
+      # répondent à « de quelle poule viennent les joueurs », pas une phrase.
+      labels = css_select("section[data-phase=barrage] .tmatch-card__placeholder-label")
+               .map { |node| node.text.strip }
+      assert_equal ["2e de Poule A", "2e de Poule B", "2e de Poule C", "2e de Poule D"],
+                   labels.grep(/^2e /).sort
+      assert_equal 4, labels.count("3e d'une autre poule"),
+                   "le 3e vient par construction d'une AUTRE poule : impossible de la nommer d'avance"
     end
     # On ne doit pas ATTERRIR sur cette section : les poules se jouent encore.
     assert_select ".tournament-board__phases[data-tournament-phase-switch-default-value=?]", "main"
@@ -174,8 +184,17 @@ class CriteriumCorrectionTest < ActionDispatch::IntegrationTest
       assert_select ".round-col__matches--grid .tmatch-card", 4,
                     "4 poules → 4 barrages, rangés en grille"
     end
-    # Les poules gardent leur ruban paginé : la grille ne doit pas déborder dessus.
-    assert_select ".round-ribbon--paginated .round-col__matches--grid", 0
+    # Les barrages reprennent la carte empilée des poules et du tableau final.
+    assert_select ".round-col__matches--grid .tmatch-card--stacked", 4
+    # Chaque joueur porte sa poule d'origine : c'est ce qui rend vérifiable la règle
+    # « jamais deux joueurs de la même poule » (cf. CriteriumFlow#avoid_same_pool).
+    assert_select "section[data-phase=barrage] .tmatch-card__pool", 8
+    assert_select "section[data-phase=barrage] .tmatch-card--stacked" do |cards|
+      cards.each do |card|
+        pools = card.css(".tmatch-card__pool").map(&:text).map(&:strip)
+        assert_equal 2, pools.uniq.size, "un barrage n'oppose jamais deux joueurs d'une même poule"
+      end
+    end
   end
 
   test "l'onglet Classement affiche le classement final une fois le tournoi terminé" do
@@ -185,7 +204,10 @@ class CriteriumCorrectionTest < ActionDispatch::IntegrationTest
     get tournament_path(@tournament)
     assert_select ".tournament-ranking__pool-title", text: /Classement final/
     # 16 joueurs, 16 places jouées : une ligne par joueur, aucun badge « ex æquo ».
-    assert_select ".tournament-ranking__table" do |tables|
+    # Sélecteur ancré sur l'onglet Classement : la phase de poules affiche
+    # désormais elle aussi des tables (le classement de chaque poule, en version
+    # compacte), qui viennent AVANT dans le document.
+    assert_select ".tournament-ranking .tournament-ranking__table" do |tables|
       final = tables.first
       assert_equal 16, final.css("tbody tr").size
       assert_equal 0, final.css(".tournament-ranking__tie").size

--- a/test/models/tournament_match_test.rb
+++ b/test/models/tournament_match_test.rb
@@ -150,8 +150,47 @@ class TournamentMatchTest < ActiveSupport::TestCase
     end
 
     assert build.call([[11, 9]]).valid?,  "11-9 doit être valide"
+    assert build.call([[11, 0]]).valid?,  "11-0 doit être valide"
     refute build.call([[11, 10]]).valid?, "11-10 (1 pt d'écart) doit être refusé"
-    assert build.call([[12, 10]]).valid?, "12-10 doit être valide"
+    refute build.call([[10, 8]]).valid?,  "10-8 : le gagnant n'a pas atteint 11"
+
+    # Prolongation : elle NE démarre qu'à 10-10 et s'arrête au premier écart de 2.
+    # Un score au-dessus de 11 avec plus de 2 points d'écart décrit donc des points
+    # joués après la fin du set — c'est ce que l'ancienne validation laissait passer.
+    assert build.call([[12, 10]]).valid?, "12-10 doit être valide (prolongation depuis 10-10)"
+    assert build.call([[15, 13]]).valid?, "15-13 doit être valide (longue prolongation)"
+    refute build.call([[12, 9]]).valid?,  "12-9 : le set était déjà fini à 11-9"
+    refute build.call([[15, 3]]).valid?,  "15-3 : impossible, le set s'arrête à 11-3"
+    refute build.call([[13, 10]]).valid?, "13-10 : le set était déjà fini à 12-10"
+
+    message = build.call([[12, 9]]).tap(&:valid?).errors[:sets].first
+    assert_includes message, "12-9", "le message doit citer le set fautif"
+    assert_includes message, "2 points d'écart", "et rappeler la règle appliquée"
+  end
+
+  # Les mêmes règles, sans cas particulier dans le code : c'est `target`, `cap` et
+  # `win_by_two` du sport qui changent, pas la validation.
+  test "la règle du set s'adapte au sport (tennis : plafond à 7)" do
+    tennis = Sport.create!(name: "Tennis", slug: "tennis", icon: "🎾")
+    tournament = Tournament.create!(name: "T", sport: tennis, format: "ronde_suisse", status: "in_progress",
+                                    max_players: 8, date: Date.tomorrow, place: "Terrain test")
+    round = tournament.tournament_rounds.create!(phase: "swiss", number: 1, status: "in_progress")
+    p1 = tournament.tournament_users.create!(user: create_test_user(email: "t1-#{SecureRandom.hex(3)}@t.fr"),
+                                             role: "joueur", status: "approved")
+    p2 = tournament.tournament_users.create!(user: create_test_user(email: "t2-#{SecureRandom.hex(3)}@t.fr"),
+                                             role: "joueur", status: "approved")
+
+    build = lambda do |sets|
+      m = round.tournament_matches.new(player_a: p1, player_b: p2, position: rand(1_000_000))
+      m.assign_score(sets)
+      m
+    end
+
+    assert build.call([[6, 4]]).valid?,  "6-4 doit être valide"
+    refute build.call([[6, 5]]).valid?,  "6-5 : à 5 partout on va au jeu décisif"
+    assert build.call([[7, 5]]).valid?,  "7-5 doit être valide"
+    assert build.call([[7, 6]]).valid?,  "7-6 (jeu décisif) doit être valide"
+    refute build.call([[8, 6]]).valid?,  "8-6 : le set ne peut pas dépasser 7 jeux"
   end
 
   test "ping-pong best_of 5 : il faut 3 sets pour gagner" do

--- a/test/services/pool_builder_test.rb
+++ b/test/services/pool_builder_test.rb
@@ -62,13 +62,103 @@ class PoolBuilderTest < ActiveSupport::TestCase
     assert_equal positions.uniq.sort, positions.sort, "positions uniques dans la ronde"
   end
 
-  test "idempotence : régénérer sans terminer la journée ne crée rien" do
+  # Le round-robin est connu d'avance : tout le calendrier naît au lancement, pour
+  # que chaque joueur voie ses 3 adversaires (et puisse convenir des dates avec eux)
+  # au lieu d'un seul.
+  test "lancement : TOUT le calendrier de poule est créé d'un coup" do
     tournament = build_tournament(16)
     TournamentEngine.for(tournament).next_round!
-    assert_equal 1, tournament.pool_rounds.count
+
+    assert_equal 3, tournament.pool_rounds.count, "poules de 4 → 3 journées d'emblée"
+    # 4 poules × 2 matchs par journée × 3 journées = 24 confrontations.
+    assert_equal 24, tournament.tournament_matches.count
+
+    # Chaque joueur affronte bien les 3 autres de SA poule, une fois chacun.
+    tournament.pools.each_value do |members|
+      members.each do |player|
+        opponents = tournament.tournament_matches
+                              .where("player_a_id = :id OR player_b_id = :id", id: player.id)
+                              .map { |m| m.player_a_id == player.id ? m.player_b_id : m.player_a_id }
+        assert_equal (members.map(&:id) - [player.id]).sort, opponents.compact.sort
+      end
+    end
+  end
+
+  # La règle ne dépend pas de la taille : poule de 4 → 3 matchs, poule de 8 → 7.
+  # C'est le round-robin intégral (LeagueBuilder.schedule), pas un nombre écrit en dur.
+  test "poule de N joueurs : chacun joue N-1 matchs, quelle que soit la taille" do
+    [3, 5, 8].each do |size|
+      tournament = build_tournament(size)
+      tournament.update!(players_per_pool: size) # une seule poule, de la taille voulue
+      TournamentEngine.for(tournament).next_round!
+
+      assert_equal 1, tournament.pools.size, "poule unique de #{size}"
+      tournament.tournament_users.players.approved.each do |player|
+        played = tournament.tournament_matches
+                           .where(is_bye: false)
+                           .where("player_a_id = :id OR player_b_id = :id", id: player.id)
+        assert_equal size - 1, played.count,
+                     "dans une poule de #{size}, chacun doit affronter les #{size - 1} autres"
+      end
+    end
+  end
+
+  test "idempotence : régénérer sans jouer ne crée aucune journée en double" do
+    tournament = build_tournament(16)
+    TournamentEngine.for(tournament).next_round!
+    assert_equal 3, tournament.pool_rounds.count
 
     TournamentEngine.for(tournament).next_round!
-    assert_equal 1, tournament.pool_rounds.count
+    assert_equal 3, tournament.pool_rounds.count
+  end
+
+  # Ce que répare la migration BackfillMissingPoolRounds : un tournoi lancé AVANT
+  # ce lot n'a que ses premières journées en base. Le moteur doit compléter le
+  # calendrier sans toucher aux journées existantes ni aux scores déjà saisis —
+  # c'est tout l'intérêt d'un rattrapage plutôt que d'un « tout créer ».
+  test "rattrapage : un calendrier amputé se complète sans perdre les scores" do
+    tournament = build_tournament(16)
+    TournamentEngine.for(tournament).next_round!
+
+    first = tournament.pool_rounds.first
+    win_tournament_match!(first.tournament_matches.first, first.tournament_matches.first.player_a)
+    kept = first.tournament_matches.first.winner_id
+
+    # On simule l'ancien état : seule la journée 1 existe.
+    tournament.pool_rounds.where.not(id: first.id).destroy_all
+    assert_equal 1, tournament.reload.pool_rounds.count
+
+    TournamentEngine.for(tournament).next_round!
+
+    assert_equal 3, tournament.reload.pool_rounds.count
+    assert_equal kept, first.reload.tournament_matches.first.winner_id,
+                 "le rattrapage ne réécrit pas les rencontres déjà jouées"
+    tournament.pools.each_value do |members|
+      members.each do |player|
+        played = tournament.tournament_matches.where(player_a: player).or(
+          tournament.tournament_matches.where(player_b: player)
+        ).joins(:tournament_round).where(tournament_rounds: { phase: "pool" })
+        assert_equal members.size - 1, played.count
+      end
+    end
+  end
+
+  # Les journées ne sont plus une porte : un joueur peut saisir sa 3e confrontation
+  # avant que la 1re journée soit finie, et sa carte ne doit pas se verrouiller pour
+  # autant. La phase entière se verrouille d'un coup, à la dernière rencontre.
+  test "les journées ne se verrouillent qu'une fois toute la phase de poules jouée" do
+    tournament = build_tournament(16)
+    TournamentEngine.for(tournament).next_round!
+
+    last = tournament.pool_rounds.last
+    last.tournament_matches.each { |m| win_tournament_match!(m, m.player_a) }
+    TournamentEngine.for(tournament).next_round!
+
+    assert_not_equal "completed", last.reload.status,
+                     "une journée jouée en avance ne verrouille pas la phase"
+
+    play_to_completion!(tournament)
+    assert tournament.pool_rounds.all? { |r| r.status == "completed" }
   end
 
   test "flux complet 16 joueurs → 3 journées → 8 qualifiés → Final 8 → completed" do


### PR DESCRIPTION
Vue centrée sur la poule (sélecteur de poules, toutes les confrontations d'un coup, classement masquable à droite, carte empilée, bouton unique « Gérer le score »).

Tout le calendrier de poule est créé au lancement : poule de N → N-1 matchs par joueur. Verrouillage de la phase en bloc. Migration de rattrapage pour les tournois déjà lancés.

Poule d'origine affichée en barrage, sur les cartes réelles comme sur les cases préfigurées.

Règle du set corrigée : au-delà de la cible, l'écart vaut exactement 2 (12-9 et 15-3 étaient acceptés au ping-pong).